### PR TITLE
Implement blocklist preloading (#76)

### DIFF
--- a/app/src/gecko/java/org/mozilla/focus/web/WebViewProvider.java
+++ b/app/src/gecko/java/org/mozilla/focus/web/WebViewProvider.java
@@ -23,6 +23,10 @@ import org.mozilla.gecko.GeckoView;
  * WebViewProvider implementation for creating a Gecko based implementation of IWebView.
  */
 public class WebViewProvider {
+    public static void preload(final Context context) {
+        // Nothing: there's no Gecko preloading (yet?).
+    }
+
     public static View create(Context context, AttributeSet attrs) {
         final GeckoView geckoView = new GeckoWebView(context, attrs);
 

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -39,6 +39,8 @@ public class MainActivity extends AppCompatActivity {
         } else {
             showHomeScreen();
         }
+
+        WebViewProvider.preload(this);
     }
 
     @Override

--- a/app/src/webkit/java/org/mozilla/focus/web/WebViewProvider.java
+++ b/app/src/webkit/java/org/mozilla/focus/web/WebViewProvider.java
@@ -20,6 +20,15 @@ import org.mozilla.focus.webkit.TrackingProtectionWebViewClient;
  * WebViewProvider for creating a WebKit based IWebVIew implementation.
  */
 public class WebViewProvider {
+    /**
+     * Preload webview data. This allows the webview implementation to load resources and other data
+     * it might need, in advance of intialising the view (at which time we are probably wanting to
+     * show a website immediately).
+     */
+    public static void preload(final Context context) {
+        TrackingProtectionWebViewClient.triggerPreload(context);
+    }
+
     public static View create(Context context, AttributeSet attrs) {
         final WebkitView webkitView = new WebkitView(context, attrs);
 


### PR DESCRIPTION
Previously, blocklists would be loaded on the UI thread (!), every time
the webview was shown. Instead, we should keep a static reference to the
lists and only load them once per session.

Loading the lists at app startup is helpful, since we should then have all
necessary data in memory by the time the user finishes typing a URL. Even
if we ever open directly to the webview, the UI will no longer be blocked.
(The loading/processing time for blocklists seems to be insignificant, but
 we should still do this for those times when reading from disk might be slow.)