### PR TITLE
Add www. prefix support to autocomplete (#58)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/autocomplete/UrlAutoCompleteFilter.java
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/UrlAutoCompleteFilter.java
@@ -26,7 +26,13 @@ public class UrlAutoCompleteFilter implements InlineAutocompleteEditText.OnFilte
             return;
         }
 
-        for (String domain : domains) {
+        for (final String domain : domains) {
+            final String wwwDomain = "www." + domain;
+            if (wwwDomain.startsWith(searchText)) {
+                view.onAutocomplete(wwwDomain);
+                return;
+            }
+
             if (domain.startsWith(searchText)) {
                 view.onAutocomplete(domain);
                 return;


### PR DESCRIPTION
We prioritise www.: if we compared against the raw domain first,
then www. matching wouldn't happen until www has been typed, but
we want to offer www.google.com as the first option when typing 'w'.