### PR TITLE
Don't read preference value until we have to

### DIFF
--- a/app/src/webkit/java/org/mozilla/focus/webkit/matcher/UrlMatcher.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/matcher/UrlMatcher.java
@@ -114,10 +114,11 @@ public class UrlMatcher implements  SharedPreferences.OnSharedPreferenceChangeLi
 
     @Override
     public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences, final String prefName) {
-        final boolean prefValue = sharedPreferences.getBoolean(prefName, false);
-
         final String categoryName = categoryPrefMap.get(prefName);
+
         if (categoryName != null) {
+            final boolean prefValue = sharedPreferences.getBoolean(prefName, false);
+
             setCategoryEnabled(categoryName, prefValue);
         }
     }


### PR DESCRIPTION
This is a followup to #20. On my 5.1 device, and "App Restriction"
preference is changed when a WebView is opened. We would then crash,
since that pref is a String. The same preference doesn't get changed
(and/or isn't ever set) on a 7.0 device.