### PR TITLE
Add support for google override list

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -2,3 +2,4 @@
 
 src/webkit/res/raw/blocklist.json
 src/webkit/res/raw/entitylist.json
+src/webkit/res/raw/google_mapping.json

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,4 +1,4 @@
 /build
 
-src/main/res/raw/blocklist.json
-src/main/res/raw/entitylist.json
+src/webkit/res/raw/blocklist.json
+src/webkit/res/raw/entitylist.json

--- a/app/src/webkit/java/org/mozilla/focus/webkit/TrackingProtectionWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/TrackingProtectionWebViewClient.java
@@ -40,7 +40,7 @@ public class TrackingProtectionWebViewClient extends WebViewClient {
 
     @WorkerThread private static synchronized UrlMatcher getMatcher(final Context context) {
         if (MATCHER == null) {
-            MATCHER = UrlMatcher.loadMatcher(context, R.raw.blocklist, R.raw.entitylist);
+            MATCHER = UrlMatcher.loadMatcher(context, R.raw.blocklist, new int[] { R.raw.google_mapping }, R.raw.entitylist);
         }
         return MATCHER;
     }

--- a/build-disconnect.py
+++ b/build-disconnect.py
@@ -121,5 +121,5 @@ if __name__ == "__main__":
     # generate_blacklists()
 
     # Dumb copy the lists for now, until we switch to the compacted version as per focus-ios
-    shutil.copy("shavar-prod-lists/disconnect-entitylist.json", "app/src/main/res/raw/entitylist.json")
-    shutil.copy("shavar-prod-lists/disconnect-blacklist.json", "app/src/main/res/raw/blocklist.json")
+    shutil.copy("shavar-prod-lists/disconnect-entitylist.json", "app/src/webkit/res/raw/entitylist.json")
+    shutil.copy("shavar-prod-lists/disconnect-blacklist.json", "app/src/webkit/res/raw/blocklist.json")

--- a/build-disconnect.py
+++ b/build-disconnect.py
@@ -7,6 +7,7 @@
 from __future__ import print_function
 
 import json
+import os.path
 import urlparse
 import shutil
 
@@ -121,5 +122,10 @@ if __name__ == "__main__":
     # generate_blacklists()
 
     # Dumb copy the lists for now, until we switch to the compacted version as per focus-ios
-    shutil.copy("shavar-prod-lists/disconnect-entitylist.json", "app/src/webkit/res/raw/entitylist.json")
-    shutil.copy("shavar-prod-lists/disconnect-blacklist.json", "app/src/webkit/res/raw/blocklist.json")
+    rawpath = "app/src/webkit/res/raw"
+    if not os.path.exists(rawpath):
+        os.makedirs(rawpath)
+
+    shutil.copy("shavar-prod-lists/disconnect-entitylist.json", rawpath + "/entitylist.json")
+    shutil.copy("shavar-prod-lists/disconnect-blacklist.json", rawpath + "/blocklist.json")
+    shutil.copy("shavar-prod-lists/google_mapping.json", rawpath + "/google_mapping.json")


### PR DESCRIPTION
We have an override list for google properties, we need to handle that too.

Given the complexity of blocklist processing code, I think it would be worth writing some python
scripts that are run at build-time (similar to what iOS does), then we could simply read two json files (definitive blocklist, and entitylist) at runtime. The blocklist is also more complex than what's needed for blocking (i.e. we discard data when reading it into memory), so the blocklist parsing would be even simpler than ever before.

That probably isn't needed for v1 though, the existing code works well enough for that.