### PR TITLE
Add format placeholder to "open with" #120

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -118,6 +118,11 @@ public class BrowserFragment extends Fragment implements View.OnClickListener, P
                 popupMenu.getMenuInflater().inflate(R.menu.menu_browser, popupMenu.getMenu());
                 popupMenu.getMenu().findItem(R.id.forward).setEnabled(webView.canGoForward());
                 popupMenu.getMenu().findItem(R.id.back).setEnabled(webView.canGoBack());
+
+                // TODO: populate this with the actual browser name (#26)
+                final String browserName = "<other browser>";
+                popupMenu.getMenu().findItem(R.id.open).setTitle(getResources().getString(R.string.menu_open_with, browserName));
+
                 popupMenu.setOnMenuItemClickListener(this);
                 popupMenu.setGravity(Gravity.TOP);
                 popupMenu.show();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,7 +26,7 @@
     <!-- Menu item: Share the currently visible page -->
     <string name="menu_share">Share</string>
     <!-- Menu item: Open the currently visible page in another browser -->
-    <string name="menu_open_with">Open with</string>
+    <string name="menu_open_with">Open with %1$s</string>
     <string name="menu_settings">Settings</string>
     <string name="menu_about">About</string>
     <string name="menu_help">Help</string>


### PR DESCRIPTION
We don't use this yet, but to avoid wasting localisers' time we should
just add the placeholder now.

(I don't know if we really want to land this - opinions welcome.)