### PR TITLE
Set severity of lint issues MissingTranslation and ExtraTranslation to warning

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<lint>
+    <!-- While we are developing the app and importing/exporting strings from the l10n repository
+         there will always be missing or extra translations. Just printing a warning is enough.
+         No need to fail the builds. -->
+    <issue id="MissingTranslation" severity="warning" />
+    <issue id="ExtraTranslation" severity="warning" />
+</lint>


### PR DESCRIPTION
When adding or removing strings the app build fails because some strings are
not translated or do not exist in strings.xml anymore. This is expected until
we do a new import. So let's not fail builds in this case.