### PR TITLE
Default browser setting

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -1,10 +1,18 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.settings;
 
 import android.os.Bundle;
+import android.preference.Preference;
 import android.preference.PreferenceFragment;
+import android.preference.PreferenceGroup;
 import android.support.annotation.Nullable;
 
 import org.mozilla.focus.R;
+import org.mozilla.focus.widget.DefaultBrowserPreference;
 
 public class SettingsFragment extends PreferenceFragment {
     @Override
@@ -12,5 +20,23 @@ public class SettingsFragment extends PreferenceFragment {
         super.onCreate(savedInstanceState);
 
         addPreferencesFromResource(R.xml.settings);
+
+        setupPreferences(getPreferenceScreen());
+    }
+
+    private void setupPreferences(PreferenceGroup group) {
+        for (int i = 0; i < group.getPreferenceCount(); i++) {
+            final Preference preference = group.getPreference(i);
+
+            if (preference instanceof PreferenceGroup) {
+                setupPreferences((PreferenceGroup) preference);
+            }
+
+            if (preference instanceof DefaultBrowserPreference
+                    && !((DefaultBrowserPreference) preference).shouldBeVisible()) {
+                group.removePreference(preference);
+                i--;
+            }
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/widget/DefaultBrowserPreference.java
+++ b/app/src/main/java/org/mozilla/focus/widget/DefaultBrowserPreference.java
@@ -1,0 +1,35 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.widget;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.preference.Preference;
+import android.provider.Settings;
+import android.util.AttributeSet;
+
+@TargetApi(Build.VERSION_CODES.N)
+public class DefaultBrowserPreference extends Preference {
+    public DefaultBrowserPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public DefaultBrowserPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public boolean shouldBeVisible() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N;
+    }
+
+    @Override
+    protected void onClick() {
+        Intent intent = new Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS);
+        getContext().startActivity(intent);
+    }
+}

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -8,5 +8,7 @@
     <string name="pref_key_performance_block_webfonts" translatable="false"><xliff:g id="preference_key">pref_performance_block_webfonts</xliff:g></string>
     <string name="pref_key_performance_block_images" translatable="false"><xliff:g id="preference_key">pref_performance_block_images</xliff:g></string>
 
+    <string name="pref_key_default_browser" translatable="false"><xliff:g id="preference_key">pref_default_browser</xliff:g></string>
+
     <string name="pref_key_telemetry" translatable="false"><xliff:g id="preference_key">pref_telemetry</xliff:g></string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,11 @@
     <string name="preference_performance_block_webfonts">Block Web fonts</string>
     <string name="preference_performance_block_images">Block Images</string>
 
+    <!-- This preference does not set Focus as the default browser but instead links to Android's
+     "default apps" screen or if not supported by this Android version to a SUMO page describing
+     how to set Focus as a default browser -->
+    <string name="preference_default_browser">Make default browser</string>
+
     <string name="preference_category_mozilla">Mozilla</string>
     <string name="preference_mozilla_telemetry">Send anonymous usage data</string>
     <string name="preference_mozilla_telemetry_summary">Learn more</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -45,6 +45,10 @@
     <PreferenceCategory
         android:title="@string/preference_category_mozilla">
 
+        <org.mozilla.focus.widget.DefaultBrowserPreference
+            android:key="@string/pref_key_default_browser"
+            android:title="@string/preference_default_browser" />
+
         <SwitchPreference
             android:title="@string/preference_mozilla_telemetry"
             android:key="@string/pref_key_telemetry"


### PR DESCRIPTION
I'll split #72 into two issues. This patch adds a setting on Android N+ devices that links to Android's "default apps" screen. On older Android versions we want to link to SUMO. But because there's no SUMO page yet I just remove the preference. I'll file a new issue for adding a link to SUMO once we have a URL.