### PR TITLE
Ensure FAB is GONE when we hide it to avoid phantom clicks (#150)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/FloatingActionButtonBehavior.java
+++ b/app/src/main/java/org/mozilla/focus/widget/FloatingActionButtonBehavior.java
@@ -74,7 +74,7 @@ public class FloatingActionButtonBehavior extends CoordinatorLayout.Behavior<Flo
         animate(button, true);
     }
 
-    private void animate(View child, final boolean hide) {
+    private void animate(final View child, final boolean hide) {
         animating = true;
 
         child.animate()
@@ -83,9 +83,25 @@ public class FloatingActionButtonBehavior extends CoordinatorLayout.Behavior<Flo
                 .setDuration(ANIMATION_DURATION)
                 .setListener(new AnimatorListenerAdapter() {
                     @Override
+                    public void onAnimationStart(Animator animation) {
+                        if (!hide) {
+                            // Ensure the child will be visible before starting animation: if it's hidden, we've also
+                            // set it to View.GONE, so we need to restore that now, _before_ the animation starts.
+                            child.setVisibility(View.VISIBLE);
+                        }
+                    }
+
+                    @Override
                     public void onAnimationEnd(Animator animation) {
                         animating = false;
                         visible = !hide;
+
+                        // Hide the FAB: even when it has size=0x0, it still intercept click events,
+                        // so we get phantom clicks causing focus to erase if the user presses
+                        // near where the FAB would usually be shown.
+                        if (hide) {
+                            child.setVisibility(View.GONE);
+                        }
                     }
                 })
                 .start();


### PR DESCRIPTION
We're still able to click on the FAB even when it's been animated to
zero-size. We need to make it truly gone to avoid having it intercept
clicks.