### PR TITLE
Nullify callback to not receive unnecessary events after exiting brow…

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -203,6 +203,13 @@ public class BrowserFragment extends Fragment implements View.OnClickListener {
         }
     }
 
+    @Override
+    public void onDetach() {
+        super.onDetach();
+
+        webView.setCallback(null);
+    }
+
     public String getUrl() {
         return webView.getUrl();
     }


### PR DESCRIPTION
…ser (#171)

Callback events are meaningless once the fragment is no longer in use.
Our callback could potentially do bad stuff (e.g. try to access the
activity, or try to access strings via fragment utils, which depend
on being attached to an activity), so we should disable that possibility
to avoid crashes.

I also considered making the getString() access in our callbacks safe, but it seems more sensible
to not let the webview call our code at all if we know we won't be shown ever again. (Getting
accessibility events for a view that is gone also doesn't make much sense.)