### PR TITLE
Show first-run on first-run, not on !first-run (#180)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/Settings.java
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.java
@@ -32,6 +32,6 @@ public class Settings {
     }
 
     public boolean shouldShowFirstrun() {
-        return preferences.getBoolean(FirstrunFragment.FIRSTRUN_PREF, false);
+        return !preferences.getBoolean(FirstrunFragment.FIRSTRUN_PREF, false);
     }
 }


### PR DESCRIPTION
This is a dumb one: I removed the negation by accident in:
c199e81d38e453c6d8d33aa9f3228c64c1843436