### PR TITLE
Add outdated locale mapping (#163)

### DIFF
--- a/tools/l10n/android2po/env.py
+++ b/tools/l10n/android2po/env.py
@@ -29,11 +29,17 @@ class IncompleteEnvironment(EnvironmentError):
 
 ANDROID_LOCALE_MAPPING = {
     'from': {
+        'in': 'id',
+        'iw': 'he',
+        'ji': 'yi',
         'zh_CN': 'zh_Hans_CN',
         'zh_HK': 'zh_Hant_HK',
         'zh_TW': 'zh_Hant_TW'
     },
     'to': {
+        'id': 'in',
+        'he': 'iw',
+        'yi': 'ji',
         'zh_Hans_CN': 'zh_CN',
         'zh_Hant_HK': 'zh_HK',
         'zh_Hant_TW': 'zh_TW'


### PR DESCRIPTION
This should hopefully make Hebrew, Indonesian, and Yiddish all work.

(I've tested hebrew to work locally - previously only english fallback strings were visible. We'll
need a new string import for default builds to actually reflect these changes.)