### PR TITLE
Opt out of Android webview metrics

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,6 +57,9 @@
                 <action android:name="android.support.customtabs.action.CustomTabsService" />
             </intent-filter>
         </service>
+
+        <meta-data android:name="android.webkit.WebView.MetricsOptOut"
+                   android:value="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
We definitely don't want to be leaking browsing data in focus, even
if the user usually would opt in to sharing metrics.

(See https://developer.android.com/reference/android/webkit/WebView.html
 -> "Metrics" )