### PR TITLE
Set FLAG_SECURE (#103)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -6,7 +6,6 @@
 package org.mozilla.focus.activity;
 
 import android.annotation.SuppressLint;
-import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
@@ -15,9 +14,8 @@ import android.preference.PreferenceManager;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.View;
-import android.widget.LinearLayout;
+import android.view.WindowManager;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.fragment.BrowserFragment;
@@ -61,6 +59,10 @@ public class MainActivity extends AppCompatActivity {
         WebViewProvider.preload(this);
 
         PreferenceManager.setDefaultValues(this, R.xml.settings, false);
+
+        if (appSettings.shouldUseSecureMode()) {
+            getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
+        }
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.java
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.java
@@ -34,4 +34,10 @@ public class Settings {
     public boolean shouldShowFirstrun() {
         return !preferences.getBoolean(FirstrunFragment.FIRSTRUN_PREF, false);
     }
+
+    public boolean shouldUseSecureMode() {
+        return preferences.getBoolean(
+                resources.getString(R.string.pref_key_secure),
+                true);
+    }
 }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -13,4 +13,6 @@
     <string name="pref_key_default_browser" translatable="false"><xliff:g id="preference_key">pref_default_browser</xliff:g></string>
 
     <string name="pref_key_telemetry" translatable="false"><xliff:g id="preference_key">pref_telemetry</xliff:g></string>
+
+    <string name="pref_key_secure" translatable="false"><xliff:g id="preference_key">pref_secure</xliff:g></string>
 </resources>


### PR DESCRIPTION
We want to enable this by default for everyone, however this flag
needs to be disabled for screenshot testing, hence we've added
a hidden preference. (This preference could be used to make things
configurable if needed in future, however we don't listen to pref
changes at this time, so that would need to be added if a user visible
preference is added.)