### PR TITLE
Skip \n removal on html string export

### DIFF
--- a/tools/l10n/android2po/convert.py
+++ b/tools/l10n/android2po/convert.py
@@ -311,7 +311,7 @@ def get_element_text(tag, name, warnfunc=dummy_warn):
                 if "<![CDATA[" in raw:
                     # Don't escape CDATA sections - they're already hand-crafted and can break
                     # if we do more escaping:
-                    value += t.replace('\n', '')
+                    value += t
                 else:
                     converted_value, elem_formatted = convert_text(t)
                     if elem_formatted:


### PR DESCRIPTION
This makes translation more difficult, and isn't necessary.

These \n are inserted when exporting strings.xml to the .pot file.
They're retained on translation, and also retained on reimport
to values-*/strings.xml. However Android/webview don't care about
\n in html content, it's completely ignored - so we don't need to care.