### PR TITLE
Update external-app dialog styling

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
@@ -114,7 +114,7 @@ public class IntentUtils {
     // end up needing more or a variable number we can change this, but java varargs are a bit messy
     // so let's try to avoid that seeing as it's not needed right now.
     private static void showConfirmationDialog(final Activity activity, final Intent targetIntent, final String title, final @StringRes int messageResource, final CharSequence param) {
-        final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        final AlertDialog.Builder builder = new AlertDialog.Builder(activity, R.style.DialogStyle);
 
         final CharSequence ourAppName = activity.getResources().getString(R.string.app_name);
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,6 +13,19 @@
         <item name="popupMenuStyle">@style/PopupMenu</item>
     </style>
 
+    <style name="DialogTitleStyle" parent="TextAppearance.AppCompat.Title">
+        <item name="android:textColor">#FFFFFF</item>
+    </style>
+
+    <!-- Setting this via alertDialogStyle in AppTheme results in crashes. You need to
+         explicitly select this via "new AlertDialog.Builder(activity, R.style.DialogStyle)"
+         We need this style because the accent colour for the MainActivity is purple,
+         but we want different accents in the dialog. -->
+    <style name="DialogStyle" parent="Theme.AppCompat.Dialog.Alert">
+        <item name="colorAccent">#FF00A4DC</item>
+        <item name="android:windowTitleStyle">@style/DialogTitleStyle</item>
+    </style>
+
     <style name="SettingsTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="colorAccent">#FF00A4DC</item>
     </style>


### PR DESCRIPTION
Trying to set the style using:
<item name="alertDialogStyle">@style/DialogStyle</item>
in AppTheme, results in:
android.content.res.Resources$NotFoundException: Resource ID #0x0

We're passing in the correct activity, so I've got no idea why this is
happening. Explicitly setting the style when creating the dialog works
so lets just stick with that for now. (Extending AlertDialog.AppCompat
results in the theming being ignored. Even an empty style that
extends Theme.AppCompat.Dialog.Alert results in crashes unless we set
it in code, so it seems something is wrong with only the xml codepath.)