### PR TITLE
Wrap preference titles (#236)

### DIFF
--- a/app/src/main/res/layout/focus_preference.xml
+++ b/app/src/main/res/layout/focus_preference.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Imported directly from the Android Project:
+     http://androidxref.com/7.1.1_r6/xref/frameworks/support/v7/preference/res/layout-v11/preference.xml
+     title has been modified to allow multiline text. -->
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:gravity="center_vertical"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd">
+
+    <LinearLayout
+        android:id="@+id/icon_frame"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:gravity="start|center_vertical"
+        android:orientation="horizontal">
+        <ImageView
+            android:id="@android:id/icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dip" />
+    </LinearLayout>
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:paddingTop="16dip"
+        android:paddingBottom="16dip">
+
+        <TextView android:id="@android:id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceListItem" />
+
+        <TextView android:id="@android:id/summary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@android:id/title"
+            android:layout_alignStart="@android:id/title"
+            android:textAppearance="?android:attr/textAppearanceListItemSecondary"
+            android:textColor="?android:attr/textColorSecondary"
+            android:maxLines="10" />
+
+    </RelativeLayout>
+
+    <!-- Preference should place its actual preference widget here. -->
+    <LinearLayout android:id="@android:id/widget_frame"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:minWidth="58dip"
+        android:gravity="end|center_vertical"
+        android:orientation="vertical" />
+
+</LinearLayout>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -5,6 +5,7 @@
         android:title="@string/preference_category_search">
 
         <org.mozilla.focus.search.SearchEnginePreference
+            android:layout="@layout/focus_preference"
             android:key="@string/pref_key_search_engine"
             android:summary="@string/preference_search_engine_default" />
 
@@ -14,21 +15,25 @@
         android:title="@string/preference_category_privacy">
 
         <SwitchPreference
+            android:layout="@layout/focus_preference"
             android:title="@string/preference_privacy_block_ads"
             android:key="@string/pref_key_privacy_block_ads"
             android:defaultValue="true" />
 
         <SwitchPreference
+            android:layout="@layout/focus_preference"
             android:title="@string/preference_privacy_block_analytics"
             android:key="@string/pref_key_privacy_block_analytics"
             android:defaultValue="true" />
 
         <SwitchPreference
+            android:layout="@layout/focus_preference"
             android:title="@string/preference_privacy_block_social"
             android:key="@string/pref_key_privacy_block_social"
             android:defaultValue="true" />
 
         <SwitchPreference
+            android:layout="@layout/focus_preference"
             android:title="@string/preference_privacy_block_content"
             android:key="@string/pref_key_privacy_block_other"
             android:summary="@string/preference_privacy_block_content_summary"
@@ -40,6 +45,7 @@
         android:title="@string/preference_category_performance">
 
         <SwitchPreference
+            android:layout="@layout/focus_preference"
             android:title="@string/preference_performance_block_webfonts"
             android:key="@string/pref_key_performance_block_webfonts"
             android:defaultValue="false" />
@@ -58,22 +64,27 @@
         android:title="@string/preference_category_mozilla">
 
         <org.mozilla.focus.widget.DefaultBrowserPreference
+            android:layout="@layout/focus_preference"
             android:key="@string/pref_key_default_browser"
             android:title="@string/preference_default_browser" />
 
         <org.mozilla.focus.widget.LinkedSwitchPreference
+            android:layout="@layout/focus_preference"
             android:title="@string/preference_mozilla_telemetry"
             android:key="@string/pref_key_telemetry"
             android:defaultValue="true"
             android:summary="@string/preference_mozilla_telemetry_summary" />
 
         <Preference
+            android:layout="@layout/focus_preference"
             android:title="@string/menu_about" />
 
         <Preference
+            android:layout="@layout/focus_preference"
             android:title="@string/menu_help" />
 
         <Preference
+            android:layout="@layout/focus_preference"
             android:title="@string/menu_rights" />
 
     </PreferenceCategory>


### PR DESCRIPTION
For some reason setting android:preferenceStyle, even with an empty
style, results in text sizing breaking - even though Preference
doesn't seem to even care about text styling (it only uses that for
things like layouts and pref contents, not styling). This is a complete
mess to debug, so I decided to just set the pref layout directly
instead.

Even just using the default preference style results in this happening,
e.g.:
<item name="android:preferenceStyle">?android:preferenceStyle</item>
results in the text looking huge, and switches disappearing.