### PR TITLE
Use launchMode=singleTask so that settings/info stay in same task  (#251)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:theme="@style/AppTheme"
         android:name=".FocusApplication">
         <activity android:name=".activity.MainActivity"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTask"
             android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout"
             android:label="@string/launcher_name">
             <intent-filter>


### PR DESCRIPTION
If we use singleInstance, then any new activities are launched in a new
task. I.e. Settings/About/Help/Rights are launched in a new task. If you
then switch apps and return to focus, then exit the Settings/About/Help/
Rights activities, you return to the home screen since the MainActivity
isn't in the same task/backstack.