### PR TITLE
Use custom tabs for external links

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/ExternalInfoActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/ExternalInfoActivity.java
@@ -34,4 +34,9 @@ public class ExternalInfoActivity {
         final String manifestoURL = SupportUtils.getManifestoURL();
         launchURL(context, manifestoURL);
     }
+
+    public static void launchDefaultBrowserInfo(final Context context) {
+        final String url = "https://support.mozilla.org/kb/make-firefox-default-browser-android?utm_source=inproduct&amp;utm_medium=settings&amp;utm_campaign=mobileandroid";
+        launchURL(context, url);
+    }
 }

--- a/app/src/main/java/org/mozilla/focus/activity/ExternalInfoActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/ExternalInfoActivity.java
@@ -15,13 +15,12 @@ import org.mozilla.focus.utils.SupportUtils;
 public class ExternalInfoActivity {
 
     private static void launchURL(final Context context, final String url) {
-        CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
-
-        CustomTabsIntent customTabIntent = builder.build();
-
         final String ctPackage = CustomTabsHelper.getPackageNameToUse(context);
 
         if (ctPackage != null) {
+            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+            CustomTabsIntent customTabIntent = builder.build();
+
             customTabIntent.intent.setPackage(ctPackage);
             customTabIntent.launchUrl(context, Uri.parse(url));
         } else {

--- a/app/src/main/java/org/mozilla/focus/activity/ExternalInfoActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/ExternalInfoActivity.java
@@ -14,7 +14,7 @@ import org.mozilla.focus.utils.SupportUtils;
  */
 public class ExternalInfoActivity {
 
-    private static void launchURL(final Context context, final String url) {
+    public static void launchURL(final Context context, final String url) {
         final String ctPackage = CustomTabsHelper.getPackageNameToUse(context);
 
         if (ctPackage != null) {

--- a/app/src/main/java/org/mozilla/focus/activity/ExternalInfoActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/ExternalInfoActivity.java
@@ -1,0 +1,38 @@
+package org.mozilla.focus.activity;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.support.customtabs.CustomTabsIntent;
+
+import org.mozilla.focus.customtabs.CustomTabsHelper;
+import org.mozilla.focus.utils.SupportUtils;
+
+/**
+ * This is not an actual activity - this is just a helper to show an information page in a new
+ * activity.
+ */
+public class ExternalInfoActivity {
+
+    private static void launchURL(final Context context, final String url) {
+        CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+
+        CustomTabsIntent customTabIntent = builder.build();
+
+        final String ctPackage = CustomTabsHelper.getPackageNameToUse(context);
+
+        if (ctPackage != null) {
+            customTabIntent.intent.setPackage(ctPackage);
+            customTabIntent.launchUrl(context, Uri.parse(url));
+        } else {
+            // Fallback to InfoActivity if there's really no custom tabs support in existence.
+            final Intent intent = InfoActivity.getIntentFor(context, url, "");
+            context.startActivity(intent);
+        }
+    }
+
+    public static void launchManifesto(final Context context) {
+        final String manifestoURL = SupportUtils.getManifestoURL();
+        launchURL(context, manifestoURL);
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/activity/ExternalInfoActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/ExternalInfoActivity.java
@@ -25,6 +25,9 @@ public class ExternalInfoActivity {
             customTabIntent.launchUrl(context, Uri.parse(url));
         } else {
             // Fallback to InfoActivity if there's really no custom tabs support in existence.
+            // We use no title, since it's hard or impossible to determine the title for most
+            // pages (moreover there's little value in doing so, since this should happen to
+            // a minimal number of users).
             final Intent intent = InfoActivity.getIntentFor(context, url, "");
             context.startActivity(intent);
         }
@@ -37,6 +40,11 @@ public class ExternalInfoActivity {
 
     public static void launchDefaultBrowserInfo(final Context context) {
         final String url = "https://support.mozilla.org/kb/make-firefox-default-browser-android?utm_source=inproduct&amp;utm_medium=settings&amp;utm_campaign=mobileandroid";
+        launchURL(context, url);
+    }
+
+    public static void launchSumoPage(final Context context, final String sumoTag) {
+        final String url = SupportUtils.getSumoURLForTopic(context, sumoTag);
         launchURL(context, url);
     }
 }

--- a/app/src/main/java/org/mozilla/focus/activity/ExternalInfoActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/ExternalInfoActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.support.customtabs.CustomTabsIntent;
 
+import org.mozilla.focus.R;
 import org.mozilla.focus.customtabs.CustomTabsHelper;
 import org.mozilla.focus.utils.SupportUtils;
 
@@ -19,6 +20,8 @@ public class ExternalInfoActivity {
 
         if (ctPackage != null) {
             CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+            builder.setToolbarColor(context.getResources().getColor(R.color.colorPrimary));
+
             CustomTabsIntent customTabIntent = builder.build();
 
             customTabIntent.intent.setPackage(ctPackage);

--- a/app/src/main/java/org/mozilla/focus/activity/InfoActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/InfoActivity.java
@@ -66,9 +66,10 @@ public class InfoActivity extends AppCompatActivity {
                 if (url.equals("manifesto:")) {
                     ExternalInfoActivity.launchManifesto(view.getContext());
                     return true;
+                } else {
+                    ExternalInfoActivity.launchURL(view.getContext(), url);
+                    return true;
                 }
-
-                return super.shouldOverrideUrlLoading(view, url);
             }
         });
 

--- a/app/src/main/java/org/mozilla/focus/activity/InfoActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/InfoActivity.java
@@ -19,7 +19,6 @@ import android.webkit.WebViewClient;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.utils.HtmlLoader;
-import org.mozilla.focus.utils.SupportUtils;
 
 import java.util.Map;
 
@@ -61,7 +60,17 @@ public class InfoActivity extends AppCompatActivity {
         // By default WebView will try to open links and redirects in an external browser (and sumo
         // links usually use a redirect to get to the desired target page). Somehow, setting a default
         // WebViewClient() is enough to disable that behaviour.
-        webView.setWebViewClient(new WebViewClient());
+        webView.setWebViewClient(new WebViewClient() {
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                if (url.equals("manifesto:")) {
+                    ExternalInfoActivity.launchManifesto(view.getContext());
+                    return true;
+                }
+
+                return super.shouldOverrideUrlLoading(view, url);
+            }
+        });
 
         loadURL(url, webView);
 
@@ -87,7 +96,7 @@ public class InfoActivity extends AppCompatActivity {
 
             final Map<String, String> substitutionMap = new ArrayMap<>();
             final String appName = webView.getContext().getResources().getString(R.string.app_name);
-            final String learnMoreURL = SupportUtils.getManifestoURL();
+            final String learnMoreURL = "manifesto:";
 
             final String aboutContent = resources.getString(R.string.about_content, appName, learnMoreURL);
             substitutionMap.put("%about-content%", aboutContent);

--- a/app/src/main/java/org/mozilla/focus/customtabs/CustomTabsHelper.java
+++ b/app/src/main/java/org/mozilla/focus/customtabs/CustomTabsHelper.java
@@ -120,6 +120,12 @@ public class CustomTabsHelper {
                     break;
                 }
             }
+
+            // If we have > 1 CT supporting packages, none of which were in our list of known apps,
+            // pick the first one:
+            if (sPackageNameToUse == null) {
+                sPackageNameToUse = packagesSupportingCustomTabs.get(0);
+            }
         }
         return sPackageNameToUse;
     }

--- a/app/src/main/java/org/mozilla/focus/customtabs/CustomTabsHelper.java
+++ b/app/src/main/java/org/mozilla/focus/customtabs/CustomTabsHelper.java
@@ -33,10 +33,27 @@ import java.util.List;
  */
 public class CustomTabsHelper {
     private static final String TAG = "CustomTabsHelper";
-    static final String STABLE_PACKAGE = "com.android.chrome";
-    static final String BETA_PACKAGE = "com.chrome.beta";
-    static final String DEV_PACKAGE = "com.chrome.dev";
-    static final String LOCAL_PACKAGE = "com.google.android.apps.chrome";
+
+    static final String[] PACKAGES = new String[] {
+            // Prefer Focus and Firefox release versions
+            "org.mozilla.focus",
+            "org.mozilla.klar",
+            "org.mozilla.firefox",
+            // And fallback to beta/aurora/dev/nightly:
+            "org.mozilla.focus.beta",
+            "org.mozilla.klar.beta",
+            "org.mozilla.firefox_beta",
+            "org.mozilla.focus.debug",
+            "org.mozilla.klar.debug",
+            "org.mozilla.fennec_aurora",
+            "org.mozilla.fennec",
+            // If none of those exist there's also chrome:
+            "com.android.chrome",
+            "com.chrome.beta",
+            "com.chrome.dev",
+            "com.google.android.apps.chrome"
+    };
+
     private static final String EXTRA_CUSTOM_TABS_KEEP_ALIVE =
             "android.support.customtabs.extra.KEEP_ALIVE";
     private static final String ACTION_CUSTOM_TABS_CONNECTION =
@@ -96,14 +113,13 @@ public class CustomTabsHelper {
                 && !hasSpecializedHandlerIntents(context, activityIntent)
                 && packagesSupportingCustomTabs.contains(defaultViewHandlerPackageName)) {
             sPackageNameToUse = defaultViewHandlerPackageName;
-        } else if (packagesSupportingCustomTabs.contains(STABLE_PACKAGE)) {
-            sPackageNameToUse = STABLE_PACKAGE;
-        } else if (packagesSupportingCustomTabs.contains(BETA_PACKAGE)) {
-            sPackageNameToUse = BETA_PACKAGE;
-        } else if (packagesSupportingCustomTabs.contains(DEV_PACKAGE)) {
-            sPackageNameToUse = DEV_PACKAGE;
-        } else if (packagesSupportingCustomTabs.contains(LOCAL_PACKAGE)) {
-            sPackageNameToUse = LOCAL_PACKAGE;
+        } else {
+            for (final String ctPackage : PACKAGES) {
+                if (packagesSupportingCustomTabs.contains(ctPackage)) {
+                    sPackageNameToUse = ctPackage;
+                    break;
+                }
+            }
         }
         return sPackageNameToUse;
     }
@@ -139,6 +155,6 @@ public class CustomTabsHelper {
      * @return All possible chrome package names that provide custom tabs feature.
      */
     public static String[] getPackages() {
-        return new String[]{"", STABLE_PACKAGE, BETA_PACKAGE, DEV_PACKAGE, LOCAL_PACKAGE};
+        return PACKAGES;
     }
 }

--- a/app/src/main/java/org/mozilla/focus/customtabs/CustomTabsHelper.java
+++ b/app/src/main/java/org/mozilla/focus/customtabs/CustomTabsHelper.java
@@ -1,0 +1,144 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Imported from: https://github.com/GoogleChrome/custom-tabs-client/blob/c51efbddc4f976c88d15c730a79feba65ca857af/shared/src/main/java/org/chromium/customtabsclient/shared/CustomTabsHelper.java
+
+package org.mozilla.focus.customtabs;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.net.Uri;
+import android.text.TextUtils;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper class for Custom Tabs.
+ */
+public class CustomTabsHelper {
+    private static final String TAG = "CustomTabsHelper";
+    static final String STABLE_PACKAGE = "com.android.chrome";
+    static final String BETA_PACKAGE = "com.chrome.beta";
+    static final String DEV_PACKAGE = "com.chrome.dev";
+    static final String LOCAL_PACKAGE = "com.google.android.apps.chrome";
+    private static final String EXTRA_CUSTOM_TABS_KEEP_ALIVE =
+            "android.support.customtabs.extra.KEEP_ALIVE";
+    private static final String ACTION_CUSTOM_TABS_CONNECTION =
+            "android.support.customtabs.action.CustomTabsService";
+
+    private static String sPackageNameToUse;
+
+    private CustomTabsHelper() {}
+
+//    public static void addKeepAliveExtra(Context context, Intent intent) {
+//        Intent keepAliveIntent = new Intent().setClassName(
+//                context.getPackageName(), KeepAliveService.class.getCanonicalName());
+//        intent.putExtra(EXTRA_CUSTOM_TABS_KEEP_ALIVE, keepAliveIntent);
+//    }
+
+    /**
+     * Goes through all apps that handle VIEW intents and have a warmup service. Picks
+     * the one chosen by the user if there is one, otherwise makes a best effort to return a
+     * valid package name.
+     *
+     * This is <strong>not</strong> threadsafe.
+     *
+     * @param context {@link Context} to use for accessing {@link PackageManager}.
+     * @return The package name recommended to use for connecting to custom tabs related components.
+     */
+    public static String getPackageNameToUse(Context context) {
+        if (sPackageNameToUse != null) return sPackageNameToUse;
+
+        PackageManager pm = context.getPackageManager();
+        // Get default VIEW intent handler.
+        Intent activityIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"));
+        ResolveInfo defaultViewHandlerInfo = pm.resolveActivity(activityIntent, 0);
+        String defaultViewHandlerPackageName = null;
+        if (defaultViewHandlerInfo != null) {
+            defaultViewHandlerPackageName = defaultViewHandlerInfo.activityInfo.packageName;
+        }
+
+        // Get all apps that can handle VIEW intents.
+        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(activityIntent, 0);
+        List<String> packagesSupportingCustomTabs = new ArrayList<>();
+        for (ResolveInfo info : resolvedActivityList) {
+            Intent serviceIntent = new Intent();
+            serviceIntent.setAction(ACTION_CUSTOM_TABS_CONNECTION);
+            serviceIntent.setPackage(info.activityInfo.packageName);
+            if (pm.resolveService(serviceIntent, 0) != null) {
+                packagesSupportingCustomTabs.add(info.activityInfo.packageName);
+            }
+        }
+
+        // Now packagesSupportingCustomTabs contains all apps that can handle both VIEW intents
+        // and service calls.
+        if (packagesSupportingCustomTabs.isEmpty()) {
+            sPackageNameToUse = null;
+        } else if (packagesSupportingCustomTabs.size() == 1) {
+            sPackageNameToUse = packagesSupportingCustomTabs.get(0);
+        } else if (!TextUtils.isEmpty(defaultViewHandlerPackageName)
+                && !hasSpecializedHandlerIntents(context, activityIntent)
+                && packagesSupportingCustomTabs.contains(defaultViewHandlerPackageName)) {
+            sPackageNameToUse = defaultViewHandlerPackageName;
+        } else if (packagesSupportingCustomTabs.contains(STABLE_PACKAGE)) {
+            sPackageNameToUse = STABLE_PACKAGE;
+        } else if (packagesSupportingCustomTabs.contains(BETA_PACKAGE)) {
+            sPackageNameToUse = BETA_PACKAGE;
+        } else if (packagesSupportingCustomTabs.contains(DEV_PACKAGE)) {
+            sPackageNameToUse = DEV_PACKAGE;
+        } else if (packagesSupportingCustomTabs.contains(LOCAL_PACKAGE)) {
+            sPackageNameToUse = LOCAL_PACKAGE;
+        }
+        return sPackageNameToUse;
+    }
+
+    /**
+     * Used to check whether there is a specialized handler for a given intent.
+     * @param intent The intent to check with.
+     * @return Whether there is a specialized handler for the given intent.
+     */
+    private static boolean hasSpecializedHandlerIntents(Context context, Intent intent) {
+        try {
+            PackageManager pm = context.getPackageManager();
+            List<ResolveInfo> handlers = pm.queryIntentActivities(
+                    intent,
+                    PackageManager.GET_RESOLVED_FILTER);
+            if (handlers == null || handlers.size() == 0) {
+                return false;
+            }
+            for (ResolveInfo resolveInfo : handlers) {
+                IntentFilter filter = resolveInfo.filter;
+                if (filter == null) continue;
+                if (filter.countDataAuthorities() == 0 || filter.countDataPaths() == 0) continue;
+                if (resolveInfo.activityInfo == null) continue;
+                return true;
+            }
+        } catch (RuntimeException e) {
+            Log.e(TAG, "Runtime exception while getting specialized handlers");
+        }
+        return false;
+    }
+
+    /**
+     * @return All possible chrome package names that provide custom tabs feature.
+     */
+    public static String[] getPackages() {
+        return new String[]{"", STABLE_PACKAGE, BETA_PACKAGE, DEV_PACKAGE, LOCAL_PACKAGE};
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/widget/DefaultBrowserPreference.java
+++ b/app/src/main/java/org/mozilla/focus/widget/DefaultBrowserPreference.java
@@ -13,6 +13,7 @@ import android.preference.Preference;
 import android.provider.Settings;
 import android.util.AttributeSet;
 
+import org.mozilla.focus.activity.ExternalInfoActivity;
 import org.mozilla.focus.activity.InfoActivity;
 
 @TargetApi(Build.VERSION_CODES.N)
@@ -31,11 +32,7 @@ public class DefaultBrowserPreference extends Preference {
             Intent intent = new Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS);
             getContext().startActivity(intent);
         } else {
-            // This link apparently doesn't need the usual SUMO processing: it's not app specific, but platform specific
-            final String url = "https://support.mozilla.org/kb/make-firefox-default-browser-android?utm_source=inproduct&amp;utm_medium=settings&amp;utm_campaign=mobileandroid";
-
-            final Intent intent = InfoActivity.getIntentFor(getContext(), url, getTitle().toString());
-            getContext().startActivity(intent);
+            ExternalInfoActivity.launchDefaultBrowserInfo(getContext());
         }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/widget/LinkedSwitchPreference.java
+++ b/app/src/main/java/org/mozilla/focus/widget/LinkedSwitchPreference.java
@@ -19,6 +19,7 @@ import android.widget.Switch;
 import android.widget.TextView;
 
 import org.mozilla.focus.R;
+import org.mozilla.focus.activity.ExternalInfoActivity;
 import org.mozilla.focus.activity.InfoActivity;
 import org.mozilla.focus.utils.SupportUtils;
 
@@ -68,11 +69,7 @@ class LinkedSwitchPreference extends Preference {
             public void onClick(View v) {
                 // This is a hardcoded link: if we ever end up needing more of these links, we should
                 // move the link into an xml parameter, but there's no advantage to making it configurable now.
-                final String url = SupportUtils.getSumoURLForTopic(getContext(), "usage-data");
-                final String title = getTitle().toString();
-
-                final Intent intent = InfoActivity.getIntentFor(getContext(), url, title);
-                getContext().startActivity(intent);
+                ExternalInfoActivity.launchSumoPage(getContext(), "usage-data");
             }
         });
 


### PR DESCRIPTION
This doesn't necessarily avoid data sharing, since we might end up reusing focus's custom tabs.
But it does let us use custom tabs, from any browser, for external pages.