### PR TITLE
Fix dynamic toolbar oddness (#247)

### DIFF
--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -19,7 +19,6 @@
         android:id="@+id/appbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true"
         android:elevation="4dp">
 
         <FrameLayout


### PR DESCRIPTION
It seems we don't need fitsSystemWindows anywhere. We already make
MainActivity fullscreen, so all our content already gets the full
screen. It's not clear why the weird issues don't happen if we've
shown a different fragment first.