### PR TITLE
Add exit fade to first-run (#170)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.java
@@ -9,10 +9,11 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.transition.Transition;
+import android.transition.TransitionInflater;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.activity.MainActivity;
@@ -24,6 +25,16 @@ public class FirstrunFragment extends Fragment implements View.OnClickListener {
 
     public static FirstrunFragment create() {
         return new FirstrunFragment();
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+
+        final Transition transition = TransitionInflater.from(context).
+                inflateTransition(R.transition.firstrun_exit);
+
+        setExitTransition(transition);
     }
 
     @Override

--- a/app/src/main/res/transition/firstrun_exit.xml
+++ b/app/src/main/res/transition/firstrun_exit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<fade xmlns:android="http://schemas.android.com/apk/res/android"
+      android:fadingMode="fade_out"
+      android:duration="@integer/erase_animation_alpha_duration" />


### PR DESCRIPTION
I wonder if we should move the 200ms definition into xml, but that doesn't seem to be someting we'll need to reconfigure.