### PR TITLE
Set "erase" snackbar delay to 100ms

### DIFF
--- a/app/src/main/res/values/configuration.xml
+++ b/app/src/main/res/values/configuration.xml
@@ -11,5 +11,5 @@
     <integer name="erase_animation_translate_duration">100</integer>
     <integer name="erase_animation_translate_offset">100</integer>
 
-    <integer name="erase_snackbar_delay">1000</integer>
+    <integer name="erase_snackbar_delay">100</integer>
 </resources>


### PR DESCRIPTION
I used 1000ms for testing. This should actually be 100ms.