### PR TITLE
Don't use external URI handling for error: pages (#279)

### DIFF
--- a/app/src/webkit/java/org/mozilla/focus/web/WebViewProvider.java
+++ b/app/src/webkit/java/org/mozilla/focus/web/WebViewProvider.java
@@ -228,7 +228,8 @@ public class WebViewProvider {
                     if ((!url.startsWith("http://")) &&
                             (!url.startsWith("https://")) &&
                             (!url.startsWith("file://")) &&
-                            (!url.startsWith("data:"))) {
+                            (!url.startsWith("data:")) &&
+                            (!url.startsWith("error:"))) {
                         callback.handleExternalUrl(url);
                         return true;
                     }


### PR DESCRIPTION
I need to refactor our whole URL and error handling to make this cleaner.
This is complicated because sometimes URL are entered by the user
(in which case shouldOverrideUrlLoading() isn't called), and sometimes
they come from the webview (in which case we can override loading). We
want to make sure we get consistent behaviour in both cases.

(However we might want to exclude error: URLs when opening via a link?)