### PR TITLE
Refactor and fix URL handling

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -133,12 +133,21 @@ public class BrowserFragment extends Fragment implements View.OnClickListener {
             }
 
             @Override
-            public void handleExternalUrl(final String url) {
+            public boolean handleExternalUrl(final String url) {
                 final String fallback = IntentUtils.handleExternalUri(getActivity(), url);
 
                 if (fallback != null) {
-                    webView.loadUrl(fallback);
+                    // Stop loading if we've received any data. The fallback is either a success indicator
+                    // (we've shown a dialog), or a completely URL that we should try to load.
+                    if (!fallback.equals("success:")) {
+                        webView.loadUrl(fallback);
+                    }
+
+                    return true;
                 }
+
+                // Unhandled: we just let the browser finish loading (e.g. showing the unsupported protocol error page).
+                return false;
             }
         });
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -134,20 +134,7 @@ public class BrowserFragment extends Fragment implements View.OnClickListener {
 
             @Override
             public boolean handleExternalUrl(final String url) {
-                final String fallback = IntentUtils.handleExternalUri(getActivity(), url);
-
-                if (fallback != null) {
-                    // Stop loading if we've received any data. The fallback is either a success indicator
-                    // (we've shown a dialog), or a completely URL that we should try to load.
-                    if (!fallback.equals("success:")) {
-                        webView.loadUrl(fallback);
-                    }
-
-                    return true;
-                }
-
-                // Unhandled: we just let the browser finish loading (e.g. showing the unsupported protocol error page).
-                return false;
+                return IntentUtils.handleExternalUri(getContext(), webView, url);
             }
         });
 

--- a/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
@@ -41,7 +41,7 @@ public class IntentUtils {
         } catch (URISyntaxException e) {
             // Let the browser handle the url (i.e. let the browser show it's unsupported protocol /
             // invalid URL page).
-            return uri;
+            return null;
         }
 
         // Since we're a browser:
@@ -71,7 +71,7 @@ public class IntentUtils {
             final CharSequence externalAppTitle = info.loadLabel(packageManager);
 
             showConfirmationDialog(activity, intent, activity.getString(R.string.external_app_prompt_title), R.string.external_app_prompt, externalAppTitle);
-            return null;
+            return "success:";
         } else { // matchingActivities.size() > 1
             // By explicitly showing the chooser, we can avoid having a (default) app from opening
             // the link immediately. This isn't perfect - we'd prefer to highlight the default app,
@@ -81,7 +81,9 @@ public class IntentUtils {
             final String chooserTitle = activity.getResources().getString(R.string.external_multiple_apps_matched_exit);
             final Intent chooserIntent = Intent.createChooser(intent, chooserTitle);
             activity.startActivity(chooserIntent);
-            return null;
+
+            // It was handled, stop loading other stuff
+            return "success:";
         }
     }
 
@@ -102,12 +104,14 @@ public class IntentUtils {
             showConfirmationDialog(activity, marketIntent,
                     activity.getResources().getString(R.string.external_app_prompt_no_app_title),
                     R.string.external_app_prompt_no_app, marketTitle);
-            return null;
+
+            // Stop loading, we essentially have a result.
+            return "success:";
         }
 
         // If there's really no way to handle this, we just let the browser handle this URL
         // (which then shows the unsupported protocol page).
-        return intent.toUri(0);
+        return null;
     }
 
     // We only need one param for both scenarios, hence we use just one "param" argument. If we ever

--- a/app/src/main/java/org/mozilla/focus/web/IWebView.java
+++ b/app/src/main/java/org/mozilla/focus/web/IWebView.java
@@ -12,7 +12,8 @@ public interface IWebView {
         void onPageStarted(String url);
         void onPageFinished(boolean isSecure);
         void onProgress(int progress);
-        void handleExternalUrl(String url);
+        /** Return true if the URL was handled, false if we should continue loading the current URL. */
+        boolean handleExternalUrl(String url);
     }
 
     void setCallback(Callback callback);

--- a/app/src/webkit/java/org/mozilla/focus/web/FocusWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/web/FocusWebViewClient.java
@@ -1,0 +1,136 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.focus.web;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.net.http.SslError;
+import android.webkit.SslErrorHandler;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import org.mozilla.focus.webkit.ErrorPage;
+import org.mozilla.focus.webkit.TrackingProtectionWebViewClient;
+
+/**
+ * WebViewClient layer that handles browser specific WebViewClient functionality, such as error pages
+ * and external URL handling.
+ */
+public class FocusWebViewClient extends TrackingProtectionWebViewClient {
+    final static String ERROR_PROTOCOL = "error:";
+
+    public FocusWebViewClient(Context context) {
+        super(context);
+    }
+
+    private IWebView.Callback callback;
+
+    public void setCallback(IWebView.Callback callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public void onPageStarted(WebView view, String url, Bitmap favicon) {
+        if (callback != null) {
+            callback.onPageStarted(url);
+        }
+        super.onPageStarted(view, url, favicon);
+    }
+
+    @Override
+    public void onPageFinished(WebView view, String url) {
+        if (callback != null) {
+            callback.onPageFinished(view.getCertificate() != null);
+        }
+        super.onPageFinished(view, url);
+    }
+
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        // shouldOverrideUrlLoading() is called for both the main frame, and iframes.
+        // That can get problematic if an iframe tries to load an unsupported URL.
+        // We then try to either handle that URL (ask to open relevant app), or extract
+        // a fallback URL from the intent (or worst case fall back to an error page). In the
+        // latter 2 cases, we explicitly open the fallback/error page in the main view.
+        // Websites probably shouldn't use unsupported URLs in iframes, but we do need to
+        // be careful to handle all valid schemes here to avoid redirecting due to such an iframe
+        // (e.g. we don't want to redirect to a data: URI just because an iframe shows such
+        // a URI).
+        // (The API 24+ version of shouldOverrideUrlLoading() lets us determine whether
+        // the request is for the main frame, and if it's not we could then completely
+        // skip the external URL handling.)
+        if ((!url.startsWith("http://")) &&
+                (!url.startsWith("https://")) &&
+                (!url.startsWith("file://")) &&
+                (!url.startsWith("data:")) &&
+                (!url.startsWith("error:"))) {
+            callback.handleExternalUrl(url);
+            return true;
+        }
+
+        return super.shouldOverrideUrlLoading(view, url);
+    }
+
+    @Override
+    public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
+        handler.cancel();
+
+        // Webkit can try to load the favicon for a bad page when you set a new URL. If we then
+        // loadErrorPage() again, webkit tries to load the favicon again. We end up in onReceivedSSlError()
+        // again, and we get an infinite loop of reloads (we also erroneously show the favicon URL
+        // in the toolbar, but that's less noticeable). Hence we check whether this error is from
+        // the desired page, or a page resource:
+        if (error.getUrl().equals(currentPageURL)) {
+            ErrorPage.loadErrorPage(view, error.getUrl(), WebViewClient.ERROR_FAILED_SSL_HANDSHAKE);
+        }
+    }
+
+    @Override
+    public void onReceivedError(final WebView webView, int errorCode,
+                                final String description, String failingUrl) {
+
+        // This is a hack: onReceivedError(WebView, WebResourceRequest, WebResourceError) is API 23+ only,
+        // - the WebResourceRequest would let us know if the error affects the main frame or not. As a workaround
+        // we just check whether the failing URL is the current URL, which is enough to detect an error
+        // in the main frame.
+
+        // WebView swallows odd pages and only sends an error (i.e. it doesn't go through the usual
+        // shouldOverrideUrlLoading), so we need to handle special pages here:
+        // about: urls are even more odd: webview doesn't tell us _anything_, hence the use of
+        // a different prefix:
+        if (failingUrl.startsWith(ERROR_PROTOCOL)) {
+            // format: error:<error_code>
+            final int errorCodePosition = ERROR_PROTOCOL.length();
+            final String errorCodeString = failingUrl.substring(errorCodePosition);
+
+            int desiredErrorCode;
+            try {
+                desiredErrorCode = Integer.parseInt(errorCodeString);
+
+                if (!ErrorPage.supportsErrorCode(desiredErrorCode)) {
+                    // I don't think there's any good way of showing an error if there's an error
+                    // in requesting an error page?
+                    desiredErrorCode = WebViewClient.ERROR_BAD_URL;
+                }
+            } catch (final NumberFormatException e) {
+                desiredErrorCode = WebViewClient.ERROR_BAD_URL;
+            }
+            ErrorPage.loadErrorPage(webView, failingUrl, desiredErrorCode);
+            return;
+        }
+
+
+        // The API 23+ version also return a *slightly* more usable description, via WebResourceError.getError();
+        // e.g.. "There was a network error.", whereas this version provides things like "net::ERR_NAME_NOT_RESOLVED"
+        if (failingUrl.equals(currentPageURL) &&
+                ErrorPage.supportsErrorCode(errorCode)) {
+            ErrorPage.loadErrorPage(webView, currentPageURL, errorCode);
+            return;
+        }
+
+        super.onReceivedError(webView, errorCode, description, failingUrl);
+    }
+
+}

--- a/app/src/webkit/java/org/mozilla/focus/web/FocusWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/web/FocusWebViewClient.java
@@ -66,8 +66,9 @@ public class FocusWebViewClient extends TrackingProtectionWebViewClient {
                 (!url.startsWith("file://")) &&
                 (!url.startsWith("data:")) &&
                 (!url.startsWith("error:"))) {
-            callback.handleExternalUrl(url);
-            return true;
+            if (callback.handleExternalUrl(url)) {
+                return true;
+            }
         }
 
         return super.shouldOverrideUrlLoading(view, url);


### PR DESCRIPTION
Enabling external intent URL processing for URLs entered by hand exposed some issues in the external intent handling, which I've now fixed.

These patches also move browser specific webviewclient code into it's own class, and removes non-tracking-protection relevant code from the TrackingProtectionWebViewClient.