### PR TITLE
Do fragment work on onResumeFragments() instead of onResume() (#288)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -76,8 +76,8 @@ public class MainActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onResume() {
-        super.onResume();
+    protected void onResumeFragments() {
+        super.onResumeFragments();
 
         if (pendingUrl != null && !new Settings(this).shouldShowFirstrun()) {
             // We have received an URL in onNewIntent(). Let's load it now.


### PR DESCRIPTION
FragmentActivity (which MainActivity extends, via AppCompatActivity),
specifies that this is the correct way of doing fragment
transactions, as state might still be saved during onResume(). This
should hopefully avoid any crashes when setting up the BrowserFragment.