### PR TITLE
Don't crash if webView == null

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -130,7 +130,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public void onBackPressed() {
         final BrowserFragment browserFragment = (BrowserFragment) getSupportFragmentManager().findFragmentByTag(BrowserFragment.FRAGMENT_TAG);
-        if (browserFragment != null && browserFragment.canGoBack()) {
+        if (browserFragment != null && browserFragment.isVisible() && browserFragment.canGoBack()) {
             browserFragment.goBack();
             return;
         }


### PR DESCRIPTION
I'm not too what's the "correct" solution here. There's no point in checking the back state of the webview unless it's actually in use. The nullchecks are ugly, but since it's legitimate for a Fragment to not be attached/visible (but still alive and in a backstack), we should really handle that case too.