### PR TITLE
Add SUMO urls for help pages. (#22)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,8 +45,6 @@
             android:theme="@style/SettingsTheme"
             android:label="@string/menu_settings" />
 
-        <activity android:name=".activity.HelpActivity" />
-
         <activity android:name=".activity.InfoActivity"
                   android:theme="@style/SettingsTheme"/>
 

--- a/app/src/main/java/org/mozilla/focus/activity/HelpActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/HelpActivity.java
@@ -1,6 +1,0 @@
-package org.mozilla.focus.activity;
-
-import android.app.Activity;
-
-public class HelpActivity extends Activity {
-}

--- a/app/src/main/java/org/mozilla/focus/activity/InfoActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/InfoActivity.java
@@ -48,6 +48,11 @@ public class InfoActivity extends AppCompatActivity {
         return getIntentFor(context, "file:///android_asset/rights-focus.html", context.getResources().getString(R.string.menu_rights));
     }
 
+    public static final Intent getHelpIntent(final Context context) {
+        final Resources resources = context.getResources();
+        return getIntentFor(context, resources.getString(R.string.url_sumo_help), resources.getString(R.string.menu_help));
+    }
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.java
@@ -18,7 +18,6 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import org.mozilla.focus.R;
-import org.mozilla.focus.activity.HelpActivity;
 import org.mozilla.focus.activity.InfoActivity;
 import org.mozilla.focus.activity.SettingsActivity;
 
@@ -84,7 +83,7 @@ public class HomeFragment extends Fragment implements View.OnClickListener, Popu
                 break;
 
             case R.id.help:
-                Intent helpIntent = new Intent(getActivity(), HelpActivity.class);
+                Intent helpIntent = InfoActivity.getHelpIntent(getActivity());
                 startActivity(helpIntent);
                 break;
         }

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -13,7 +13,6 @@ import android.preference.PreferenceScreen;
 import android.support.annotation.Nullable;
 
 import org.mozilla.focus.R;
-import org.mozilla.focus.activity.HelpActivity;
 import org.mozilla.focus.activity.InfoActivity;
 
 public class SettingsFragment extends PreferenceFragment {
@@ -30,8 +29,8 @@ public class SettingsFragment extends PreferenceFragment {
             final Intent intent = InfoActivity.getAboutIntent(getActivity());
             startActivity(intent);
         } else if (preference.getKey().equals(getResources().getString(R.string.pref_key_help))) {
-            final Intent intent = new Intent(getActivity(), HelpActivity.class);
-            startActivity(intent);
+            Intent helpIntent = InfoActivity.getHelpIntent(getActivity());
+            startActivity(helpIntent);
         } else if (preference.getKey().equals(getResources().getString(R.string.pref_key_rights))) {
             final Intent intent = InfoActivity.getRightsIntent(getActivity());
             startActivity(intent);

--- a/app/src/main/res/values-de/urls.xml
+++ b/app/src/main/res/values-de/urls.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="url_sumo_help">https://support.mozilla.org/kb/klar-android-de</string>
+</resources>

--- a/app/src/main/res/values-es/urls.xml
+++ b/app/src/main/res/values-es/urls.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="url_sumo_help">https://support.mozilla.org/kb/focus-android-es</string>
+</resources>

--- a/app/src/main/res/values-fr/urls.xml
+++ b/app/src/main/res/values-fr/urls.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="url_sumo_help">https://support.mozilla.org/kb/focus-android-fr</string>
+</resources>

--- a/app/src/main/res/values-hi/urls.xml
+++ b/app/src/main/res/values-hi/urls.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="url_sumo_help">https://support.mozilla.org/kb/focus-android-hi</string>
+</resources>

--- a/app/src/main/res/values-id/urls.xml
+++ b/app/src/main/res/values-id/urls.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="url_sumo_help">https://support.mozilla.org/kb/focus-android-id</string>
+</resources>

--- a/app/src/main/res/values-it/urls.xml
+++ b/app/src/main/res/values-it/urls.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="url_sumo_help">https://support.mozilla.org/kb/focus-android-it</string>
+</resources>

--- a/app/src/main/res/values-ja/urls.xml
+++ b/app/src/main/res/values-ja/urls.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="url_sumo_help">https://support.mozilla.org/kb/focus-android-jp</string>
+</resources>

--- a/app/src/main/res/values-pl/urls.xml
+++ b/app/src/main/res/values-pl/urls.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="url_sumo_help">https://support.mozilla.org/kb/focus-android-pl</string>
+</resources>

--- a/app/src/main/res/values-pt/urls.xml
+++ b/app/src/main/res/values-pt/urls.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="url_sumo_help">https://support.mozilla.org/kb/focus-android-pt</string>
+</resources>

--- a/app/src/main/res/values-ru/urls.xml
+++ b/app/src/main/res/values-ru/urls.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="url_sumo_help">https://support.mozilla.org/kb/focus-android-ru</string>
+</resources>

--- a/app/src/main/res/values-zh-rCN/urls.xml
+++ b/app/src/main/res/values-zh-rCN/urls.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="url_sumo_help">https://support.mozilla.org/kb/focus-android-cn</string>
+</resources>

--- a/app/src/main/res/values/urls.xml
+++ b/app/src/main/res/values/urls.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <string name="url_sumo_help">https://support.mozilla.org/kb/focus-android-en</string>
+</resources>


### PR DESCRIPTION
It's a bit annoying that we have to handle all those URLs in our code.

I also noticed that hiding the WebView until the website is loaded is not really a nice solution for external pages. There should at least be some kind of loading indicator. However that's something for another issue.