### PR TITLE
Remove obsolete onDetach()

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/WebFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/WebFragment.java
@@ -71,18 +71,12 @@ public abstract class WebFragment extends Fragment {
     @Override
     public void onDestroy() {
         if (webView != null) {
+            webView.setCallback(null);
             webView.destroy();
             webView = null;
         }
 
         super.onDestroy();
-    }
-
-    @Override
-    public void onDetach() {
-        webView.setCallback(null);
-
-        super.onDetach();
     }
 
     @Override


### PR DESCRIPTION
Since we're now destroying the webView in onDestroy, there's
no webView to remove callbacks from. We can still remove the callback
in onDestroy just to be safe, but hopefully webView doesn't send
any more callbacks after we've told it to destroy itself.

This avoids crashing when exiting the browser using the back button.