### PR TITLE
Set max width for "Open With" dialog (#248)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/open/OpenWithFragment.java
+++ b/app/src/main/java/org/mozilla/focus/open/OpenWithFragment.java
@@ -6,10 +6,12 @@
 package org.mozilla.focus.open;
 
 import android.app.Dialog;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.design.widget.BottomSheetDialog;
 import android.support.v7.app.AppCompatDialogFragment;
 import android.support.v7.widget.LinearLayoutManager;
@@ -17,6 +19,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 
 import org.mozilla.focus.R;
 
@@ -43,7 +46,7 @@ public class OpenWithFragment extends AppCompatDialogFragment implements AppAdap
 
         final View view = LayoutInflater.from(wrapper).inflate(R.layout.fragment_open_with, null);
 
-        final Dialog dialog = new BottomSheetDialog(wrapper);
+        final Dialog dialog = new CustomWidthBottomSheetDialog(wrapper);
         dialog.setContentView(view);
 
         final RecyclerView appList = (RecyclerView) view.findViewById(R.id.apps);
@@ -54,6 +57,20 @@ public class OpenWithFragment extends AppCompatDialogFragment implements AppAdap
         appList.setAdapter(adapter);
 
         return dialog;
+    }
+
+    static class CustomWidthBottomSheetDialog extends BottomSheetDialog {
+        public CustomWidthBottomSheetDialog(@NonNull Context context) {
+            super(context);
+        }
+
+        @Override
+        protected void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            int width = getContext().getResources().getDimensionPixelSize(R.dimen.bottom_sheet_width);
+            getWindow().setLayout(width > 0 ? width : ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT);
+        }
     }
 
     @Override

--- a/app/src/main/res/values-sw600dp/configuration.xml
+++ b/app/src/main/res/values-sw600dp/configuration.xml
@@ -4,4 +4,6 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
     <bool name="is_tablet">true</bool>
+
+    <dimen name="bottom_sheet_width">480dp</dimen>
 </resources>

--- a/app/src/main/res/values/configuration.xml
+++ b/app/src/main/res/values/configuration.xml
@@ -12,4 +12,6 @@
     <integer name="erase_animation_translate_offset">150</integer>
 
     <integer name="erase_snackbar_delay">500</integer>
+
+    <dimen name="bottom_sheet_width">0dp</dimen>
 </resources>


### PR DESCRIPTION
Approach is borrowed from:
http://www.hidroh.com/2016/06/17/bottom-sheet-everything/

Setting the window sizes during onCreateDialog() doesn't work, it seems
those sizes get discarded. Dialog.onCreate() works well, so let's just
use that.