### PR TITLE
Reuse existing BrowserFragment when possible (#319)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -328,4 +328,11 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
             webView.goBack();
         }
     }
+
+    public void loadURL(final String url) {
+        final IWebView webView = getWebView();
+        if (webView != null) {
+            webView.loadUrl(url);
+        }
+    }
 }

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
@@ -146,11 +146,18 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
         // Replace all fragments with a fresh browser fragment. This means we either remove the
         // HomeFragment with an UrlInputFragment on top or an old BrowserFragment with an
         // UrlInputFragment.
-        getActivity().getSupportFragmentManager()
-                .beginTransaction()
-                .replace(R.id.container, BrowserFragment.create(url), BrowserFragment.FRAGMENT_TAG)
-                .addToBackStack("browser")
-                .commit();
+        final BrowserFragment browserFragment = (BrowserFragment) getActivity().getSupportFragmentManager()
+                .findFragmentByTag(BrowserFragment.FRAGMENT_TAG);
+
+        if (browserFragment != null) {
+            browserFragment.loadURL(url);
+        } else {
+            getActivity().getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.container, BrowserFragment.create(url), BrowserFragment.FRAGMENT_TAG)
+                    .addToBackStack("browser")
+                    .commit();
+        }
     }
 
     @Override


### PR DESCRIPTION
This makes sure we don't have multiple WebViews, each with
separate history.