### PR TITLE
Make sure webview is retrievable before URL loading (#333)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/WebFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/WebFragment.java
@@ -42,14 +42,13 @@ public abstract class WebFragment extends Fragment {
         final View view = inflateLayout(inflater, container, savedInstanceState);
 
         webView = (IWebView) view.findViewById(R.id.webview);
+        isWebViewAvailable = true;
         webView.setCallback(createCallback());
 
         final String url = getInitialUrl();
         if (url != null) {
             webView.loadUrl(url);
         }
-
-        isWebViewAvailable = true;
 
         return view;
     }


### PR DESCRIPTION
Our external intent handling requires access to the webview (it needs
to be able to open error or fallback pages). If isWebViewAvailable==false,
then WebFragment.getWebView() returns null, which means
BrowserFragment.handleExternalUrl() gets a null WebView, and it therefore
doesn't call the external URL handling code. Hence we need to make
sure that getWebView() can return the current WebView before calling
loadUrl().