### PR TITLE
Followup: only reuse existing fragment if visible (#319)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
@@ -149,7 +149,10 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
         final BrowserFragment browserFragment = (BrowserFragment) getActivity().getSupportFragmentManager()
                 .findFragmentByTag(BrowserFragment.FRAGMENT_TAG);
 
-        if (browserFragment != null) {
+        if (browserFragment != null && browserFragment.isVisible()) {
+            // Reuse existing visible fragment - in this case we know the user is already browsing.
+            // The fragment might exist if we "erased" a browsing session, hence we need to check
+            // for visibility in addition to existence.
             browserFragment.loadURL(url);
         } else {
             getActivity().getSupportFragmentManager()


### PR DESCRIPTION
It's possible for browserFragment to exist, without being useful:
if you exit BrowserFragment by erase()'ing, we replace() it with
HomeFragment. FragmentMangaer doesn't kill BrowserFragment then,
but trying to load a URL at that point does nothing. In this case,
we should use the normal framgent replacement logic to ensure we can
still load URLs after erase().

(The other case is when you exit BrowserFragment by pressing the back
 button, in that case BrowserFragment is popped off the backstack,
 and FragmentManager completely kills it.)