### PR TITLE
Copy strings into existing folders instead of moving (#326)

### DIFF
--- a/tools/l10n/fix_locale_folders.sh
+++ b/tools/l10n/fix_locale_folders.sh
@@ -24,9 +24,16 @@ do
 
 		echo "Fixing ${folder} -> ${fixed_folder}"
 
-		rm -rf "${fixed_folder}"
+		# The target folder might already have some data (e.g. our urls.xml),
+		# hence we only copy newly generated files over (and keep existing
+		# non-generated files).
+		if [ ! -d "${fixed_folder}" ]; then
+		    mkdir "${fixed_folder}"
+		fi
 
-		mv "$folder" "${fixed_folder}"
+		cp -r "$folder"/* "${fixed_folder}"
+
+		rm -rf "$folder"
 	fi
 done
 


### PR DESCRIPTION
This avoids deleting resource files that we track in git during
stringsImport, e.g. urls.xml.