### PR TITLE
Animate URL bar when switching from home screen to url input and back. (#115)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -8,7 +8,6 @@ package org.mozilla.focus.activity;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.Color;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.app.FragmentManager;
@@ -21,6 +20,7 @@ import org.mozilla.focus.R;
 import org.mozilla.focus.fragment.BrowserFragment;
 import org.mozilla.focus.fragment.FirstrunFragment;
 import org.mozilla.focus.fragment.HomeFragment;
+import org.mozilla.focus.fragment.UrlInputFragment;
 import org.mozilla.focus.utils.Settings;
 import org.mozilla.focus.web.IWebView;
 import org.mozilla.focus.web.WebViewProvider;
@@ -130,10 +130,24 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        final BrowserFragment browserFragment = (BrowserFragment) getSupportFragmentManager().findFragmentByTag(BrowserFragment.FRAGMENT_TAG);
-        if (browserFragment != null && browserFragment.isVisible() && browserFragment.canGoBack()) {
-            browserFragment.goBack();
-            return;
+        final FragmentManager fragmentManager = getSupportFragmentManager();
+
+        final UrlInputFragment urlInputFragment = (UrlInputFragment) fragmentManager.findFragmentByTag(UrlInputFragment.FRAGMENT_TAG);
+        if (urlInputFragment != null && urlInputFragment.isVisible()) {
+            if (urlInputFragment.onBackPressed()) {
+                // The URL input fragment has handled the back press. It does its own animations so
+                // we do not try to remove it from outside.
+                return;
+            }
+        }
+
+        final BrowserFragment browserFragment = (BrowserFragment) fragmentManager.findFragmentByTag(BrowserFragment.FRAGMENT_TAG);
+        if (browserFragment != null && browserFragment.isVisible()) {
+            if (browserFragment.onBackPressed()) {
+                // The Browser fragment handles back presses on its own because it might just go back
+                // in the browsing history.
+                return;
+            }
         }
 
         super.onBackPressed();

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -165,6 +165,34 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
         };
     }
 
+
+    public boolean onBackPressed() {
+        if (canGoBack()) {
+            goBack();
+        } else {
+            eraseAndShowHomeScreen();
+        }
+
+        return true;
+    }
+
+    private void eraseAndShowHomeScreen() {
+        final IWebView webView = getWebView();
+        if (webView != null) {
+            webView.cleanup();
+        }
+
+        getActivity().getSupportFragmentManager()
+                .beginTransaction()
+                .setCustomAnimations(0, R.anim.erase_animation)
+                .replace(R.id.container, HomeFragment.create(), HomeFragment.FRAGMENT_TAG)
+                .commit();
+
+        ViewUtils.showBrandedSnackbar(getActivity().findViewById(android.R.id.content),
+                R.string.feedback_erase,
+                getResources().getInteger(R.integer.erase_snackbar_delay));
+    }
+
     @Override
     public void onClick(View view) {
         switch (view.getId()) {
@@ -176,30 +204,14 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
             case R.id.url:
                 getActivity().getSupportFragmentManager()
                         .beginTransaction()
-                        .add(R.id.container, UrlInputFragment.create(getWebView().getUrl()))
-                        .addToBackStack("url_entry")
+                        .add(R.id.container, UrlInputFragment.create(getWebView().getUrl()), UrlInputFragment.FRAGMENT_TAG)
                         .commit();
                 break;
 
             case R.id.erase: {
-                final IWebView webView = getWebView();
-                if (webView != null) {
-                    webView.cleanup();
-                }
-
-                getActivity().getSupportFragmentManager()
-                        .beginTransaction()
-                        .setCustomAnimations(0, R.anim.erase_animation)
-                        .replace(R.id.container, HomeFragment.create(), HomeFragment.FRAGMENT_TAG)
-                        .commit();
-
-                ViewUtils.showBrandedSnackbar(getActivity().findViewById(android.R.id.content),
-                        R.string.feedback_erase,
-                        getResources().getInteger(R.integer.erase_snackbar_delay));
-
+                eraseAndShowHomeScreen();
                 break;
             }
-
 
             case R.id.back: {
                 final IWebView webView = getWebView();
@@ -310,7 +322,6 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
         forwardButton.setEnabled(canGoForward);
         forwardButton.setAlpha(canGoForward ? 1.0f : 0.5f);
-
         backButton.setEnabled(canGoBack);
         backButton.setAlpha(canGoBack ? 1.0f : 0.5f);
     }

--- a/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.java
@@ -9,7 +9,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
 import android.support.v7.widget.PopupMenu;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -31,11 +30,15 @@ public class HomeFragment extends Fragment implements View.OnClickListener, Popu
         return new HomeFragment();
     }
 
+    private View fakeUrlBarView;
+
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         final View view = inflater.inflate(R.layout.fragment_home, container, false);
 
-        view.findViewById(R.id.url).setOnClickListener(this);
+        fakeUrlBarView = view.findViewById(R.id.fake_urlbar);
+        fakeUrlBarView.setOnClickListener(this);
+
         view.findViewById(R.id.menu).setOnClickListener(this);
 
         return view;
@@ -44,12 +47,13 @@ public class HomeFragment extends Fragment implements View.OnClickListener, Popu
     @Override
     public void onClick(View view) {
         switch (view.getId()) {
-            case R.id.url:
-                final FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
-                fragmentManager.beginTransaction()
-                        .add(R.id.container, UrlInputFragment.create())
-                        .addToBackStack("url_input")
+            case R.id.fake_urlbar:
+                UrlInputFragment fragment = UrlInputFragment.createWithHomeScreenAnimation(fakeUrlBarView);
+
+                getActivity().getSupportFragmentManager().beginTransaction()
+                        .add(R.id.container, fragment, UrlInputFragment.FRAGMENT_TAG)
                         .commit();
+
                 break;
 
             case R.id.menu:

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
@@ -5,15 +5,20 @@
 
 package org.mozilla.focus.fragment;
 
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.text.SpannableString;
 import android.text.style.StyleSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
+import android.view.animation.DecelerateInterpolator;
 import android.widget.TextView;
 
 import org.mozilla.focus.R;
@@ -26,11 +31,34 @@ import org.mozilla.focus.widget.InlineAutocompleteEditText;
  * Fragment for displaying he URL input controls.
  */
 public class UrlInputFragment extends Fragment implements View.OnClickListener, InlineAutocompleteEditText.OnCommitListener, InlineAutocompleteEditText.OnFilterListener {
-    public static final String ARGUMENT_URL = "url";
+    public static final String FRAGMENT_TAG = "url_input";
 
-    public static UrlInputFragment create() {
-        final UrlInputFragment fragment = new UrlInputFragment();
-        fragment.setArguments(new Bundle());
+    private static final String ARGUMENT_URL = "url";
+    private static final String ARGUMENT_ANIMATION = "animation";
+    private static final String ARGUMENT_X = "x";
+    private static final String ARGUMENT_Y = "y";
+    private static final String ARGUMENT_WIDTH = "width";
+    private static final String ARGUMENT_HEIGHT = "height";
+
+    private static final String ANIMATION_HOME_SCREEN = "home_screen";
+
+    /**
+     * Create a new UrlInputFragment and animate the url input view from the position/size of the
+     * fake url bar view.
+     */
+    public static UrlInputFragment createWithHomeScreenAnimation(View fakeUrlBarView) {
+        int[] screenLocation = new int[2];
+        fakeUrlBarView.getLocationOnScreen(screenLocation);
+
+        Bundle arguments = new Bundle();
+        arguments.putString(ARGUMENT_ANIMATION, ANIMATION_HOME_SCREEN);
+        arguments.putInt(ARGUMENT_X, screenLocation[0]);
+        arguments.putInt(ARGUMENT_Y, screenLocation[1]);
+        arguments.putInt(ARGUMENT_WIDTH, fakeUrlBarView.getWidth());
+        arguments.putInt(ARGUMENT_HEIGHT, fakeUrlBarView.getHeight());
+
+        UrlInputFragment fragment = new UrlInputFragment();
+        fragment.setArguments(arguments);
 
         return fragment;
     }
@@ -51,6 +79,9 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
     private TextView searchView;
 
     private UrlAutoCompleteFilter urlAutoCompleteFilter;
+    private View dismissView;
+    private View urlBackgroundView;
+    private View toolbarBackgroundView;
 
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -59,7 +90,8 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
         final ViewGroup backgroundView = (ViewGroup) view.findViewById(R.id.background);
         backgroundView.setOnClickListener(this);
 
-        view.findViewById(R.id.dismiss).setOnClickListener(this);
+        dismissView = view.findViewById(R.id.dismiss);
+        dismissView.setOnClickListener(this);
 
         clearView = view.findViewById(R.id.clear);
         clearView.setOnClickListener(this);
@@ -82,6 +114,21 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
             }
         });
 
+        urlBackgroundView = view.findViewById(R.id.url_background);
+
+        toolbarBackgroundView = view.findViewById(R.id.toolbar_background);
+
+        urlBackgroundView.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
+            @Override
+            public boolean onPreDraw() {
+                urlBackgroundView.getViewTreeObserver().removeOnPreDrawListener(this);
+
+                animateFirstDraw();
+
+                return true;
+            }
+        });
+
         urlView.setOnCommitListener(this);
 
         if (getArguments().containsKey(ARGUMENT_URL)) {
@@ -90,6 +137,11 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
         }
 
         return view;
+    }
+
+    public boolean onBackPressed() {
+        animateAndDismiss();
+        return true;
     }
 
     @Override
@@ -112,12 +164,102 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
                 break;
 
             case R.id.dismiss:
-                getActivity().getSupportFragmentManager()
-                        .beginTransaction()
-                        .remove(this)
-                        .commit();
+                animateAndDismiss();
                 break;
         }
+    }
+
+    private void animateFirstDraw() {
+        if (ANIMATION_HOME_SCREEN.equals(getArguments().getString(ARGUMENT_ANIMATION))) {
+            playHomeScreenAnimation(false);
+        }
+    }
+
+    private void animateAndDismiss() {
+        if (ANIMATION_HOME_SCREEN.equals(getArguments().getString(ARGUMENT_ANIMATION))) {
+            playHomeScreenAnimation(true);
+        } else {
+            dismiss();
+        }
+    }
+
+    /**
+     * Play animation between home screen and the URL input.
+     */
+    private void playHomeScreenAnimation(final boolean reverse) {
+        int[] screenLocation = new int[2];
+        urlBackgroundView.getLocationOnScreen(screenLocation);
+
+        int leftDelta = getArguments().getInt(ARGUMENT_X) - screenLocation[0];
+        int topDelta = getArguments().getInt(ARGUMENT_Y) - screenLocation[1];
+
+        float widthScale = (float) getArguments().getInt(ARGUMENT_WIDTH) / urlBackgroundView.getWidth();
+        float heightScale = (float) getArguments().getInt(ARGUMENT_HEIGHT) / urlBackgroundView.getHeight();
+
+        if (!reverse) {
+            // Move all views to the position of the fake URL bar on the home screen. Hide them until
+            // the animation starts because we need to switch between fake URL bar and the actual URL
+            // bar once the animation starts.
+            urlBackgroundView.setAlpha(0);
+            urlBackgroundView.setPivotX(0);
+            urlBackgroundView.setPivotY(0);
+            urlBackgroundView.setScaleX(widthScale);
+            urlBackgroundView.setScaleY(heightScale);
+            urlBackgroundView.setTranslationX(leftDelta);
+            urlBackgroundView.setTranslationY(topDelta);
+
+            toolbarBackgroundView.setAlpha(0);
+            toolbarBackgroundView.setTranslationY(-toolbarBackgroundView.getHeight());
+
+            dismissView.setAlpha(0);
+        }
+
+        // Move the URL bar from its position on the home screen to the actual position (and scale it).
+        urlBackgroundView.animate()
+                .setDuration(200)
+                .scaleX(reverse ? widthScale : 1)
+                .scaleY(reverse ? heightScale : 1)
+                .translationX(reverse ? leftDelta : 0)
+                .translationY(reverse ? topDelta : 0)
+                .setInterpolator(new DecelerateInterpolator())
+                .setListener(new AnimatorListenerAdapter() {
+                    @Override
+                    public void onAnimationStart(Animator animation) {
+                        ViewUtils.updateAlphaIfViewExists(getActivity(), R.id.fake_urlbar, 0f);
+
+                        urlBackgroundView.setAlpha(1);
+                    }
+
+                    @Override
+                    public void onAnimationEnd(Animator animation) {
+                        if (reverse) {
+                            urlBackgroundView.setAlpha(0f);
+
+                            ViewUtils.updateAlphaIfViewExists(getActivity(), R.id.fake_urlbar, 1f);
+
+                            dismiss();
+                        }
+                    }
+                });
+
+        // Let the toolbar background come int from the top
+        toolbarBackgroundView.animate()
+                .alpha(reverse ? 0 : 1)
+                .translationY(reverse ? -toolbarBackgroundView.getHeight() : 0)
+                .setDuration(200)
+                .setInterpolator(new DecelerateInterpolator());
+
+        // Use an alpha animation on the transparent black background
+        dismissView.animate()
+                .alpha(reverse ? 0 : 1)
+                .setDuration(200);
+    }
+
+    private void dismiss() {
+        getActivity().getSupportFragmentManager()
+                .beginTransaction()
+                .remove(this)
+                .commit();
     }
 
     @Override
@@ -140,15 +282,12 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
     }
 
     private void openUrl(String url) {
-        // Since we've completed URL entry, we no longer want the URL entry fragment in our backstack
-        // (exiting browser activity should return you to the main activity), so we pop that entry (which
-        // essentially removes the fragment which was add()ed elsewhere)
-        getActivity().getSupportFragmentManager().popBackStack();
+        final FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
 
         // Replace all fragments with a fresh browser fragment. This means we either remove the
         // HomeFragment with an UrlInputFragment on top or an old BrowserFragment with an
         // UrlInputFragment.
-        final BrowserFragment browserFragment = (BrowserFragment) getActivity().getSupportFragmentManager()
+        final BrowserFragment browserFragment = (BrowserFragment) fragmentManager
                 .findFragmentByTag(BrowserFragment.FRAGMENT_TAG);
 
         if (browserFragment != null && browserFragment.isVisible()) {
@@ -156,11 +295,15 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
             // The fragment might exist if we "erased" a browsing session, hence we need to check
             // for visibility in addition to existence.
             browserFragment.loadURL(url);
+
+            // And this fragment can be removed again.
+            fragmentManager.beginTransaction()
+                    .remove(this)
+                    .commit();
         } else {
-            getActivity().getSupportFragmentManager()
+            fragmentManager
                     .beginTransaction()
                     .replace(R.id.container, BrowserFragment.create(url), BrowserFragment.FRAGMENT_TAG)
-                    .addToBackStack("browser")
                     .commit();
         }
     }

--- a/app/src/main/java/org/mozilla/focus/utils/ViewUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/ViewUtils.java
@@ -5,7 +5,10 @@
 
 package org.mozilla.focus.utils;
 
+import android.app.Activity;
 import android.content.Context;
+import android.support.annotation.IdRes;
+import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
@@ -55,5 +58,22 @@ public class ViewUtils {
 
     public static boolean isRTL(View view) {
         return ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL;
+    }
+
+    /**
+     * Update the alpha value of the view with the given id. All kinds of failures (null activity,
+     * view not found, ..) will be ignored by this method.
+     */
+    public static void updateAlphaIfViewExists(@Nullable Activity activity, @IdRes int id, float alpha) {
+        if (activity == null) {
+            return;
+        }
+
+        final View view = activity.findViewById(id);
+        if (view == null) {
+            return;
+        }
+
+        view.setAlpha(alpha);
     }
 }

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -3,13 +3,11 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/activity_main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/background_home">
 
     <FrameLayout
-        android:id="@+id/urlbar"
         android:layout_width="match_parent"
         android:layout_height="81dp"
         android:paddingTop="25dp">
@@ -31,20 +29,21 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
+        android:layout_height="match_parent"
+        android:clipChildren="false"
+        android:gravity="center"
         android:orientation="vertical">
 
         <ImageView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/wordmark"
-            android:paddingBottom="30dp"
             android:layout_gravity="center_horizontal"
-            android:contentDescription="@string/app_name" />
+            android:contentDescription="@string/app_name"
+            android:paddingBottom="30dp"
+            android:src="@drawable/wordmark" />
 
         <TextView
-            android:id="@+id/url"
+            android:id="@+id/fake_urlbar"
             android:layout_width="match_parent"
             android:layout_height="40dp"
             android:layout_marginLeft="18dp"
@@ -53,19 +52,19 @@
             android:gravity="center"
             android:padding="8dp"
             android:text="@string/urlbar_hint"
-            android:textSize="15sp"
             android:textColor="#40ffffff"
+            android:textSize="15sp"
             android:transitionName="urlbar" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:paddingTop="30dp"
-            android:textSize="14sp"
             android:lineSpacingExtra="7sp"
+            android:paddingTop="30dp"
             android:text="@string/teaser"
-            android:textColor="#eeeeee" />
+            android:textColor="#eeeeee"
+            android:textSize="14sp" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_urlinput.xml
+++ b/app/src/main/res/layout/fragment_urlinput.xml
@@ -3,27 +3,36 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/background"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@color/colorUrlInputBackground">
+    android:clipChildren="false"
+    android:clipToPadding="false">
 
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="81dp"
-        android:paddingTop="25dp"
-        android:background="@drawable/background_inactive"
         android:orientation="horizontal"
-        android:elevation="4dp">
+        android:elevation="4dp"
+        android:clipChildren="false"
+        android:clipToPadding="false">
 
-        <LinearLayout
+        <View
+            android:id="@+id/toolbar_background"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:background="@drawable/background_inactive" />
+
+        <LinearLayout
+            android:id="@+id/url_background"
+            android:layout_width="match_parent"
+            android:layout_height="40dp"
+            android:layout_gravity="bottom"
             android:orientation="horizontal"
             android:layout_margin="8dp"
-            android:background="@drawable/urlbar_background">
+            android:background="@drawable/urlbar_background"
+            android:transitionName="urlbar">
 
             <org.mozilla.focus.widget.InlineAutocompleteEditText
                 android:id="@+id/url_edit"
@@ -45,8 +54,7 @@
                 android:textColor="#ffffff"
                 android:textColorHighlight="@color/colorAutocompleteHighlight"
                 android:textColorHint="#40ffffff"
-                android:textSize="15sp"
-                android:transitionName="urlbar"/>
+                android:textSize="15sp" />
 
             <ImageButton
                 android:id="@+id/clear"
@@ -68,11 +76,19 @@
 
     </FrameLayout>
 
+    <View
+        android:id="@+id/dismiss"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/colorUrlInputBackground"
+        android:contentDescription="@string/content_description_dismiss_input" />
+
     <FrameLayout
         android:id="@+id/search_hint_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="gone">
+        android:visibility="gone"
+        android:layout_marginTop="81dp">
 
         <TextView
             android:id="@+id/search_hint"
@@ -83,6 +99,7 @@
             android:gravity="center_vertical"
             android:padding="16dp"
             android:lines="1"
+            android:text="Hello World!"
             android:ellipsize="end"
             android:textSize="14sp"
             android:textColor="@color/searchHintTextColor"
@@ -96,11 +113,4 @@
 
     </FrameLayout>
 
-    <View
-        android:id="@+id/dismiss"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:contentDescription="@string/content_description_dismiss_input" />
-
-</LinearLayout>
+</FrameLayout>


### PR DESCRIPTION
In addition to adding the animation:
* We now do not use AddToBackStack() anymore. It had weird side effects of fragments
  suddenly existing multiple times. Instead some fragments now have onBackPressed()
  callbacks to handle pressing back themselves if they wish to. This fixes #371.
* We now treat pressing back in the BrowserFragment as if the user pressed the erase
  button (only if there's no browser history to go back to anymore). With that the
  behavior is more consistent and we always remove the browser history when you go
  back to the home screen. This fixes #373.