### PR TITLE
Also update URL during onProgressChanged() (#377)

### DIFF
--- a/app/src/webkit/java/org/mozilla/focus/web/WebViewProvider.java
+++ b/app/src/webkit/java/org/mozilla/focus/web/WebViewProvider.java
@@ -238,6 +238,11 @@ public class WebViewProvider {
                 @Override
                 public void onProgressChanged(WebView view, int newProgress) {
                     if (callback != null) {
+                        // This is the earliest point where we might be able to confirm a redirected
+                        // URL: we don't necessarily get a shouldInterceptRequest() after a redirect,
+                        // so we can only check the updated url in onProgressChanges(), or in onPageFinished()
+                        // (which is even later).
+                        callback.onURLChanged(view.getUrl());
                         callback.onProgress(newProgress);
                     }
                 }


### PR DESCRIPTION
We now update the URL:
- If we've been notified of the page URL in onPageStarted() AND a request is made (onShouldInterceptRequest()) - but the latter isn't called for redirects.
- During onProgressChanged() - the webview will start reflecting a redirected URL by about 70% load progress.
- During onPageFinished() - the webview will reflect the actual URL.

There's also onPageCommitVisible() on API 23+, but that happens well after onProgressChanged() - and sometimes gets called after onPageFinished().