### PR TITLE
Fixed #338 and #398

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -331,13 +331,13 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
                 final Browsers browsers = new Browsers(getContext(), webView.getUrl());
 
-                if (browsers.isInstalled(Browsers.KnownBrowser.FIREFOX)) {
+                if (browsers.hasFirefoxBrandedBrowserInstalled()) {
                     final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(webView.getUrl()));
-                    intent.setPackage(Browsers.KnownBrowser.FIREFOX.packageName);
+                    intent.setPackage(browsers.getFirefoxBrandedBrowser().packageName);
                     startActivity(intent);
                 } else {
                     final Intent intent = new Intent(Intent.ACTION_VIEW,
-                            Uri.parse("market://details?id=" + Browsers.KnownBrowser.FIREFOX));
+                            Uri.parse("market://details?id=" + Browsers.KnownBrowser.FIREFOX.packageName));
                     startActivity(intent);
                 }
 

--- a/app/src/main/java/org/mozilla/focus/menu/BrowserMenuAdapter.java
+++ b/app/src/main/java/org/mozilla/focus/menu/BrowserMenuAdapter.java
@@ -52,8 +52,14 @@ public class BrowserMenuAdapter extends RecyclerView.Adapter<BrowserMenuViewHold
 
         items.add(new MenuItem(R.id.share, resources.getString(R.string.menu_share)));
 
-        items.add(new MenuItem(R.id.open_firefox, resources.getString(
-                R.string.menu_open_with_default_browser, "Firefox")));
+        if (browsers.hasFirefoxBrandedBrowserInstalled()) {
+            items.add(new MenuItem(R.id.open_firefox, resources.getString(
+                    R.string.menu_open_with_default_browser, browsers.getFirefoxBrandedBrowser()
+                            .loadLabel(context.getPackageManager()))));
+        } else {
+            items.add(new MenuItem(R.id.open_firefox, resources.getString(
+                    R.string.menu_open_with_default_browser, "Firefox")));
+        }
 
         if (browsers.hasThirdPartyDefaultBrowser(context)) {
             items.add(new MenuItem(R.id.open_default, resources.getString(

--- a/app/src/main/java/org/mozilla/focus/utils/Browsers.java
+++ b/app/src/main/java/org/mozilla/focus/utils/Browsers.java
@@ -61,6 +61,10 @@ public class Browsers {
 
     private final Map<String, ActivityInfo> browsers;
     private ActivityInfo defaultBrowser;
+    // This will contain installed firefox branded browser ordered by priority from Firefox,
+    // Firefox_Beta, Firefox Aurora and Firefox_Nightly. If multiple firefox branded browser is
+    // installed then higher priority one will be stored here
+    private ActivityInfo firefoxBrandedBrowser;
 
     public Browsers(Context context, String url) {
         final PackageManager packageManager = context.getPackageManager();
@@ -75,6 +79,20 @@ public class Browsers {
 
         this.browsers = browsers;
         this.defaultBrowser = findDefault(packageManager, url);
+        this.firefoxBrandedBrowser = findFirefoxBrandedBrowser();
+    }
+
+    private ActivityInfo findFirefoxBrandedBrowser() {
+        if (browsers.containsKey(KnownBrowser.FIREFOX.packageName)) {
+            return browsers.get(KnownBrowser.FIREFOX.packageName);
+        } else if (browsers.containsKey(KnownBrowser.FIREFOX_BETA.packageName)) {
+            return browsers.get(KnownBrowser.FIREFOX_BETA.packageName);
+        } else if (browsers.containsKey(KnownBrowser.FIREFOX_AURORA.packageName)) {
+            return browsers.get(KnownBrowser.FIREFOX_AURORA.packageName);
+        } else if (browsers.containsKey(KnownBrowser.FIREFOX_NIGHTLY.packageName)) {
+            return browsers.get(KnownBrowser.FIREFOX_NIGHTLY.packageName);
+        }
+        return null;
     }
 
     private Map<String, ActivityInfo> resolveBrowsers(PackageManager packageManager, String url) {
@@ -180,5 +198,13 @@ public class Browsers {
         final Collection<ActivityInfo> collection = browsers.values();
 
         return collection.toArray(new ActivityInfo[collection.size()]);
+    }
+
+    public boolean hasFirefoxBrandedBrowserInstalled() {
+        return firefoxBrandedBrowser != null;
+    }
+
+    public ActivityInfo getFirefoxBrandedBrowser() {
+        return firefoxBrandedBrowser;
     }
 }


### PR DESCRIPTION
Fixed #338-Firefox Focus should be able to detect installed Firefox Beta
Now focus will able to detect the following version of firefox and show
in menu if installed.
1. Firefox
2. Firefox-Beta
3. Firefox-Aurora
4. Firefox-nightly

Fixed #398
open firefox install page in playstore if firefox is not
installed.