### PR TITLE
Ensure SearchEngine data is loaded before loading prefs (#405)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/FocusApplication.java
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.java
@@ -17,9 +17,12 @@ public class FocusApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
-        PreferenceManager.setDefaultValues(this, R.xml.settings, false);
-
+        // Loading preferences depends on the Search Engine manager, because the default search
+        // engine pref uses the search engine manager - we therefore need to ensure
+        // that prefs aren't loaded until search engines are loaded.
         SearchEngineManager.getInstance().init(this);
+
+        PreferenceManager.setDefaultValues(this, R.xml.settings, false);
 
         TelemetryWrapper.init(this);
         AdjustHelper.setupAdjustIfNeeded(this);


### PR DESCRIPTION
Otherwise a fresh install will hang at startup.