### PR TITLE
Remove unused character from Trie

### DIFF
--- a/app/src/webkit/java/org/mozilla/focus/webkit/matcher/Trie.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/matcher/Trie.java
@@ -42,7 +42,6 @@ import org.mozilla.focus.webkit.matcher.util.FocusString;
         }
     }
 
-    public final char character;
     public final SparseArray<Trie> children = new SparseArray<>();
     public boolean terminator = false;
 
@@ -96,8 +95,6 @@ import org.mozilla.focus.webkit.matcher.util.FocusString;
     }
 
     private Trie(char character, Trie parent) {
-        this.character = character;
-
         if (parent != null) {
             parent.children.put(character, this);
         }


### PR DESCRIPTION
The node's character is already implied by the path from the previous
node, this copy is unused so we can remove it.