### PR TITLE
[BLOCKED] SearchEngineManager: make variables volatile

### DIFF
--- a/app/src/main/java/org/mozilla/focus/search/SearchEngineManager.java
+++ b/app/src/main/java/org/mozilla/focus/search/SearchEngineManager.java
@@ -32,13 +32,13 @@ public class SearchEngineManager extends BroadcastReceiver {
 
     private static SearchEngineManager instance = new SearchEngineManager();
 
-    private List<SearchEngine> searchEngines;
+    private volatile List<SearchEngine> searchEngines;
 
     /**
      * A flag indicating that data has been loaded, or is loading. This lets us detect if data
      * has been requested without a preceeding init().
      */
-    private boolean loadHasBeenTriggered = false;
+    private volatile boolean loadHasBeenTriggered = false;
 
     public static SearchEngineManager getInstance() {
         return instance;


### PR DESCRIPTION
Both of these are accessed across threads (i.e they will be written
to from a background thread during loadFromDisk(), and we're reading
them from a different thread in awaitLoadingSearchEnginesLocked()).
In order to avoid a race condition we should make these volatile.

(Inspired by findbugs complaining about lack of synchronisation for these values)