### PR TITLE
Add support for file downloads and request storage permission if needed. (#14)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
           package="org.mozilla.focus">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="false"

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -34,6 +34,7 @@ import org.mozilla.focus.menu.BrowserMenu;
 import org.mozilla.focus.notification.BrowsingNotificationService;
 import org.mozilla.focus.open.OpenWithFragment;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
+import org.mozilla.focus.utils.AppConstants;
 import org.mozilla.focus.utils.Browsers;
 import org.mozilla.focus.utils.IntentUtils;
 import org.mozilla.focus.utils.UrlUtils;
@@ -241,6 +242,10 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
             @Override
             public void onDownloadStart(Download download) {
+                if (!AppConstants.supportsDownloadingFiles()) {
+                    return;
+                }
+
                 if (PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(getContext(), Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
                     // We do have the permission to write to the external storage. Proceed with the download.
                     queueDownload(download);

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -5,22 +5,28 @@
 
 package org.mozilla.focus.fragment;
 
+import android.Manifest;
 import android.app.Activity;
+import android.app.DownloadManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
 import android.graphics.drawable.TransitionDrawable;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Environment;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
-import android.util.AttributeSet;
+import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.CookieManager;
+import android.webkit.URLUtil;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.activity.SettingsActivity;
@@ -32,8 +38,8 @@ import org.mozilla.focus.utils.Browsers;
 import org.mozilla.focus.utils.IntentUtils;
 import org.mozilla.focus.utils.UrlUtils;
 import org.mozilla.focus.utils.ViewUtils;
+import org.mozilla.focus.web.Download;
 import org.mozilla.focus.web.IWebView;
-import org.mozilla.focus.web.WebViewProvider;
 
 import java.lang.ref.WeakReference;
 
@@ -43,9 +49,10 @@ import java.lang.ref.WeakReference;
 public class BrowserFragment extends WebFragment implements View.OnClickListener {
     public static final String FRAGMENT_TAG = "browser";
 
+    private static int REQUEST_CODE_STORAGE_PERMISSION = 101;
     private static final int ANIMATION_DURATION = 300;
-
     private static final String ARGUMENT_URL = "url";
+    private static final String RESTORE_KEY_DOWNLOAD = "download";
 
     public static BrowserFragment create(String url) {
         Bundle arguments = new Bundle();
@@ -57,6 +64,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
         return fragment;
     }
 
+    private Download pendingDownload;
     private TransitionDrawable backgroundTransition;
     private TextView urlView;
     private ProgressBar progressView;
@@ -92,6 +100,12 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
     @Override
     public View inflateLayout(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        if (savedInstanceState != null && savedInstanceState.containsKey(RESTORE_KEY_DOWNLOAD)) {
+            // If this activity was destroyed before we could start a download (e.g. because we were waiting for a permission)
+            // then restore the download object.
+            pendingDownload = savedInstanceState.getParcelable(RESTORE_KEY_DOWNLOAD);
+        }
+
         final View view = inflater.inflate(R.layout.fragment_browser, container, false);
 
         urlView = (TextView) view.findViewById(R.id.display_url);
@@ -126,6 +140,17 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
         menuView.setOnClickListener(this);
 
         return view;
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        if (pendingDownload != null) {
+            // We were not able to start this download yet (waiting for a permission). Save this download
+            // so that we can start it once we get restored and receive the permission.
+            outState.putParcelable(RESTORE_KEY_DOWNLOAD, pendingDownload);
+        }
     }
 
     public interface LoadStateListener {
@@ -213,7 +238,70 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
                 shareIntent.putExtra(Intent.EXTRA_TEXT, url);
                 startActivity(shareIntent);
             }
+
+            @Override
+            public void onDownloadStart(Download download) {
+                if (PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(getContext(), Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                    // We do have the permission to write to the external storage. Proceed with the download.
+                    queueDownload(download);
+                } else {
+                    // We do not have the permission to write to the external storage. Request the permission and start the
+                    // download from onRequestPermissionsResult().
+                    final Activity activity = getActivity();
+                    if (activity == null) {
+                        return;
+                    }
+
+                    pendingDownload = download;
+
+                    requestPermissions(new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE }, REQUEST_CODE_STORAGE_PERMISSION);
+                }
+            }
         };
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        if (requestCode != REQUEST_CODE_STORAGE_PERMISSION) {
+            return;
+        }
+
+        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            queueDownload(pendingDownload);
+        }
+
+        pendingDownload = null;
+    }
+
+    /**
+     * Use Android's Download Manager to queue this download.
+     */
+    private void queueDownload(Download download) {
+        if (download == null) {
+            return;
+        }
+
+        final Context context = getContext();
+        if (context == null) {
+            return;
+        }
+
+        final String cookie = CookieManager.getInstance().getCookie(download.getUrl());
+        final String fileName = URLUtil.guessFileName(
+                download.getUrl(), download.getContentDisposition(), download.getMimeType());
+
+        final DownloadManager.Request request = new DownloadManager.Request(Uri.parse(download.getUrl()))
+                .addRequestHeader("User-Agent", download.getUserAgent())
+                .addRequestHeader("Cookie", cookie)
+                .addRequestHeader("Referer", getUrl())
+                .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
+                .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+                .setMimeType(download.getMimeType());
+
+        request.allowScanningByMediaScanner();
+
+        final DownloadManager manager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
+        manager.enqueue(request);
     }
 
     private boolean isStartedFromExternalApp() {

--- a/app/src/main/java/org/mozilla/focus/fragment/InfoFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/InfoFragment.java
@@ -13,6 +13,7 @@ import android.view.ViewGroup;
 import android.widget.ProgressBar;
 
 import org.mozilla.focus.R;
+import org.mozilla.focus.web.Download;
 import org.mozilla.focus.web.IWebView;
 
 public class InfoFragment extends WebFragment {
@@ -84,7 +85,11 @@ public class InfoFragment extends WebFragment {
 
             @Override
             public void onLinkLongPress(final String url) {
-            };
+            }
+
+            @Override
+            public void onDownloadStart(Download download) {
+            }
 
             @Override
             public void onURLChanged(String url) {

--- a/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
+++ b/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
@@ -26,4 +26,9 @@ public final class AppConstants {
     public static boolean isReleaseBuild() {
         return BUILD_TYPE_RELEASE.equals(BuildConfig.BUILD_TYPE);
     }
+
+    public static boolean supportsDownloadingFiles() {
+        // This feature is not on the roadmap for v1 - but let's keep it enabled in dev builds. (#14)
+        return isDevBuild();
+    }
 }

--- a/app/src/main/java/org/mozilla/focus/web/Download.java
+++ b/app/src/main/java/org/mozilla/focus/web/Download.java
@@ -1,0 +1,77 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.web;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class Download implements Parcelable {
+    public static final Parcelable.Creator<Download> CREATOR = new Parcelable.Creator<Download>() {
+
+        @Override
+        public Download createFromParcel(Parcel source) {
+            return new Download(
+                    source.readString(),
+                    source.readString(),
+                    source.readString(),
+                    source.readString(),
+                    source.readLong());
+        }
+
+        @Override
+        public Download[] newArray(int size) {
+            return new Download[size];
+        }
+    };
+
+    private final String url;
+    private final String contentDisposition;
+    private final String mimeType;
+    private final long contentLength;
+    private final String userAgent;
+
+    public Download(String url, String userAgent, String contentDisposition, String mimetype, long contentLength) {
+        this.url = url;
+        this.userAgent = userAgent;
+        this.contentDisposition = contentDisposition;
+        this.mimeType = mimetype;
+        this.contentLength = contentLength;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getContentDisposition() {
+        return contentDisposition;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public long getContentLength() {
+        return contentLength;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(url);
+        dest.writeString(userAgent);
+        dest.writeString(contentDisposition);
+        dest.writeString(mimeType);
+        dest.writeLong(contentLength);
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/web/IWebView.java
+++ b/app/src/main/java/org/mozilla/focus/web/IWebView.java
@@ -19,6 +19,8 @@ public interface IWebView {
         /** Return true if the URL was handled, false if we should continue loading the current URL. */
         boolean handleExternalUrl(String url);
         void onLinkLongPress(String url);
+
+        void onDownloadStart(Download download);
     }
 
     void setCallback(Callback callback);

--- a/app/src/webkit/java/org/mozilla/focus/web/WebViewProvider.java
+++ b/app/src/webkit/java/org/mozilla/focus/web/WebViewProvider.java
@@ -17,6 +17,7 @@ import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
 import android.webkit.CookieManager;
+import android.webkit.DownloadListener;
 import android.webkit.WebBackForwardList;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
@@ -26,7 +27,6 @@ import android.webkit.WebViewDatabase;
 
 import org.mozilla.focus.BuildConfig;
 import org.mozilla.focus.R;
-
 import org.mozilla.focus.utils.FileUtils;
 import org.mozilla.focus.utils.Settings;
 import org.mozilla.focus.utils.ThreadUtils;
@@ -200,6 +200,7 @@ public class WebViewProvider {
 
             setWebViewClient(client);
             setWebChromeClient(createWebChromeClient());
+            setDownloadListener(createDownloadListener());
 
             if (BuildConfig.DEBUG) {
                 setWebContentsDebuggingEnabled(true);
@@ -356,6 +357,18 @@ public class WebViewProvider {
                         // (which is even later).
                         callback.onURLChanged(view.getUrl());
                         callback.onProgress(newProgress);
+                    }
+                }
+            };
+        }
+
+        private DownloadListener createDownloadListener() {
+            return new DownloadListener() {
+                @Override
+                public void onDownloadStart(String url, String userAgent, String contentDisposition, String mimetype, long contentLength) {
+                    if (callback != null) {
+                        final Download download = new Download(url, userAgent, contentDisposition, mimetype, contentLength);
+                        callback.onDownloadStart(download);
                     }
                 }
             };


### PR DESCRIPTION
This patch adds support for downloads. No UI yet - just requesting the permission (if needed) and queuing the download in Android's Download Manager.