### PR TITLE
Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,60 +30,10 @@ Build instructions
 
 1. Make sure to select the right build variant in Android Studio: **focusWebkitDebug**
 
-Updating translations
----------------------
+Docs
+----
 
-Firefox Focus for Android is getting localized on [Pontoon](https://pontoon.mozilla.org/projects/focus-for-android/).
-
-For converting between Android XML files and Gettext PO files (to be consumed by Pontoon) we use a local, slightly modified version of [android2po](https://github.com/miracle2k/android2po) (See `tools/l10n/android2po`).
-
-### Setup
-
-1. Python, Pip and Git need to be installed.
-
-1. Run the `stringsSetup` gradle tasks to create a local checkout of the L10N repository (in folder `l10n-repo`) and to install the python dependencies to run the l10n scripts:
-
-  ```shell
-  ./gradlew stringsSetup
-  ```
-
-
-### Export strings for translation
-
-1. Fetch the latest changes from the L10N repository and remove all local modifications with the `stringsCleanUpdate` gradle task:
-
-  ```shell
-  ./gradlew stringsCleanUpdate
-  ```
-
-1. Run the `stringsExport` gradle task to update the template and existing translations:
-
-  ```shell
-  ./gradlew stringsExport
-  ```
-  
-1. Create separate commits for every locale using the `stringsCommit` gradle task:
-
-  ```shell
-  ./gradlew stringsCommit
-  ```
-
-1. Go to the l10n-repo folder, verify the changes and push them to the L10N repository.
-
-### Import translated strings
-
-1. Fetch the latest changes from the L10N repository and remove all local modifications with the `stringsCleanUpdate` gradle task:
-
-  ```shell
-  ./gradlew stringsCleanUpdate
-  ```
-  
-1. Run the `stringsImport` gradle task to generate the Android XML files.
-
-  ```shell
-  ./gradlew stringsImport
-  ```
-
-1. Verify the changes and then commit and push the updated XML files to the app repository.
-  
-
+* [Content blocking](docs/contentblocking.md)
+* [Translations](docs/translations.md)
+* [Search](docs/search.md)
+* [Telemetry](docs/telemetry.md)

--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ Docs
 * [Translations](docs/translations.md)
 * [Search](docs/search.md)
 * [Telemetry](docs/telemetry.md)
+
+License
+-------
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/docs/contentblocking.md
+++ b/docs/contentblocking.md
@@ -1,0 +1,5 @@
+# Firefox Focus for Android
+
+## Content blocking
+
+    TODO

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,5 @@
+# Firefox Focus for Android
+
+## Search
+
+    TODO

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -2,4 +2,58 @@
 
 ## Telemetry
 
-    TODO
+For clients that have "send anonymous usage data" enabled Focus sends a "core" ping and an "event" ping to Mozilla's telemetry service. Sending telemetry can be disabled in the app's settings. Builds of "Focus for Android" have telemetry enabled by default ("opt-out") while builds of "Klar for Android" have telemetry disabled by default.
+
+### Core ping
+
+Focus for Android creates and tries to send a "core" ping whenever the app goes to the background. This core ping uses the same format as Firefox for Android and is [documented on readthedocs.io](https://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/core-ping.html).
+
+### Event ping
+
+In addition to the core ping an event ping for UI telemetry is generated and sent as soon as the app is sent to the background.
+
+#### Settings
+
+As part of the event ping the most recent state of the user's setting is sent:
+
+* Search engine selection (`pref_search_engine`: search engine identifier)
+* Block ad trackers (`pref_privacy_block_ads`: true/false)
+* Block analytics trackers (`pref_privacy_block_other`: true/false)
+* Block social trackers (`pref_privacy_block_social`: true/false)
+* Block content trackers (`pref_privacy_block_analytics`: true/false)
+* Block web fonts (`pref_performance_block_webfonts`: true/false)
+* Block images (`pref_performance_block_images`: true/false)
+
+#### Events
+
+The event ping contains a list of events ([see event format on readthedocs.io](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/collection/events.html)) for the following actions:
+
+* Start session - ("action", "foreground", "app")
+* Stop session - ("action", "background", "app")
+* (Browsing) URL entered: - ("action", "type_url", "search_bar")
+* (Browsing) Incoming intent from third-party app - ("action", "intent_url", "app")
+* (Search) Query entered: - ("action", "type_query", "search_bar")
+* (Search) Query/Hint clicked: - ("action", "select_query", "search_bar")
+* (Erase) UI button clicked - ("action", "click", "erase_button")
+* (Erase) device’s back button pressed - ("action", "click", "back_button", "erase")
+* Setting changed: - ("action", "change", "settings", <key>, { "to": <value> })
+* Share URL with third-party app - ("action", "share", "menu")
+* Open default app for URL - ("action", "open", "menu", "default")
+* Open Firefox directly - ("action", "open", "menu", "firefox")
+* Open an app for this URL from a list of available apps - ("action", "open", "menu", "selection")
+
+#### Limits
+
+* An event ping will contain up to but no more than 500 events
+* No more than 40 pings per type (core/event) are stored on disk for upload at a later time
+* No more than 100 pings are sent per day
+
+### Implementation notes
+
+* Event pings are generated (and stored on disk) whenever the onStop() callback of the main activity is triggered. This happens whenever the main screen of the app is no longer visible (The app is in the background or another screen is displayed on top of the app).
+
+* Whenever we are storing pings we are also scheduling an upload. We are using Android’s JobScheduler API for that. This allows the system to run the background task whenever it is convenient and certain criterias are met. The only criteria we are specifying is that we require an active network connection. In most cases this job is executed immediately after the app is in the background.
+
+* Whenever an upload fails we are scheduling a retry. The first retry will happen after 30 seconds (or later if there’s no active network connection at this time). For further retries a exponential backoff policy is used: [30 seconds] * 2 ^ (num_failures - 1)
+
+* An earlier retry of the upload can happen whenever the app is coming to the foreground and sent to the background again (the previous scheduled job is reset and we are starting all over again).

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,5 @@
+# Firefox Focus for Android
+
+## Telemetry
+
+    TODO

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,55 @@
+# Firefox Focus for Android
+
+## Updating translations
+
+Firefox Focus for Android is getting localized on [Pontoon](https://pontoon.mozilla.org/projects/focus-for-android/).
+
+For converting between Android XML files and Gettext PO files (to be consumed by Pontoon) we use a local, slightly modified version of [android2po](https://github.com/miracle2k/android2po) (See `tools/l10n/android2po`).
+
+### Setup
+
+1. Python, Pip and Git need to be installed.
+
+1. Run the `stringsSetup` gradle tasks to create a local checkout of the L10N repository (in folder `l10n-repo`) and to install the python dependencies to run the l10n scripts:
+
+  ```shell
+  ./gradlew stringsSetup
+  ```
+
+### Export strings for translation
+
+1. Fetch the latest changes from the L10N repository and remove all local modifications with the `stringsCleanUpdate` gradle task:
+
+  ```shell
+  ./gradlew stringsCleanUpdate
+  ```
+
+1. Run the `stringsExport` gradle task to update the template and existing translations:
+
+  ```shell
+  ./gradlew stringsExport
+  ```
+  
+1. Create separate commits for every locale using the `stringsCommit` gradle task:
+
+  ```shell
+  ./gradlew stringsCommit
+  ```
+
+1. Go to the l10n-repo folder, verify the changes and push them to the L10N repository.
+
+### Import translated strings
+
+1. Fetch the latest changes from the L10N repository and remove all local modifications with the `stringsCleanUpdate` gradle task:
+
+  ```shell
+  ./gradlew stringsCleanUpdate
+  ```
+  
+1. Run the `stringsImport` gradle task to generate the Android XML files.
+
+  ```shell
+  ./gradlew stringsImport
+  ```
+
+1. Verify the changes and then commit and push the updated XML files to the app repository.


### PR DESCRIPTION
Creating a docs folder and moving some part of the README into separate files. Added a telemetry doc and created some empty docs for things that we might want to document (how to update search plugins, how content blocking works or the lists are updated [we already have that in the blocklist folder])