### PR TITLE
Disable wideWiewPort (#461)

### DIFF
--- a/app/src/webkit/java/org/mozilla/focus/web/WebViewProvider.java
+++ b/app/src/webkit/java/org/mozilla/focus/web/WebViewProvider.java
@@ -86,7 +86,6 @@ public class WebViewProvider {
 
         // To respect the html viewport:
         settings.setLoadWithOverviewMode(true);
-        settings.setUseWideViewPort(true);
 
         // Also increase text size to fill the viewport (this mirrors the behaviour of Firefox,
         // Chrome does this in the current Chrome Dev, but not Chrome release).


### PR DESCRIPTION
This breaks error pages, and could potentially cause weird effects
on other pages. Chrome uses setLoadWithOverViewMode by default,
but doesn't use wideViewPort - we should probably do the same.
It also seems to disable zooming for such pages.