### PR TITLE
Fix amp (and other first-party resources)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
@@ -75,15 +75,15 @@ public class UrlUtils {
     }
 
     public static boolean isPermittedResourceProtocol(final String url) {
-        return url.startsWith("http:") ||
-                url.startsWith("https:") ||
-                url.startsWith("file:") ||
-                url.startsWith("data:");
+        return url.startsWith("http") ||
+                url.startsWith("https") ||
+                url.startsWith("file") ||
+                url.startsWith("data");
     }
 
     public static boolean isSupportedProtocol(final String url) {
         return isPermittedResourceProtocol(url) ||
-                url.startsWith("error:");
+                url.startsWith("error");
     }
 
     public static boolean urlsMatchExceptForTrailingSlash(final @NonNull String url1, final @NonNull String url2) {

--- a/app/src/test/java/org/mozilla/focus/utils/UrlUtilsTest.java
+++ b/app/src/test/java/org/mozilla/focus/utils/UrlUtilsTest.java
@@ -30,25 +30,22 @@ public class UrlUtilsTest {
 
     @Test
     public void isPermittedResourceProtocol() {
-        Assert.assertTrue(UrlUtils.isPermittedResourceProtocol("http:"));
-        Assert.assertTrue(UrlUtils.isPermittedResourceProtocol("https:"));
+        Assert.assertTrue(UrlUtils.isPermittedResourceProtocol("http"));
+        Assert.assertTrue(UrlUtils.isPermittedResourceProtocol("https"));
 
-        Assert.assertTrue(UrlUtils.isPermittedResourceProtocol("http://foobar.com"));
-        Assert.assertTrue(UrlUtils.isPermittedResourceProtocol("https://foobar.com"));
+        Assert.assertTrue(UrlUtils.isPermittedResourceProtocol("data"));
+        Assert.assertTrue(UrlUtils.isPermittedResourceProtocol("file"));
 
-        Assert.assertTrue(UrlUtils.isPermittedResourceProtocol("data:???????????????"));
-        Assert.assertTrue(UrlUtils.isPermittedResourceProtocol("file:///android_asset/something/index.html"));
-
-        Assert.assertFalse(UrlUtils.isPermittedResourceProtocol("nielsenwebid://nuid/999"));
+        Assert.assertFalse(UrlUtils.isPermittedResourceProtocol("nielsenwebid"));
     }
 
     @Test
     public void isPermittedProtocol() {
-        Assert.assertTrue(UrlUtils.isSupportedProtocol("http:"));
-        Assert.assertTrue(UrlUtils.isSupportedProtocol("http://mozilla.org"));
-        Assert.assertTrue(UrlUtils.isSupportedProtocol("error:-1"));
-        Assert.assertTrue(UrlUtils.isSupportedProtocol("data:?????"));
+        Assert.assertTrue(UrlUtils.isSupportedProtocol("http"));
+        Assert.assertTrue(UrlUtils.isSupportedProtocol("https"));
+        Assert.assertTrue(UrlUtils.isSupportedProtocol("error"));
+        Assert.assertTrue(UrlUtils.isSupportedProtocol("data"));
 
-        Assert.assertFalse(UrlUtils.isSupportedProtocol("market:details?id=org.mozilla.firefox"));
+        Assert.assertFalse(UrlUtils.isSupportedProtocol("market"));
     }
 }

--- a/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/DisconnectTest.java
+++ b/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/DisconnectTest.java
@@ -52,19 +52,19 @@ public class DisconnectTest {
 
         // We check that our google_mapping was loaded correctly. We do these checks per-category, so we have:
         // ads:
-        assertTrue(matcher.matches(Uri.parse("http://admeld.com/foobar"), "http://mozilla.org"));
+        assertTrue(matcher.matches(Uri.parse("http://admeld.com/foobar"), Uri.parse("http://mozilla.org")));
         // And we check that the entitylist unblocks this on google properties:
-        assertFalse(matcher.matches(Uri.parse("http://admeld.com/foobar"), "http://google.com"));
+        assertFalse(matcher.matches(Uri.parse("http://admeld.com/foobar"), Uri.parse("http://google.com")));
         // analytics:
-        assertTrue(matcher.matches(Uri.parse("http://google-analytics.com/foobar"), "http://mozilla.org"));
-        assertFalse(matcher.matches(Uri.parse("http://google-analytics.com/foobar"), "http://google.com"));
+        assertTrue(matcher.matches(Uri.parse("http://google-analytics.com/foobar"), Uri.parse("http://mozilla.org")));
+        assertFalse(matcher.matches(Uri.parse("http://google-analytics.com/foobar"), Uri.parse("http://google.com")));
         // social:
-        assertTrue(matcher.matches(Uri.parse("http://plus.google.com/something"), "http://mozilla.org"));
-        assertFalse(matcher.matches(Uri.parse("http://plus.google.com/something"), "http://google.com"));
+        assertTrue(matcher.matches(Uri.parse("http://plus.google.com/something"), Uri.parse("http://mozilla.org")));
+        assertFalse(matcher.matches(Uri.parse("http://plus.google.com/something"), Uri.parse("http://google.com")));
 
         // Facebook is special in that we move it from "Disconnect" into social:
-        assertTrue(matcher.matches(Uri.parse("http://facebook.fr"), "http://mozilla.org"));
-        assertFalse(matcher.matches(Uri.parse("http://facebook.fr"), "http://facebook.com"));
+        assertTrue(matcher.matches(Uri.parse("http://facebook.fr"), Uri.parse("http://mozilla.org")));
+        assertFalse(matcher.matches(Uri.parse("http://facebook.fr"), Uri.parse("http://facebook.com")));
 
         // Now disable social, and check that only social sites have changed:
         prefs.edit()
@@ -75,18 +75,18 @@ public class DisconnectTest {
                 .commit();
 
         // ads:
-        assertTrue(matcher.matches(Uri.parse("http://admeld.com/foobar"), "http://mozilla.org"));
-        assertFalse(matcher.matches(Uri.parse("http://admeld.com/foobar"), "http://google.com"));
+        assertTrue(matcher.matches(Uri.parse("http://admeld.com/foobar"), Uri.parse("http://mozilla.org")));
+        assertFalse(matcher.matches(Uri.parse("http://admeld.com/foobar"), Uri.parse("http://google.com")));
         // analytics:
-        assertTrue(matcher.matches(Uri.parse("http://google-analytics.com/foobar"), "http://mozilla.org"));
-        assertFalse(matcher.matches(Uri.parse("http://google-analytics.com/foobar"), "http://google.com"));
+        assertTrue(matcher.matches(Uri.parse("http://google-analytics.com/foobar"), Uri.parse("http://mozilla.org")));
+        assertFalse(matcher.matches(Uri.parse("http://google-analytics.com/foobar"), Uri.parse("http://google.com")));
         // social:
-        assertFalse(matcher.matches(Uri.parse("http://plus.google.com/something"), "http://mozilla.org"));
-        assertFalse(matcher.matches(Uri.parse("http://plus.google.com/something"), "http://google.com"));
+        assertFalse(matcher.matches(Uri.parse("http://plus.google.com/something"), Uri.parse("http://mozilla.org")));
+        assertFalse(matcher.matches(Uri.parse("http://plus.google.com/something"), Uri.parse("http://google.com")));
 
         // And facebook which has been moved from Disconnect into social
-        assertFalse(matcher.matches(Uri.parse("http://facebook.fr"), "http://mozilla.org"));
-        assertFalse(matcher.matches(Uri.parse("http://facebook.fr"), "http://facebook.com"));
+        assertFalse(matcher.matches(Uri.parse("http://facebook.fr"), Uri.parse("http://mozilla.org")));
+        assertFalse(matcher.matches(Uri.parse("http://facebook.fr"), Uri.parse("http://facebook.com")));
 
         // Now disable everything - all sites should work:
         prefs.edit()
@@ -97,17 +97,17 @@ public class DisconnectTest {
                 .commit();
 
         // ads:
-        assertFalse(matcher.matches(Uri.parse("http://admeld.com/foobar"), "http://mozilla.org"));
-        assertFalse(matcher.matches(Uri.parse("http://admeld.com/foobar"), "http://google.com"));
+        assertFalse(matcher.matches(Uri.parse("http://admeld.com/foobar"), Uri.parse("http://mozilla.org")));
+        assertFalse(matcher.matches(Uri.parse("http://admeld.com/foobar"), Uri.parse("http://google.com")));
         // analytics:
-        assertFalse(matcher.matches(Uri.parse("http://google-analytics.com/foobar"), "http://mozilla.org"));
-        assertFalse(matcher.matches(Uri.parse("http://google-analytics.com/foobar"), "http://google.com"));
+        assertFalse(matcher.matches(Uri.parse("http://google-analytics.com/foobar"), Uri.parse("http://mozilla.org")));
+        assertFalse(matcher.matches(Uri.parse("http://google-analytics.com/foobar"), Uri.parse("http://google.com")));
         // social:
-        assertFalse(matcher.matches(Uri.parse("http://plus.google.com/something"), "http://mozilla.org"));
-        assertFalse(matcher.matches(Uri.parse("http://plus.google.com/something"), "http://google.com"));
+        assertFalse(matcher.matches(Uri.parse("http://plus.google.com/something"), Uri.parse("http://mozilla.org")));
+        assertFalse(matcher.matches(Uri.parse("http://plus.google.com/something"), Uri.parse("http://google.com")));
 
         // Facebook is special in that we move it from "Disconnect" into social:
-        assertFalse(matcher.matches(Uri.parse("http://facebook.fr"), "http://mozilla.org"));
-        assertFalse(matcher.matches(Uri.parse("http://facebook.fr"), "http://facebook.com"));
+        assertFalse(matcher.matches(Uri.parse("http://facebook.fr"), Uri.parse("http://mozilla.org")));
+        assertFalse(matcher.matches(Uri.parse("http://facebook.fr"), Uri.parse("http://facebook.com")));
     }
 }

--- a/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/EntityListTest.java
+++ b/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/EntityListTest.java
@@ -1,5 +1,7 @@
 package org.mozilla.focus.webkit.matcher;
 
+import android.net.Uri;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mozilla.focus.webkit.matcher.util.FocusString;
@@ -39,29 +41,29 @@ public class EntityListTest {
         entityList.putWhiteList(FocusString.create(mozillaOrg).reverse(), fooComTrie);
         entityList.putWhiteList(FocusString.create(fooMozillaOrg).reverse(), barComTrie);
 
-        assertTrue(entityList.isWhiteListed("http://" + mozillaOrg, "http://" + fooCom));
-        assertFalse(entityList.isWhiteListed("http://" + mozillaOrg, "http://" + barCom));
+        assertTrue(entityList.isWhiteListed(Uri.parse("http://" + mozillaOrg), Uri.parse("http://" + fooCom)));
+        assertFalse(entityList.isWhiteListed(Uri.parse("http://" + mozillaOrg), Uri.parse("http://" + barCom)));
 
-        assertTrue(entityList.isWhiteListed("http://" + fooMozillaOrg, "http://" + fooCom));
-        assertTrue(entityList.isWhiteListed("http://" + fooMozillaOrg, "http://" + barCom));
+        assertTrue(entityList.isWhiteListed(Uri.parse("http://" + fooMozillaOrg), Uri.parse("http://" + fooCom)));
+        assertTrue(entityList.isWhiteListed(Uri.parse("http://" + fooMozillaOrg), Uri.parse("http://" + barCom)));
 
         // Test some junk inputs to make sure we haven't messed up
-        assertFalse(entityList.isWhiteListed("http://" + barCom, "http://" + barCom));
-        assertFalse(entityList.isWhiteListed("http://" + barCom, "http://" + mozillaOrg));
+        assertFalse(entityList.isWhiteListed(Uri.parse("http://" + barCom), Uri.parse("http://" + barCom)));
+        assertFalse(entityList.isWhiteListed(Uri.parse("http://" + barCom), Uri.parse("http://" + mozillaOrg)));
 
         // Test some made up subdomains to ensure they still match *.foo.mozilla.org
-        assertTrue(entityList.isWhiteListed("http://" + "hello." + fooMozillaOrg, "http://" + fooCom));
-        assertTrue(entityList.isWhiteListed("http://" + "hello." + fooMozillaOrg, "http://" + barCom));
+        assertTrue(entityList.isWhiteListed(Uri.parse("http://" + "hello." + fooMozillaOrg), Uri.parse("http://" + fooCom)));
+        assertTrue(entityList.isWhiteListed(Uri.parse("http://" + "hello." + fooMozillaOrg), Uri.parse("http://" + barCom)));
 
         // And that these only match *.mozilla.org
-        assertTrue(entityList.isWhiteListed("http://" + "hello." + mozillaOrg, "http://" + fooCom));
-        assertFalse(entityList.isWhiteListed("http://" + "hello." + mozillaOrg, "http://" + barCom));
+        assertTrue(entityList.isWhiteListed(Uri.parse("http://" + "hello." + mozillaOrg), Uri.parse("http://" + fooCom)));
+        assertFalse(entityList.isWhiteListed(Uri.parse("http://" + "hello." + mozillaOrg), Uri.parse("http://" + barCom)));
 
         // And random subpages don't fail:
-        assertTrue(entityList.isWhiteListed("http://" + mozillaOrg + "/somewhere", "http://" + fooCom + "/somewhereElse/bla/bla"));
-        assertFalse(entityList.isWhiteListed("http://" + mozillaOrg + "/another/page.html?u=a", "http://" + barCom + "/hello"));
-        assertTrue(entityList.isWhiteListed("http://" + fooMozillaOrg + "/somewhere", "http://" + fooCom + "/somewhereElse/bla/bla"));
-        assertTrue(entityList.isWhiteListed("http://" + fooMozillaOrg + "/another/page.html?u=a", "http://" + barCom + "/hello"));
+        assertTrue(entityList.isWhiteListed(Uri.parse("http://" + mozillaOrg + "/somewhere"), Uri.parse("http://" + fooCom + "/somewhereElse/bla/bla")));
+        assertFalse(entityList.isWhiteListed(Uri.parse("http://" + mozillaOrg + "/another/page.html?u=a"), Uri.parse("http://" + barCom + "/hello")));
+        assertTrue(entityList.isWhiteListed(Uri.parse("http://" + fooMozillaOrg + "/somewhere"), Uri.parse("http://" + fooCom + "/somewhereElse/bla/bla")));
+        assertTrue(entityList.isWhiteListed(Uri.parse("http://" + fooMozillaOrg + "/another/page.html?u=a"), Uri.parse("http://" + barCom + "/hello")));
     }
 
 }

--- a/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/UrlMatcherTest.java
+++ b/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/UrlMatcherTest.java
@@ -31,21 +31,21 @@ public class UrlMatcherTest {
                 "bcd.random"
         });
 
-        assertTrue(matcher.matches(Uri.parse("http://bcd.random/something"), "http://mozilla.org"));
-        assertTrue(matcher.matches(Uri.parse("http://bcd.random"), "http://mozilla.org"));
-        assertTrue(matcher.matches(Uri.parse("http://www.bcd.random"), "http://mozilla.org"));
-        assertTrue(matcher.matches(Uri.parse("http://www.bcd.random/something"), "http://mozilla.org"));
-        assertTrue(matcher.matches(Uri.parse("http://foobar.bcd.random"), "http://mozilla.org"));
-        assertTrue(matcher.matches(Uri.parse("http://foobar.bcd.random/something"), "http://mozilla.org"));
+        assertTrue(matcher.matches(Uri.parse("http://bcd.random/something"), Uri.parse("http://mozilla.org")));
+        assertTrue(matcher.matches(Uri.parse("http://bcd.random"), Uri.parse("http://mozilla.org")));
+        assertTrue(matcher.matches(Uri.parse("http://www.bcd.random"), Uri.parse("http://mozilla.org")));
+        assertTrue(matcher.matches(Uri.parse("http://www.bcd.random/something"), Uri.parse("http://mozilla.org")));
+        assertTrue(matcher.matches(Uri.parse("http://foobar.bcd.random"), Uri.parse("http://mozilla.org")));
+        assertTrue(matcher.matches(Uri.parse("http://foobar.bcd.random/something"), Uri.parse("http://mozilla.org")));
 
-        assertTrue(!matcher.matches(Uri.parse("http://other.random"), "http://mozilla.org"));
-        assertTrue(!matcher.matches(Uri.parse("http://other.random/something"), "http://mozilla.org"));
-        assertTrue(!matcher.matches(Uri.parse("http://www.other.random"), "http://mozilla.org"));
-        assertTrue(!matcher.matches(Uri.parse("http://www.other.random/something"), "http://mozilla.org"));
-        assertTrue(!matcher.matches(Uri.parse("http://bcd.specific"), "http://mozilla.org"));
-        assertTrue(!matcher.matches(Uri.parse("http://bcd.specific/something"), "http://mozilla.org"));
-        assertTrue(!matcher.matches(Uri.parse("http://www.bcd.specific"), "http://mozilla.org"));
-        assertTrue(!matcher.matches(Uri.parse("http://www.bcd.specific/something"), "http://mozilla.org"));
+        assertTrue(!matcher.matches(Uri.parse("http://other.random"), Uri.parse("http://mozilla.org")));
+        assertTrue(!matcher.matches(Uri.parse("http://other.random/something"), Uri.parse("http://mozilla.org")));
+        assertTrue(!matcher.matches(Uri.parse("http://www.other.random"), Uri.parse("http://mozilla.org")));
+        assertTrue(!matcher.matches(Uri.parse("http://www.other.random/something"), Uri.parse("http://mozilla.org")));
+        assertTrue(!matcher.matches(Uri.parse("http://bcd.specific"), Uri.parse("http://mozilla.org")));
+        assertTrue(!matcher.matches(Uri.parse("http://bcd.specific/something"), Uri.parse("http://mozilla.org")));
+        assertTrue(!matcher.matches(Uri.parse("http://www.bcd.specific"), Uri.parse("http://mozilla.org")));
+        assertTrue(!matcher.matches(Uri.parse("http://www.bcd.specific/something"), Uri.parse("http://mozilla.org")));
     }
 
     @Test
@@ -127,7 +127,7 @@ public class UrlMatcherTest {
                 final String url = "http://category" + currentCategory + ".com";
 
                 Assert.assertEquals("Incorrect category matched for combo=" + categoryPattern + " url=" + url,
-                        enabled, matcher.matches(Uri.parse(url), "http://www.mozilla.org"));
+                        enabled, matcher.matches(Uri.parse(url), Uri.parse("http://www.mozilla.org")));
             }
         }
     }

--- a/app/src/webkit/java/org/mozilla/focus/web/FocusWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/web/FocusWebViewClient.java
@@ -7,6 +7,7 @@ package org.mozilla.focus.web;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
+import android.net.Uri;
 import android.net.http.SslError;
 import android.support.v4.util.ArrayMap;
 import android.webkit.SslErrorHandler;
@@ -184,7 +185,8 @@ public class FocusWebViewClient extends TrackingProtectionWebViewClient {
         // (The API 24+ version of shouldOverrideUrlLoading() lets us determine whether
         // the request is for the main frame, and if it's not we could then completely
         // skip the external URL handling.)
-        if (!UrlUtils.isSupportedProtocol(url) &&
+        final Uri uri = Uri.parse(url);
+        if (!UrlUtils.isSupportedProtocol(uri.getScheme()) &&
                 callback != null &&
                 callback.handleExternalUrl(url)) {
             return true;

--- a/app/src/webkit/java/org/mozilla/focus/webkit/TrackingProtectionWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/TrackingProtectionWebViewClient.java
@@ -84,8 +84,9 @@ public class TrackingProtectionWebViewClient extends WebViewClient {
 
         // Don't block the main frame from being loaded. This also protects against cases where we
         // open a link that redirects to another app (e.g. to the play store).
+        final Uri pageUri = Uri.parse(currentPageURL);
         if ((!request.isForMainFrame()) &&
-                matcher.matches(resourceUri, currentPageURL)) {
+                matcher.matches(resourceUri, pageUri)) {
             return new WebResourceResponse(null, null, null);
         }
 

--- a/app/src/webkit/java/org/mozilla/focus/webkit/matcher/EntityList.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/matcher/EntityList.java
@@ -5,6 +5,8 @@
 package org.mozilla.focus.webkit.matcher;
 
 
+import android.net.Uri;
+
 import org.mozilla.focus.utils.UrlUtils;
 import org.mozilla.focus.webkit.matcher.Trie.WhiteListTrie;
 import org.mozilla.focus.webkit.matcher.util.FocusString;
@@ -24,23 +26,19 @@ import java.net.URL;
         rootNode.putWhiteList(revhost, whitelist);
     }
 
-    public boolean isWhiteListed(final String site, final String resource) {
-        if (site.length() == 0 ||
-                resource.length() == 0 ||
-                site.startsWith("data:")) {
+    public boolean isWhiteListed(final Uri site, final Uri resource) {
+        if (site.getHost().length() == 0 ||
+                resource.getHost().length() == 0 ||
+                site.getScheme().equals("data")) {
             return true;
         }
 
-        if (UrlUtils.isPermittedResourceProtocol(resource) &&
-                UrlUtils.isSupportedProtocol(site)) {
-            try {
-                final FocusString revSitehost = FocusString.create(new URL(site).getHost()).reverse();
-                final FocusString revResourcehost = FocusString.create(new URL(resource).getHost()).reverse();
+        if (UrlUtils.isPermittedResourceProtocol(resource.getScheme()) &&
+                UrlUtils.isSupportedProtocol(site.getScheme())) {
+            final FocusString revSitehost = FocusString.create(site.getHost()).reverse();
+            final FocusString revResourcehost = FocusString.create(resource.getHost()).reverse();
 
-                return isWhiteListed(revSitehost, revResourcehost, rootNode);
-            } catch (MalformedURLException e) {
-                throw new IllegalArgumentException("Malformed URI supplied");
-            }
+            return isWhiteListed(revSitehost, revResourcehost, rootNode);
         } else {
             // This might be some imaginary/custom protocol: theguardian.com loads
             // things like "nielsenwebid://nuid/999" and/or sets an iFrame URL to that:

--- a/app/src/webkit/java/org/mozilla/focus/webkit/matcher/UrlMatcher.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/matcher/UrlMatcher.java
@@ -212,7 +212,7 @@ public class UrlMatcher implements  SharedPreferences.OnSharedPreferenceChangeLi
         }
     }
 
-    public boolean matches(final Uri resourceURI, final String pageURLString) {
+    public boolean matches(final Uri resourceURI, final Uri pageURI) {
         final String path = resourceURI.getPath();
 
         if (path == null) {
@@ -237,18 +237,19 @@ public class UrlMatcher implements  SharedPreferences.OnSharedPreferenceChangeLi
         }
 
         if (entityList != null &&
-                entityList.isWhiteListed(pageURLString, resourceURLString)) {
+                entityList.isWhiteListed(pageURI, resourceURI)) {
             // We must not cache entityList items (and/or if we did, we'd have to clear the cache
             // on every single location change)
             return false;
         }
 
+        final String resourceHost = resourceURI.getHost();
+        final String pageHost = pageURI.getHost();
         if (previouslyMatched.contains(resourceURLString)) {
             return true;
         }
 
-        final String host = resourceURI.getHost().toString();
-        final FocusString revhost = FocusString.create(host).reverse();
+        final FocusString revhost = FocusString.create(resourceHost).reverse();
 
         for (final Map.Entry<String, Trie> category : categories.entrySet()) {
             if (enabledCategories.contains(category.getKey())) {

--- a/app/src/webkit/java/org/mozilla/focus/webkit/matcher/UrlMatcher.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/matcher/UrlMatcher.java
@@ -245,6 +245,11 @@ public class UrlMatcher implements  SharedPreferences.OnSharedPreferenceChangeLi
 
         final String resourceHost = resourceURI.getHost();
         final String pageHost = pageURI.getHost();
+
+        if (pageHost.equals(resourceHost)) {
+            return false;
+        }
+
         if (previouslyMatched.contains(resourceURLString)) {
             return true;
         }


### PR DESCRIPTION
We would previously block google.com.tw loads when on google.com.tw. We shouldn't be blocking resources from the current domain, which these commits fix.  (These patches contain a lot of test noise due to the change of our whitelist method signature.)