### PR TITLE
Don't crash when erasing via notification on Android 6 (#522)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/notification/BrowsingNotificationService.java
+++ b/app/src/main/java/org/mozilla/focus/notification/BrowsingNotificationService.java
@@ -97,6 +97,10 @@ public class BrowsingNotificationService extends Service {
                     activityIntent.setFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
                 }
 
+                // This doesn't seem to be needed on Android 7.1. It is needed on Android 6, or otherwise
+                // we crash with "AndroidRuntimeException: Calling startActivity() from outside of an Activity context requires the FLAG_ACTIVITY_NEW_TASK flag."
+                activityIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
                 startActivity(activityIntent);
                 return Service.START_NOT_STICKY;
 


### PR DESCRIPTION
I haven't tested Android 5, or 7.0 yet.