### PR TITLE
Remove unneeded onclicklistener

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
@@ -108,9 +108,6 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         final View view = inflater.inflate(R.layout.fragment_urlinput, container, false);
 
-        final ViewGroup backgroundView = (ViewGroup) view.findViewById(R.id.background);
-        backgroundView.setOnClickListener(this);
-
         dismissView = view.findViewById(R.id.dismiss);
         dismissView.setOnClickListener(this);
 


### PR DESCRIPTION
We don't actually handle this click (which results in crashes
since we assert that all clicks are handled in onClick), we can
just avoid fetching this View altogether.