### PR TITLE
Remove individual selector instead of entire rule if possible (#529)

### DIFF
--- a/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
@@ -64,7 +64,18 @@ import java.util.Map;
             "    let cssRule = stylesheet.cssRules[i];" +
             // Depending on style type, there might be no selector
             "    if (cssRule.selectorText && cssRule.selectorText.includes(':visited')) {" +
-            "      stylesheet.deleteRule(i);" +
+            "      let tokens = cssRule.selectorText.split(',');" +
+            "      let j = tokens.length;" +
+            "      while (j--) {" +
+            "        if (tokens[j].includes(':visited')) {" +
+            "          tokens.splice(j, 1);" +
+            "        }" +
+            "      }" +
+            "      if (tokens.length == 0) {" +
+            "        stylesheet.deleteRule(i);" +
+            "      } else {" +
+            "        cssRule.selectorText = tokens.join(',');" +
+            "      }" +
             "    }" +
             "  }" +
             "}";


### PR DESCRIPTION
Some sites use a, a:visited [etc] { /*stuff*/ }. Removing the entire
rule means we break content beyond just removing visited link styling,
instead we can just modify the selector and remove the offending
:visited components.