### PR TITLE
Disable findbugs in buddybuild for now

### DIFF
--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -4,4 +4,4 @@ set -e # Exit (and fail) immediately if any command in this scriptfails
 # buddybuild doesn't seem to offer any direct way of running findbugs.
 # findbugs is run as part of |gradle build| and |gradle| check, but those
 # aren't run directly in buddybuild.
-./gradlew findbugs
+#./gradlew findbugs


### PR DESCRIPTION
Running gradle breaks the build, but only in buddybuild with the
sdk integration enabled. It seems buddybuild injects its SDK calls
into FocusApplication.java, however gradle doesn't actually know
about that dependency during postbuild. I have no idea how the main
build accesses it, this will need more investigation before reenabling.