### PR TITLE
Reenable findbugs / unblock gradle in postbuild

### DIFF
--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -4,6 +4,7 @@ set -e # Exit (and fail) immediately if any command in this scriptfails
 # buddybuild doesn't seem to offer any direct way of running findbugs.
 # findbugs is run as part of |gradle build| and |gradle| check, but those
 # aren't run directly in buddybuild.
-#./gradlew findbugs
+./gradlew findbugs
+
 ./gradlew jacocoTestReport
- bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
+bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -e # Exit (and fail) immediately if any command in this scriptfails
 
+# buddybuild modifies our buildscripts and sources (this is partly to enable
+# their SDK, and partly to allow selecting flavours in the BuddyBuild UI).
+# We don't know where the Buddybuild SDK lives, which causes gradle builds
+# to be broken (due to the SDK dependency injected into FocusApplication),
+# it's easiest just to revert to a clean source state here:
+git reset --hard
+
 # buddybuild doesn't seem to offer any direct way of running findbugs.
 # findbugs is run as part of |gradle build| and |gradle| check, but those
 # aren't run directly in buddybuild.

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
- The 2.2.X android gradle plugins seem to have a bug during packaging during incremental builds ("file == null", which occasionally happens for our master builds too), updating to 2.2.3 didn't help, but 2.3.1 seems to work (see e.g. https://issuetracker.google.com/issues/37115739 )
- It seems simplest to remove the SDK changes that buddybuild make, since there's no documentation on how to make gradle work with the SDK (unless we manually integrate the SDK outside of buddybuild, but I'm guessing we don't want that in release versions).