### PR TITLE
Don't send data: URLs when loading error pages (#455)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
@@ -85,6 +85,10 @@ public class UrlUtils {
                 url.startsWith("error");
     }
 
+    public static boolean isInternalErrorURL(final String url) {
+        return "data:text/html;charset=utf-8;base64,".equals(url);
+    }
+
     public static boolean urlsMatchExceptForTrailingSlash(final @NonNull String url1, final @NonNull String url2) {
         int lengthDifference = url1.length() - url2.length();
 

--- a/app/src/test/java/org/mozilla/focus/utils/UrlUtilsTest.java
+++ b/app/src/test/java/org/mozilla/focus/utils/UrlUtilsTest.java
@@ -97,4 +97,15 @@ public class UrlUtilsTest {
 
         assertEquals("öäü102ß", UrlUtils.stripUserInfo("öäü102ß"));
     }
+
+    @Test
+    public void isInternalErrorURL() {
+        assertTrue(UrlUtils.isInternalErrorURL("data:text/html;charset=utf-8;base64,"));
+
+        assertFalse(UrlUtils.isInternalErrorURL("http://www.mozilla.org"));
+        assertFalse(UrlUtils.isInternalErrorURL("https://www.mozilla.org/en-us/about"));
+        assertFalse(UrlUtils.isInternalErrorURL("www.mozilla.org"));
+        assertFalse(UrlUtils.isInternalErrorURL("error:-8"));
+        assertFalse(UrlUtils.isInternalErrorURL("hello world"));
+    }
 }

--- a/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
@@ -21,8 +21,6 @@ import org.mozilla.focus.utils.HtmlLoader;
 import org.mozilla.focus.utils.SupportUtils;
 import org.mozilla.focus.utils.UrlUtils;
 import org.mozilla.focus.web.IWebView;
-import org.mozilla.focus.webkit.ErrorPage;
-import org.mozilla.focus.webkit.TrackingProtectionWebViewClient;
 
 import java.util.Map;
 
@@ -162,8 +160,11 @@ import java.util.Map;
         if (callback != null) {
             callback.onPageFinished(view.getCertificate() != null);
             // The URL which is supplied in onPageFinished() could be fake (see #301), but webview's
-            // URL is always correct:
-            callback.onURLChanged(view.getUrl());
+            // URL is always correct _except_ for error pages
+            final String viewURL = view.getUrl();
+            if (!UrlUtils.isInternalErrorURL(viewURL)) {
+                callback.onURLChanged(view.getUrl());
+            }
         }
         super.onPageFinished(view, url);
 

--- a/app/src/webkit/java/org/mozilla/focus/webkit/WebkitView.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/WebkitView.java
@@ -21,6 +21,7 @@ import android.webkit.WebViewDatabase;
 import org.mozilla.focus.BuildConfig;
 import org.mozilla.focus.utils.FileUtils;
 import org.mozilla.focus.utils.ThreadUtils;
+import org.mozilla.focus.utils.UrlUtils;
 import org.mozilla.focus.web.Download;
 import org.mozilla.focus.web.IWebView;
 import org.mozilla.focus.web.WebViewProvider;
@@ -189,7 +190,10 @@ public class WebkitView extends NestedWebView implements IWebView, SharedPrefere
                     // URL: we don't necessarily get a shouldInterceptRequest() after a redirect,
                     // so we can only check the updated url in onProgressChanges(), or in onPageFinished()
                     // (which is even later).
-                    callback.onURLChanged(view.getUrl());
+                    final String viewURL = view.getUrl();
+                    if (!UrlUtils.isInternalErrorURL(viewURL)) {
+                        callback.onURLChanged(viewURL);
+                    }
                     callback.onProgress(newProgress);
                 }
             }


### PR DESCRIPTION
WebView seems to be a bit broken when loading data: URLs when
there's no network connection. It sometimes returns the data: URL
(instead of the original page URL), this happens at the same time as
when it doesn't send onLoadFinished(). Unfortunately there doesn't
seem to be any good workaround other than filtering out the incorrect
URL when it happens. It's impossible to predict when this will happen.