### PR TITLE
Handle null and empty Strings in stripUserInfo() (#567)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
@@ -8,6 +8,7 @@ package org.mozilla.focus.utils;
 import android.content.Context;
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import org.mozilla.focus.search.SearchEngine;
@@ -51,7 +52,11 @@ public class UrlUtils {
         return searchEngine.buildSearchUrl(searchTerm);
     }
 
-    public static String stripUserInfo(String url) {
+    public static String stripUserInfo(@Nullable String url) {
+        if (TextUtils.isEmpty(url)) {
+            return "";
+        }
+
         try {
             URI uri = new URI(url);
 

--- a/app/src/test/java/org/mozilla/focus/utils/UrlUtilsTest.java
+++ b/app/src/test/java/org/mozilla/focus/utils/UrlUtilsTest.java
@@ -88,6 +88,9 @@ public class UrlUtilsTest {
     @Test
     @SuppressLint("AuthLeak")
     public void testStripUserInfo() {
+        assertEquals("", UrlUtils.stripUserInfo(null));
+        assertEquals("", UrlUtils.stripUserInfo(""));
+
         assertEquals("https://www.mozilla.org", UrlUtils.stripUserInfo("https://user:password@www.mozilla.org"));
         assertEquals("https://www.mozilla.org", UrlUtils.stripUserInfo("https://user@www.mozilla.org"));
 


### PR DESCRIPTION
Sometimes the WebView will have a null URL in onProgressChanged().
It seems safest to update the url to be empty in this case, in
case the website is doing some spoofing-related tricks. We'll
hopefully get more feedback on what pages cause this soon.