### PR TITLE
Add language selector strings (#122)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,11 @@
     <!-- This label is shown below the name of the default search engine in settings -->
     <string name="preference_search_engine_default">Default</string>
 
+    <string name="preference_language">Language</string>
+    <!-- This is shown when the user hasn't set a focus specific language, i.e. when Focus
+         is using the system default language. -->
+    <string name="preference_language_systemdefault">System default</string>
+
     <!-- This is the title of the dialog for selecting a new default search engine -->
     <string name="preference_dialog_title_search_engine">Default search</string>
 


### PR DESCRIPTION
The individual language names can be fetched using Locale.getDisplayName(),
so we don't need to ship those ourselves.

I want to land these now so that there's no timing pressure on landing the actual locale switcher
work (hopefully that will be ready in a day or two but...). I'm not 100% sure we'll want the locale
switcher in V1, but we might as well land these strings now.