### PR TITLE
Telemetry max lengths (custom tabs)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
@@ -76,8 +76,8 @@ public final class TelemetryWrapper {
         private static final String BLOCKING_SWITCH = "blocking_switch";
         private static final String BROWSER = "browser";
         private static final String BROWSER_CONTEXTMENU = "browser_contextmenu";
-        private static final String CUSTOM_TAB_CLOSE_BUTTON = "custom_tab_close_button";
-        private static final String CUSTOM_TAB_ACTION_BUTTON = "custom_tab_action_button";
+        private static final String CUSTOM_TAB_CLOSE_BUTTON = "custom_tab_close_but";
+        private static final String CUSTOM_TAB_ACTION_BUTTON = "custom_tab_action_bu";
     }
 
     private static class Value {

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
@@ -213,8 +213,22 @@ public final class TelemetryWrapper {
     /**
      * Sends a list of the custom tab options that a custom-tab intent made use of.
      */
-    public static void customTabsIntentEvent(final String options) {
-        TelemetryEvent.create(Category.ACTION, Method.INTENT_CUSTOM_TAB, Object.APP, options).queue();
+    public static void customTabsIntentEvent(final List<String> options) {
+        final TelemetryEvent event = TelemetryEvent.create(Category.ACTION, Method.INTENT_CUSTOM_TAB, Object.APP);
+
+        // We can send at most 10 extras per event - we just ignore the rest if there are too many
+        final int extrasCount;
+        if (options.size() > 10) {
+            extrasCount = 10;
+        } else {
+            extrasCount = options.size();
+        }
+
+        for (final String option : options.subList(0, extrasCount)) {
+            event.extra(option, "true");
+        }
+
+        event.queue();
     }
 
     public static void closeCustomTabEvent() {

--- a/app/src/main/java/org/mozilla/focus/web/CustomTabConfig.java
+++ b/app/src/main/java/org/mozilla/focus/web/CustomTabConfig.java
@@ -16,6 +16,7 @@ import org.mozilla.focus.utils.SafeBundle;
 import org.mozilla.focus.utils.SafeIntent;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -237,7 +238,7 @@ public class CustomTabConfig {
     /**
      * Get a list of options enabled in the custom tabs intent, e.g. [hasToolbarColor, hasCloseButton].
      */
-    public String getOptionsList() {
+    public List<String> getOptionsList() {
         // A list of custom-tab features that are used, stored for telemetry purposed
         final List<String> featureList = new LinkedList<>(unsupportedFeatureList);
 
@@ -265,7 +266,6 @@ public class CustomTabConfig {
             featureList.add("hasCustomizedMenu");
         }
 
-        // List.toString() returns a nicely formatted list like "[item1, item2, etc]":
-        return featureList.toString();
+        return Collections.unmodifiableList(featureList);
     }
 }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -36,8 +36,8 @@ The event ping contains a list of events ([see event format on readthedocs.io](h
 * (Browsing) Incoming custom tab intent from third-party app - ("action", "intent_custom_tab", "app", options). Options is a list of enabled custom tab options as requested by the third-party app, e.g. [hasToolbarColor, hasCloseButton] etc.
 * (Browsing) Text selection action from third-party app ("action", "text_selection_intent", "app")
 * (Browsing) Long press on image or link, or image in link ("action", "long_press", "browser")
-* (CustomTab) Custom Tab close button clicked - ("action", "click", "custom_tab_close_button")
-* (CustomTab) Custom Tab action button clicked - ("action", "click", "custom_tab_action_button")
+* (CustomTab) Custom Tab close button clicked - ("action", "click", "custom_tab_close_but")
+* (CustomTab) Custom Tab action button clicked - ("action", "click", "custom_tab_action_bu")
 * (CustomTab) Browser Menu custom tab item selected - ("action", "open", "menu", "custom_tab")
 * (BrowserContextMenu) Context menu dismissed without any selection ("action", "cancel", "browser_contextmenu")
 * (BrowserContextMenu) Share Link menu item selected ("action", "share", "browser_contextmenu", "link")


### PR DESCRIPTION
I don't know if it's better to
- split custom tabs features over multiple events if there are more than 10? (There are up to 15ish, we only send an extra for those that are enabled
- change the button strings to e.g. ct_action_button instead of truncating?