### PR TITLE
Correctly track visibility state of MainActivity. (#774)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         applicationId "org.mozilla"
         minSdkVersion 21
         targetSdkVersion 25
-        versionCode 3
+        versionCode 4
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -92,10 +92,15 @@ public class MainActivity extends LocaleAwareAppCompatActivity {
     }
 
     @Override
-    protected void onResume() {
-        super.onResume();
+    protected void onStart() {
+        super.onStart();
 
         BrowsingNotificationService.foreground(this);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
 
         TelemetryWrapper.startSession();
 
@@ -114,14 +119,14 @@ public class MainActivity extends LocaleAwareAppCompatActivity {
 
         super.onPause();
 
-        BrowsingNotificationService.background(this);
-
         TelemetryWrapper.stopSession();
     }
 
     @Override
     protected void onStop() {
         super.onStop();
+
+        BrowsingNotificationService.background(this);
 
         TelemetryWrapper.stopMainActivity();
     }

--- a/app/src/main/java/org/mozilla/focus/notification/BrowsingNotificationService.java
+++ b/app/src/main/java/org/mozilla/focus/notification/BrowsingNotificationService.java
@@ -70,6 +70,15 @@ public class BrowsingNotificationService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         switch (intent.getAction()) {
             case ACTION_START:
+                // When we use ACTION_STOP to stop the browsing session, we also stop this Service (to conserve
+                // resources) so we lose track of the MainActivity's foreground/background state. If we start the
+                // session again (ACTION_START), we assume the default Activity state, backgrounded, and our handling
+                // of an additional ACTION_STOP will unexpectedly take the backgrounded code path even though the
+                // MainActivity is actually in the foreground, which closes the app.
+                //
+                // We can assume we would only start a browsing session with the MainActivity foregrounded,
+                // so we fix this problem by setting the MainActivity to the foreground state whenever ACTION_START
+                // is received.
                 foreground = true;
                 startBrowsingSession();
                 break;

--- a/app/src/main/java/org/mozilla/focus/notification/BrowsingNotificationService.java
+++ b/app/src/main/java/org/mozilla/focus/notification/BrowsingNotificationService.java
@@ -70,6 +70,7 @@ public class BrowsingNotificationService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         switch (intent.getAction()) {
             case ACTION_START:
+                foreground = true;
                 startBrowsingSession();
                 break;
 


### PR DESCRIPTION
#774.

When clicking the notification to erase the browsing history our BrowsingNotificationService
needs to decide:

* Is the app in the background? Then close it so that we start fresh the next time it is started.
* Is it in the foreground? Then notify it and play the erase animation.

The previous version tracked forground/background state by looking at onResume() and onPause().
This is not correct in all cases: An activity can be visible but not in the foreground (e.g.
another translucent screen is on top). In this case we still want to play the animation and
not (visibly) close the app.

With this patch we now track the state from onStart() and onStop(). Those callbacks are exactly
for this: They are called once an activity becomes visible to the user.

Additionally with this patch we will track the start of a browsing session as a "foreground"
event. This is necessary because since the service could have been removed since the last
foreground event (it's only "ongoing" *during* a session). However we are *always* in the
foreground when starting a browsing session.