### PR TITLE
Closes #783: Allow pages to load about:blank.

### DIFF
--- a/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
@@ -186,6 +186,13 @@ import java.util.Map;
             return true;
         }
 
+        // Allow pages to blank themselves by loading about:blank. While it's a little incorrect to let pages
+        // access our internal URLs, Chrome allows loads to about:blank and, to ensure our behavior conforms
+        // to the behavior that most of the web is developed against, we do too.
+        if (url.equals("about:blank")) {
+            return false;
+        }
+
         // shouldOverrideUrlLoading() is called for both the main frame, and iframes.
         // That can get problematic if an iframe tries to load an unsupported URL.
         // We then try to either handle that URL (ask to open relevant app), or extract


### PR DESCRIPTION
#783.