### PR TITLE
Add Custom Tabs status bar colour

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -17,6 +17,7 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.TransitionDrawable;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -26,6 +27,8 @@ import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
 import android.webkit.CookieManager;
 import android.webkit.URLUtil;
 import android.widget.ImageButton;
@@ -200,6 +203,12 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
             textColor = ColorUtils.getReadableTextColor(customTabConfig.toolbarColor);
             urlView.setTextColor(textColor);
+
+            final Window window = getActivity().getWindow();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+                window.setStatusBarColor(ColorUtils.darken(customTabConfig.toolbarColor, 0.25));
+            }
         } else {
             textColor = Color.WHITE;
         }

--- a/app/src/main/java/org/mozilla/focus/utils/ColorUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/ColorUtils.java
@@ -26,4 +26,19 @@ public class ColorUtils {
         // humans perceive color.
         return (int) (0.299 * red + 0.587 * green + 0.114 * blue);
     }
+
+    public static int darken(final int color, final double fraction) {
+        int red = Color.red(color);
+        int green = Color.green(color);
+        int blue = Color.blue(color);
+        red = darkenColor(red, fraction);
+        green = darkenColor(green, fraction);
+        blue = darkenColor(blue, fraction);
+        final int alpha = Color.alpha(color);
+        return Color.argb(alpha, red, green, blue);
+    }
+
+    private static int darkenColor(final int color, final double fraction) {
+        return (int) Math.max(color - (color * fraction), 0);
+    }
 }


### PR DESCRIPTION
This was cherry-picked from the [fennec patch][1] and goes hand-in-hand with the toolbar colour changes as well.

Left is before, right is after.

![out](https://user-images.githubusercontent.com/1370580/27461522-3a008d56-5788-11e7-903a-bc6785c7b5bf.png)




[1]: https://hg.mozilla.org/mozilla-central/file/1c529127c7a4/mobile/android/base/java/org/mozilla/gecko/customtabs/CustomTabsActivity.java