### PR TITLE
Set progress to 5% when new page starts loading. (#818)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -307,7 +307,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
                 backgroundTransition.resetTransition();
 
-                progressView.setProgress(0);
+                progressView.setProgress(5);
                 progressView.setVisibility(View.VISIBLE);
 
                 updateToolbarButtonStates();


### PR DESCRIPTION
Otherwise it might look like the browser is doing nothing (on a slow network) until we
receive a progress from WebView.