### PR TITLE
Avoid showing keyboard again if pressing back key on UrlInputFragment

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
@@ -104,6 +104,8 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
     private View urlInputBackgroundView;
     private View toolbarBackgroundView;
 
+    private boolean isBackPressed;
+
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         final View view = inflater.inflate(R.layout.fragment_urlinput, container, false);
@@ -127,7 +129,8 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
         urlView.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-                if (hasFocus) {
+                // Avoid showing keyboard again when returning to the previous page by back key.
+                if (hasFocus && !isBackPressed) {
                     ViewUtils.showKeyboard(urlView);
                 }
             }
@@ -159,6 +162,7 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
     }
 
     public boolean onBackPressed() {
+        isBackPressed = true;
         animateAndDismiss();
         return true;
     }


### PR DESCRIPTION
Currently if we press back key on the UrlInputFragment, the soft keyboard will disappear at the first time. However, if we press again, when the UrlInputFragment has already animated to the HomeFragment, the keyboard will soon appear and then disappear. I think this behavior does not make sense, so I add a check to avoid this case.