### PR TITLE
Make UrlInputFragment handling more robust

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.java
@@ -9,7 +9,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
 import android.support.v7.widget.PopupMenu;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -78,12 +80,7 @@ public class HomeFragment
     public void onClick(View view) {
         switch (view.getId()) {
             case R.id.fake_urlbar:
-                UrlInputFragment fragment = UrlInputFragment.createWithHomeScreenAnimation(fakeUrlBarView);
-
-                getActivity().getSupportFragmentManager().beginTransaction()
-                        .add(R.id.container, fragment, UrlInputFragment.FRAGMENT_TAG)
-                        .commit();
-
+                showUrlInput();
                 break;
 
             case R.id.menu:
@@ -97,6 +94,23 @@ public class HomeFragment
             default:
                 throw new IllegalStateException("Unhandled view ID in onClick()");
         }
+    }
+
+    private synchronized void showUrlInput() {
+        final FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
+
+        final Fragment existingFragment = fragmentManager.findFragmentByTag(UrlInputFragment.FRAGMENT_TAG);
+        if (existingFragment != null && existingFragment.isAdded() && !existingFragment.isRemoving()) {
+            // We are already showing an URL input fragment. This might have been a double click on the
+            // fake URL bar. Just ignore it.
+            return;
+        }
+
+        final UrlInputFragment fragment = UrlInputFragment.createWithHomeScreenAnimation(fakeUrlBarView);
+
+        fragmentManager.beginTransaction()
+                .add(R.id.container, fragment, UrlInputFragment.FRAGMENT_TAG)
+                .commit();
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
@@ -105,7 +105,6 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
     private View toolbarBackgroundView;
 
     private volatile boolean isAnimating;
-    private boolean isBackPressed;
 
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -131,7 +130,7 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
                 // Avoid showing keyboard again when returning to the previous page by back key.
-                if (hasFocus && !isBackPressed) {
+                if (hasFocus && !isAnimating) {
                     ViewUtils.showKeyboard(urlView);
                 }
             }
@@ -163,7 +162,6 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
     }
 
     public boolean onBackPressed() {
-        isBackPressed = true;
         animateAndDismiss();
         return true;
     }

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
@@ -207,6 +207,11 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
     }
 
     private synchronized void animateAndDismiss() {
+        if (isAnimating) {
+            // We are already animating some state change. Ignore all other requests.
+            return;
+        }
+
         // Don't allow any more clicks: dismissView is still visible until the animation ends,
         // but we don't want to restart animations and/or trigger hiding again (which could potentially
         // cause crashes since we don't know what state we're in). Ignoring further clicks is the simplest

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
@@ -405,10 +405,15 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
     }
 
     private void dismiss() {
+        // This method is called from animation callbacks. In the short time frame between the animation
+        // starting and ending the activity can be paused. In this case this code can throw an
+        // IllegalStateException because we already saved the state (of the activity / fragment) before
+        // this transaction is committed. To avoid this we commit while allowing a state loss here.
+        // We do not save any state in this fragment (It's getting destroyed) so this should not be a problem.
         getActivity().getSupportFragmentManager()
                 .beginTransaction()
                 .remove(this)
-                .commit();
+                .commitAllowingStateLoss();
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
@@ -104,6 +104,7 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
     private View urlInputBackgroundView;
     private View toolbarBackgroundView;
 
+    private volatile boolean isAnimating;
     private boolean isBackPressed;
 
     @Override
@@ -205,7 +206,7 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
         }
     }
 
-    private void animateAndDismiss() {
+    private synchronized void animateAndDismiss() {
         // Don't allow any more clicks: dismissView is still visible until the animation ends,
         // but we don't want to restart animations and/or trigger hiding again (which could potentially
         // cause crashes since we don't know what state we're in). Ignoring further clicks is the simplest
@@ -227,6 +228,13 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
      * Play animation between home screen and the URL input.
      */
     private void playHomeScreenAnimation(final boolean reverse) {
+        if (isAnimating) {
+            // We are already animating, let's ignore another request.
+            return;
+        }
+
+        isAnimating = true;
+
         int[] screenLocation = new int[2];
         urlInputContainerView.getLocationOnScreen(screenLocation);
 
@@ -287,6 +295,8 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
                         } else {
                             urlView.setCursorVisible(true);
                         }
+
+                        isAnimating = false;
                     }
                 });
 
@@ -309,6 +319,13 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
     }
 
     private void playBrowserScreenAnimation(final boolean reverse) {
+        if (isAnimating) {
+            // We are already animating, let's ignore another request.
+            return;
+        }
+
+        isAnimating = true;
+
         {
             float containerMargin = ((FrameLayout.LayoutParams) urlInputContainerView.getLayoutParams()).bottomMargin;
 
@@ -353,6 +370,8 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
                             } else {
                                 clearView.setAlpha(1);
                             }
+
+                            isAnimating = false;
                         }
                     });
         }


### PR DESCRIPTION
There have been some crashes (and other visual issues) when some of the animations and actions where triggered while an other animation was still in flight or the activity was getting backgrounded.