### PR TITLE
UrlInputFragment.dismissView(): Instead of synchronizing assert we ar…

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
@@ -26,6 +26,7 @@ import android.widget.TextView;
 import org.mozilla.focus.R;
 import org.mozilla.focus.autocomplete.UrlAutoCompleteFilter;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
+import org.mozilla.focus.utils.ThreadUtils;
 import org.mozilla.focus.utils.UrlUtils;
 import org.mozilla.focus.utils.ViewUtils;
 import org.mozilla.focus.widget.HintFrameLayout;
@@ -204,7 +205,9 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
         }
     }
 
-    private synchronized void animateAndDismiss() {
+    private void animateAndDismiss() {
+        ThreadUtils.assertOnUiThread();
+
         if (isAnimating) {
             // We are already animating some state change. Ignore all other requests.
             return;

--- a/app/src/main/java/org/mozilla/focus/utils/ThreadUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/ThreadUtils.java
@@ -16,6 +16,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class ThreadUtils {
     private static final ExecutorService backgroundExecutorService = Executors.newSingleThreadExecutor();
     private static final Handler handler = new Handler(Looper.getMainLooper());
+    private static final Thread uiThread = Looper.getMainLooper().getThread();
 
     @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE", justification = "We don't care about the results here")
     public static void postToBackgroundThread(final Runnable runnable) {
@@ -28,5 +29,17 @@ public class ThreadUtils {
 
     public static void postToMainThreadDelayed(final Runnable runnable, long delayMillis) {
         handler.postDelayed(runnable, delayMillis);
+    }
+
+    public static void assertOnUiThread() {
+        final Thread currentThread = Thread.currentThread();
+        final long currentThreadId = currentThread.getId();
+        final long expectedThreadId = uiThread.getId();
+
+        if (currentThreadId == expectedThreadId) {
+            return;
+        }
+
+        throw new IllegalThreadStateException("Expected UI thread, but running on " + currentThread.getName());
     }
 }


### PR DESCRIPTION
…e running on the UI thread. (#853)