### PR TITLE
Update tests for the new app name

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/ImageSelectTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ImageSelectTest.java
@@ -109,7 +109,7 @@ public class ImageSelectTest {
             .enabled(true));
     private UiObject warning = TestHelper.mDevice.findObject(new UiSelector()
             .resourceId("org.mozilla.focus.debug:id/warning")
-            .text("Saved and shared images will not be deleted when you erase Firefox Focus (Dev) history.")
+            .text("Saved and shared images will not be deleted when you erase Firefox Focus history.")
             .enabled(true));
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/focus/activity/PageVisitTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/PageVisitTest.java
@@ -59,7 +59,7 @@ public class PageVisitTest {
                 .text("Your Rights"));
         UiObject aboutPartialText = TestHelper.mDevice.findObject(new UiSelector()
                 .className("android.view.View")
-                .description("Firefox Focus (Dev) puts you in control."));
+                .description("Firefox Focus puts you in control."));
         UiObject aboutHeading = TestHelper.mDevice.findObject(new UiSelector()
                 .className("android.widget.TextView")
                 .text("About"));


### PR DESCRIPTION
Now the focusWebkitDebug is caled 'Firefox Focus' instead of 'Firefox Focus (Dev)'