### PR TITLE
Closes #838: Dismiss HomeFragment's PopupMenu onDetach.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.java
@@ -29,7 +29,7 @@ import org.mozilla.focus.locale.LocaleAwareFragment;
  */
 public class HomeFragment
         extends LocaleAwareFragment
-        implements View.OnClickListener, PopupMenu.OnMenuItemClickListener {
+        implements View.OnClickListener, PopupMenu.OnMenuItemClickListener, PopupMenu.OnDismissListener {
     public static final String FRAGMENT_TAG = "home";
 
     public static HomeFragment create() {
@@ -37,6 +37,8 @@ public class HomeFragment
     }
 
     private View fakeUrlBarView;
+
+    @Nullable private PopupMenu displayedPopupMenu = null;
 
     @Override
     public void applyLocale() {
@@ -65,6 +67,18 @@ public class HomeFragment
     }
 
     @Override
+    public void onDetach() {
+        super.onDetach();
+
+        // On detach, the PopupMenu is no longer relevant to other content (e.g. BrowserFragment) so dismiss it.
+        // Note: if we don't dismiss the PopupMenu, its onMenuItemClick method references the old Fragment, which now
+        // has a null Context and will cause crashes.
+        if (displayedPopupMenu != null) {
+            displayedPopupMenu.dismiss();
+        }
+    }
+
+    @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         final View view = inflater.inflate(R.layout.fragment_home, container, false);
 
@@ -89,6 +103,7 @@ public class HomeFragment
                 popupMenu.setOnMenuItemClickListener(this);
                 popupMenu.setGravity(Gravity.TOP);
                 popupMenu.show();
+                displayedPopupMenu = popupMenu;
                 break;
 
             default:
@@ -140,5 +155,10 @@ public class HomeFragment
             default:
                 throw new IllegalStateException("Unhandled view ID in onMenuItemClick()");
         }
+    }
+
+    @Override
+    public void onDismiss(final PopupMenu menu) {
+        displayedPopupMenu = null;
     }
 }


### PR DESCRIPTION
One undesirable effect of this change: this issue only shows itself when we
.replace the HomeFragment, which happens when we change locales, whose code
only gets called from `onResume`. This means the menu is *briefly* visible when
returning to the app when following the STR in the bug. This is ugly but given
how infrequently I expect this to happen, I think it's fine.

The solution would be to additionally dismiss the PopupMenu in onStop, but:

1. I'm concerned about unforseen side effects from that change
2. For correctness, we'd have to dismiss the PopupMenu in both `onDetach` and
`onStop` which is a little confusing from a code perspective - better to keep
it clean, I think!

@pocmo Let me know if you have any opinions here ^.