### PR TITLE
entering blank spaces in search should not show 'Search for' dialog (…

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
@@ -487,7 +487,7 @@ public class UrlInputFragment extends Fragment implements View.OnClickListener, 
 
         urlAutoCompleteFilter.onFilter(searchText, view);
 
-        if (searchText.length() == 0) {
+        if (searchText.trim().isEmpty()) {
             clearView.setVisibility(View.GONE);
             searchViewContainer.setVisibility(View.GONE);
         } else {


### PR DESCRIPTION
…#875)