### PR TITLE
Closes #895: Add a telemetry probe for "default browser"

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/Browsers.java
+++ b/app/src/main/java/org/mozilla/focus/utils/Browsers.java
@@ -61,6 +61,9 @@ public class Browsers {
         }
     }
 
+    // Sample URL handled by traditional web browsers. Used to find installed (basic) web browsers.
+    public static final String TRADITIONAL_BROWSER_URL = "http://www.mozilla.org";
+
     private final Map<String, ActivityInfo> browsers;
     private final ActivityInfo defaultBrowser;
     // This will contain installed firefox branded browser ordered by priority from Firefox,

--- a/app/src/main/java/org/mozilla/focus/widget/DefaultBrowserPreference.java
+++ b/app/src/main/java/org/mozilla/focus/widget/DefaultBrowserPreference.java
@@ -49,7 +49,7 @@ public class DefaultBrowserPreference extends Preference {
 
     public void update() {
         if (switchView != null) {
-            final Browsers browsers = new Browsers(getContext(), "http://www.mozilla.org");
+            final Browsers browsers = new Browsers(getContext(), Browsers.TRADITIONAL_BROWSER_URL);
             switchView.setChecked(browsers.isDefaultBrowser(getContext()));
         }
     }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -24,6 +24,7 @@ As part of the event ping the most recent state of the user's setting is sent (d
 * Block web fonts (`pref_performance_block_webfonts`: true/**false**)
 * Block images (`pref_performance_block_images`: true/**false**)
 * Locale override (`pref_locale`: **empty string**/<locale-code>). **empty string** indicates "System Default" locale is selected.
+* Focus is set as the default browser (`pref_default_browser`: true/**false**)
 
 #### Events
 


### PR DESCRIPTION
This is the new version of the telemetry probe using the SettingsMeasurement.