### PR TITLE
Closes #785: Separate gradient background view into two views

### DIFF
--- a/app/src/main/java/org/mozilla/focus/animation/TransitionDrawableGroup.java
+++ b/app/src/main/java/org/mozilla/focus/animation/TransitionDrawableGroup.java
@@ -1,0 +1,31 @@
+package org.mozilla.focus.animation;
+
+import android.graphics.drawable.TransitionDrawable;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A class to allow {@link TransitionDrawable}'s animations to play together: similar to {@link android.animation.AnimatorSet}.
+ */
+public class TransitionDrawableGroup {
+    private final Collection<TransitionDrawable> transitionDrawables;
+
+    public TransitionDrawableGroup(final Collection<TransitionDrawable> c) {
+        transitionDrawables = Collections.unmodifiableCollection(c);
+    }
+
+    public void startTransition(final int durationMillis) {
+        // In theory, there are no guarantees these will play together.
+        // In practice, I haven't noticed any problems.
+        for (final TransitionDrawable transitionDrawable : transitionDrawables) {
+            transitionDrawable.startTransition(durationMillis);
+        }
+    }
+
+    public void resetTransition() {
+        for (final TransitionDrawable transitionDrawable : transitionDrawables) {
+            transitionDrawable.resetTransition();
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/animation/TransitionDrawableGroup.java
+++ b/app/src/main/java/org/mozilla/focus/animation/TransitionDrawableGroup.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.animation;
 
 import android.graphics.drawable.TransitionDrawable;

--- a/app/src/main/java/org/mozilla/focus/utils/ScreenUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/ScreenUtils.java
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.utils;
+
+import android.graphics.Rect;
+import android.support.annotation.NonNull;
+import android.view.Window;
+
+/** Utilities for managing the screen. */
+public class ScreenUtils {
+    private ScreenUtils() {}
+
+    // via https://stackoverflow.com/a/3410200/2219998.
+    public static int getStatusBarHeight(@NonNull final Window window) {
+        final Rect appContentRect = new Rect();
+        window.getDecorView().getWindowVisibleDisplayFrame(appContentRect);
+        return appContentRect.top;
+    }
+}

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -13,10 +13,20 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <!-- The toolbar gradient background extends from under the system status bar to the app's Toolbar.
+             This view is broken up into two views:
+             - This view, for the status bar
+             - The AppBarLayout, for the application's Toolbar
+
+             The height of this view is set dynamically to match the system status bar height because
+             there is no way to access this value statically: see the associated code in BrowserFragment.
+
+             A previous implementation used one view for the gradient, which is slightly simpler, but ran
+             into draw order problems (#785). -->
         <View
-            android:id="@+id/background"
+            android:id="@+id/status_bar_background"
             android:layout_width="match_parent"
-            android:layout_height="81dp"
+            android:layout_height="0dp"
             android:background="@drawable/animated_background" />
 
         <org.mozilla.focus.widget.ResizableKeyboardLayout
@@ -38,7 +48,7 @@
                 android:id="@+id/appbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@android:color/transparent"
+                android:background="@drawable/animated_background"
                 app:elevation="0dp"
                 android:clipChildren="false">
 


### PR DESCRIPTION
#785

Tested on:
- N5 (Android 6)
- GS5 (Android 6)