### PR TITLE
UrlUtils: Scheme passed to isPermittedResourceProtocol() and isSupportedProtocol() can be null. (#899)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
@@ -88,16 +88,16 @@ public class UrlUtils {
         }
     }
 
-    public static boolean isPermittedResourceProtocol(final String url) {
-        return url.startsWith("http") ||
-                url.startsWith("https") ||
-                url.startsWith("file") ||
-                url.startsWith("data");
+    public static boolean isPermittedResourceProtocol(@Nullable final String scheme) {
+        return scheme != null && (
+                scheme.startsWith("http") ||
+                scheme.startsWith("https") ||
+                scheme.startsWith("file") ||
+                scheme.startsWith("data"));
     }
 
-    public static boolean isSupportedProtocol(final String url) {
-        return isPermittedResourceProtocol(url) ||
-                url.startsWith("error");
+    public static boolean isSupportedProtocol(@Nullable final String scheme) {
+        return scheme != null && (isPermittedResourceProtocol(scheme) || scheme.startsWith("error"));
     }
 
     public static boolean isInternalErrorURL(final String url) {

--- a/app/src/test/java/org/mozilla/focus/utils/UrlUtilsTest.java
+++ b/app/src/test/java/org/mozilla/focus/utils/UrlUtilsTest.java
@@ -35,6 +35,9 @@ public class UrlUtilsTest {
 
     @Test
     public void isPermittedResourceProtocol() {
+        assertFalse(UrlUtils.isPermittedResourceProtocol(""));
+        assertFalse(UrlUtils.isPermittedResourceProtocol(null));
+
         assertTrue(UrlUtils.isPermittedResourceProtocol("http"));
         assertTrue(UrlUtils.isPermittedResourceProtocol("https"));
 
@@ -46,6 +49,9 @@ public class UrlUtilsTest {
 
     @Test
     public void isPermittedProtocol() {
+        assertFalse(UrlUtils.isSupportedProtocol(""));
+        assertFalse(UrlUtils.isSupportedProtocol(null));
+
         assertTrue(UrlUtils.isSupportedProtocol("http"));
         assertTrue(UrlUtils.isSupportedProtocol("https"));
         assertTrue(UrlUtils.isSupportedProtocol("error"));


### PR DESCRIPTION
In various places we pass the value from Uri.getScheme() to those methods. However getScheme() can return null and in those cases we crash. I haven't been able to actually find a way to trigger
this crash. But it seems to be rare looking at the number of crash reports we received.