### PR TITLE
Realigned FAB for Android Multi-Window fixes #934

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/ResizableKeyboardLayout.java
+++ b/app/src/main/java/org/mozilla/focus/widget/ResizableKeyboardLayout.java
@@ -63,7 +63,7 @@ public class ResizableKeyboardLayout extends CoordinatorLayout {
         public void onGlobalLayout() {
             int difference = calculateDifferenceBetweenHeightAndUsableArea();
 
-            if (difference != 0) {
+            if (difference > 0) {
                 // Keyboard showing -> Set difference has bottom padding.
                 if (getPaddingBottom() != difference) {
                     setPadding(0, 0, 0, difference);

--- a/app/src/main/java/org/mozilla/focus/widget/ResizableKeyboardLayout.java
+++ b/app/src/main/java/org/mozilla/focus/widget/ResizableKeyboardLayout.java
@@ -64,7 +64,7 @@ public class ResizableKeyboardLayout extends CoordinatorLayout {
             int difference = calculateDifferenceBetweenHeightAndUsableArea();
 
             // If difference > 0, keyboard is showing. 
-            // If difference =< 0, keyboard is not showing or is in multiview mode
+            // If difference =< 0, keyboard is not showing or is in multiview mode.
             if (difference > 0) {
                 // Keyboard showing -> Set difference has bottom padding.
                 if (getPaddingBottom() != difference) {

--- a/app/src/main/java/org/mozilla/focus/widget/ResizableKeyboardLayout.java
+++ b/app/src/main/java/org/mozilla/focus/widget/ResizableKeyboardLayout.java
@@ -63,7 +63,7 @@ public class ResizableKeyboardLayout extends CoordinatorLayout {
         public void onGlobalLayout() {
             int difference = calculateDifferenceBetweenHeightAndUsableArea();
 
-            // If difference > 0, keyboard is showing. 
+            // If difference > 0, keyboard is showing.
             // If difference =< 0, keyboard is not showing or is in multiview mode.
             if (difference > 0) {
                 // Keyboard showing -> Set difference has bottom padding.

--- a/app/src/main/java/org/mozilla/focus/widget/ResizableKeyboardLayout.java
+++ b/app/src/main/java/org/mozilla/focus/widget/ResizableKeyboardLayout.java
@@ -63,6 +63,8 @@ public class ResizableKeyboardLayout extends CoordinatorLayout {
         public void onGlobalLayout() {
             int difference = calculateDifferenceBetweenHeightAndUsableArea();
 
+            // If difference > 0, keyboard is showing. 
+            // If difference =< 0, keyboard is not showing or is in multiview mode
             if (difference > 0) {
                 // Keyboard showing -> Set difference has bottom padding.
                 if (getPaddingBottom() != difference) {


### PR DESCRIPTION
The problem was that the Global Layout Listener did not differentiate between the keyboard appearing and multi-view initiating making the FAB offscreen as demonstrated in #934. This is not a perfect solution but fixes the main UI issue. The solution does not set FAB visibility to gone when in multi-window view AND keyboard is displayed. I don't believe there are currently reliable Android methods to detect multi-window view and to detect if the keyboard is showing. 


<img width="335" alt="screen shot 2017-07-18 at 4 26 27 pm" src="https://user-images.githubusercontent.com/25442310/28344060-168e11d8-6bd6-11e7-8fb9-538fac2a3779.png">


<img width="575" alt="screen shot 2017-07-18 at 4 26 41 pm" src="https://user-images.githubusercontent.com/25442310/28344061-1850f846-6bd6-11e7-9174-61a8e9a93182.png">

FAB still visible when keyboard is up + multi-window. 
<img width="348" alt="screen shot 2017-07-18 at 4 27 20 pm" src="https://user-images.githubusercontent.com/25442310/28344067-2a3d4604-6bd6-11e7-9411-83d0f80d48a1.png">

<img width="323" alt="screen shot 2017-07-18 at 4 29 04 pm" src="https://user-images.githubusercontent.com/25442310/28344110-6c12e642-6bd6-11e7-8100-318ab5c2c34c.png">


