### PR TITLE
Keep WebView state in memory when view gets destroyed. (#651)

### DIFF
--- a/app/src/gecko/java/org/mozilla/focus/web/WebViewProvider.java
+++ b/app/src/gecko/java/org/mozilla/focus/web/WebViewProvider.java
@@ -113,13 +113,13 @@ public class WebViewProvider {
         }
 
         @Override
-        public void restoreWebviewState(Bundle savedInstanceState) {
-            // TODO: restore navigation history, and reopen previously opened page
+        public void saveWebViewState(Bundle outState) {
+            // TODO: save anything needed for navigation history restoration.
         }
 
         @Override
-        public void onSaveInstanceState(Bundle outState) {
-            // TODO: save anything needed for navigation history restoration.
+        public void restoreWebViewState(Bundle inState) {
+            // TODO: restore navigation history, and reopen previously opened page
         }
 
         private ContentListener createContentListener() {

--- a/app/src/main/java/org/mozilla/focus/fragment/WebFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/WebFragment.java
@@ -64,7 +64,7 @@ public abstract class WebFragment extends LocaleAwareFragment {
                 webView.loadUrl(url);
             }
         } else {
-            webView.restoreWebviewState(savedInstanceState);
+            webView.restoreWebViewState(savedInstanceState);
         }
 
         onCreateViewCalled();
@@ -102,7 +102,7 @@ public abstract class WebFragment extends LocaleAwareFragment {
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        webView.onSaveInstanceState(outState);
+        webView.saveWebViewState(outState);
 
         super.onSaveInstanceState(outState);
     }

--- a/app/src/main/java/org/mozilla/focus/web/BrowsingSession.java
+++ b/app/src/main/java/org/mozilla/focus/web/BrowsingSession.java
@@ -5,14 +5,16 @@
 
 package org.mozilla.focus.web;
 
-import java.lang.ref.WeakReference;
-
 import android.content.Context;
-import android.content.Intent;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.mozilla.focus.utils.SafeIntent;
+
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A global object keeping the state of the current browsing session.
@@ -38,8 +40,11 @@ public class BrowsingSession {
     private WeakReference<TrackingCountListener> listenerWeakReference;
     private @Nullable CustomTabConfig customTabConfig;
 
+    private Map<String, Bundle> webViewStates;
+
     private BrowsingSession() {
         listenerWeakReference = new WeakReference<>(null);
+        webViewStates = new HashMap<>();
     }
 
     public void start() {
@@ -49,6 +54,7 @@ public class BrowsingSession {
     public void stop() {
         isActive = false;
         customTabConfig = null;
+        webViewStates.clear();
     }
 
     public boolean isActive() {
@@ -80,6 +86,30 @@ public class BrowsingSession {
         }
 
         customTabConfig = CustomTabConfig.parseCustomTabIntent(context, intent);
+    }
+
+    /**
+     * Keep a reference to this WebView state (saved in Bundle) linked to the given UUID so that
+     * we can restore it later.
+     */
+    public void putWebViewState(@NonNull String uuid, @NonNull Bundle bundle) {
+        webViewStates.put(uuid, bundle);
+    }
+
+    /**
+     * Get the WebView state saved linked to the given UUID or null if no such state exists.
+     */
+    @Nullable
+    public Bundle getWebViewState(@Nullable String uuid) {
+        return uuid != null ? webViewStates.get(uuid) : null;
+    }
+
+    /**
+     * Do we have a WebView state linked to the given UUID?
+     */
+    public boolean hasWebViewState(@Nullable String uuid) {
+        return uuid != null && webViewStates.containsKey(uuid);
+
     }
 
     public boolean isCustomTab() {

--- a/app/src/main/java/org/mozilla/focus/web/IWebView.java
+++ b/app/src/main/java/org/mozilla/focus/web/IWebView.java
@@ -106,9 +106,9 @@ public interface IWebView {
 
     boolean canGoBack();
 
-    void restoreWebviewState(Bundle savedInstanceState);
+    void restoreWebViewState(Bundle inState);
 
-    void onSaveInstanceState(Bundle outState);
+    void saveWebViewState(Bundle outState);
 
     /**
      * Get an icon (usually favicon) for the currently displayed website.


### PR DESCRIPTION
The issue in #651 is happening when WebView's state is too large to be saved in the state bundle that Android will take care of. Instead we are keeping the state in memory and only store a UUID in the state bundle.