### PR TITLE
Added correct telemetry for Download Dialog

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/DownloadDialogFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/DownloadDialogFragment.java
@@ -78,7 +78,7 @@ public class DownloadDialogFragment extends DialogFragment {
                     @Override
                     public void onClick(View v) {
                         sendDownloadDialogButtonClicked(pendingDownload, shouldDownload);
-                        TelemetryWrapper.downloadDialogDownloadEvent();
+                        TelemetryWrapper.downloadDialogDownloadEvent(shouldDownload);
                         dismiss();
                     }
                 });

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
@@ -65,7 +65,6 @@ public final class TelemetryWrapper {
         private static final String INTENT_CUSTOM_TAB = "intent_custom_tab";
         private static final String TEXT_SELECTION_INTENT = "text_selection_intent";
         private static final String SHOW = "show";
-        private static final String DOWNLOAD = "download";
     }
 
     private static class Object {
@@ -248,14 +247,13 @@ public final class TelemetryWrapper {
         event.queue();
     }
 
-    public static void downloadDialogDownloadEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.DOWNLOAD, Object.DOWNLOAD_DIALOG, Value.DOWNLOAD).queue();
+    public static void downloadDialogDownloadEvent(boolean sentToDownload) {
+        if (sentToDownload) {
+            TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.DOWNLOAD_DIALOG, Value.DOWNLOAD).queue();
+        } else {
+            TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.DOWNLOAD_DIALOG, Value.CANCEL_DOWNLOAD).queue();
+        }
     }
-
-    public static void downloadDialogCancelEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.DOWNLOAD, Object.DOWNLOAD_DIALOG, Value.CANCEL_DOWNLOAD).queue();
-    }
-
 
     public static void closeCustomTabEvent() {
         TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.CUSTOM_TAB_CLOSE_BUTTON).queue();


### PR DESCRIPTION
Realized I only added positive telemetry and we're not recording download dialog _cancel_ events. I also noticed the method should probably be "click" instead of "download" but if it's too difficult to change this because it's already "out in the wild" and would change telemetry reports, I can take that change out. 