### PR TITLE
Increase timing for lock icon detection

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/TypicalUseScenarioTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/TypicalUseScenarioTest.java
@@ -94,8 +94,8 @@ public class TypicalUseScenarioTest {
         TestHelper.pressEnterKey();
         TestHelper.webView.waitForExists(waitingTime);
         assertTrue (TestHelper.browserURLbar.getText().contains("https://www.google"));
-        TestHelper.lockIcon.waitForExists(waitingTime);
-        assertTrue (TestHelper.lockIcon.exists());
+        TestHelper.lockIcon.waitForExists(waitingTime * 2);
+        assertTrue (TestHelper.lockIcon.isEnabled());
 
         // Let's delete my history again
         TestHelper.floatingEraseButton.perform(click());


### PR DESCRIPTION
Let's try this for the intermittent test failure.  From the video, the lock icon is visible, yet the test was failing. If this doesn't fix it, we could remove the check for the presence of lock icon on https://