### PR TITLE
Codecov: Show coverage with higher precision and do not allow dropping more than 0.1%.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ codecov:
 comment: false
 
 coverage:
-  precision: 0
+  precision: 2
   round: down
   status:
     project:
@@ -13,7 +13,7 @@ coverage:
     patch:
       default:
         enabled: yes
-        threshold: 1
+        threshold: 0.1
         if_not_found: success
     changes:
       default:


### PR DESCRIPTION
A precision of 0 is way too low. We can't really see the changes (because it's often small). Also dropping coverage by 1% sounds scary. Let's try 0.1% - maybe that's too strict. Let's try!