### PR TITLE
Decode URI special characters before creating File - closes #1011

### DIFF
--- a/app/src/main/java/org/mozilla/focus/broadcastreceiver/DownloadBroadcastReceiver.java
+++ b/app/src/main/java/org/mozilla/focus/broadcastreceiver/DownloadBroadcastReceiver.java
@@ -63,11 +63,10 @@ public class DownloadBroadcastReceiver extends BroadcastReceiver {
                     final String localUri = uriString.startsWith(FILE_SCHEME) ? uriString.substring(FILE_SCHEME.length()) : uriString;
                     final String fileExtension = MimeTypeMap.getFileExtensionFromUrl(localUri);
                     final String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension);
-                    final String fileName = URLUtil.guessFileName(localUri, null, mimeType);
+                    final String fileName = URLUtil.guessFileName(Uri.decode(localUri), null, mimeType);
 
-                    final File file = new File(localUri);
+                    final File file = new File(Uri.decode(localUri));
                     final Uri uriForFile = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + FILE_PROVIDER_EXTENSION, file);
-
                     final Intent openFileIntent = IntentUtils.createOpenFileIntent(uriForFile, mimeType);
                     showSnackbarForFilename(openFileIntent, context, fileName);
                 }


### PR DESCRIPTION
In reference to (#1011), this includes a check to see if the file exists before showing the snackbar and I added Uri decoding to take care of special properties that should only appear in the Uri and not when creating the File or displaying the file name. 