### PR TITLE
Filter out Focus in the BottomSheet when "Open with..." is clicked #894

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/Browsers.java
+++ b/app/src/main/java/org/mozilla/focus/utils/Browsers.java
@@ -76,7 +76,7 @@ public class Browsers {
 
         final Uri uri = Uri.parse(url);
 
-        final Map<String, ActivityInfo> browsers = resolveBrowsers(packageManager, uri);
+        final Map<String, ActivityInfo> browsers = resolveBrowsers(context, packageManager, uri);
 
         // If there's a default browser set then modern Android systems won't return other browsers
         // anymore when using queryIntentActivities(). That's annoying and our only option is
@@ -102,7 +102,7 @@ public class Browsers {
         return null;
     }
 
-    private Map<String, ActivityInfo> resolveBrowsers(PackageManager packageManager, @NonNull Uri uri) {
+    private Map<String, ActivityInfo> resolveBrowsers(Context context, PackageManager packageManager, @NonNull Uri uri) {
         final Map<String, ActivityInfo> browsers = new HashMap<>();
 
         final Intent intent = new Intent(Intent.ACTION_VIEW);
@@ -111,7 +111,9 @@ public class Browsers {
         final List<ResolveInfo> infos = packageManager.queryIntentActivities(intent, 0);
 
         for (ResolveInfo info : infos) {
-            browsers.put(info.activityInfo.packageName, info.activityInfo);
+            if (!context.getPackageName().equals(info.activityInfo.packageName)) {
+                browsers.put(info.activityInfo.packageName, info.activityInfo);
+            }
         }
 
         return browsers;
@@ -190,7 +192,7 @@ public class Browsers {
      * Does this user have browsers installed that are not Focus, Firefox or the default browser?
      */
     public boolean hasMultipleThirdPartyBrowsers(Context context) {
-        if (browsers.size() > 2) {
+        if (browsers.size() > 1) {
             // There are more than us and Firefox.
             return true;
         }


### PR DESCRIPTION
Apply filter so that current app (Mozilla Focus or Gecko) is not included from Browsers' 'resolveBrowsers' method. This prevents the current app from ever having opportunity to be included in 'Open with...' menu. Additionally, provided very simple update to logic in 'hasMultipleThirdPartyBrowsers' - had to adjust to check for just two other browsers (as opposed to 3) since current browser is no longer contributing to list size.

Worth noting that this will still include Focus when using Gecko (and vice versa). Did not necessarily consider this a bug. In order to change this, I would adjust filter within resolveBrowsers to exclude both browsers based on commonality in package names (org.mozilla.focus is present in both). This is a sufficiently unique key which I feel would always appropriately filter out browsers, should it be decided that the sibling app not be included in browser list.

Created a new pull request as I am now working with a new (much better organized) repository.