### PR TITLE
Using color resource for inactive text for URL EditText hint

### DIFF
--- a/app/src/main/res/layout/fragment_urlinput.xml
+++ b/app/src/main/res/layout/fragment_urlinput.xml
@@ -90,7 +90,7 @@
                     android:selectAllOnFocus="true"
                     android:textColor="#ffffff"
                     android:textColorHighlight="@color/colorAutocompleteHighlight"
-                    android:textColorHint="#40ffffff"
+                    android:textColorHint="@color/inactive_text"
                     android:textSize="15sp" />
 
                 <ImageButton

--- a/app/src/main/res/layout/menu_blocking_switch.xml
+++ b/app/src/main/res/layout/menu_blocking_switch.xml
@@ -6,7 +6,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="80dp"
-    android:background="#262626"
+    android:background="#272727"
     android:gravity="center_vertical"
     android:orientation="horizontal"
     android:paddingEnd="0dp"
@@ -26,7 +26,7 @@
             android:ellipsize="end"
             android:maxLines="1"
             android:text="@string/menu_trackers_blocked_title"
-            android:textColor="#808080"
+            android:textColor="@color/inactive_text"
             android:textSize="16sp" />
 
         <LinearLayout

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -41,5 +41,5 @@
     <color name="add_to_homescreen_button_text">#FF00A4DC</color>
     <color name="add_to_homescreen_text">#FFFFFF</color>
 
-    <color name="inactive_text">#5FFFFFFF</color>
+    <color name="inactive_text">#7FFFFFFF</color>
 </resources>


### PR DESCRIPTION
Talked to @antlam about this and he wanted the URL input hint text color to match other inactive text color (50% white) which I added as a color resource in a previous PR. 