### PR TITLE
Restructure BrowserFragment layout to cast toolbar shadow and fix UI issues. (#1108, #785)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/animation/TransitionDrawableGroup.java
+++ b/app/src/main/java/org/mozilla/focus/animation/TransitionDrawableGroup.java
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.animation;
+
+import android.graphics.drawable.TransitionDrawable;
+
+/**
+ * A class to allow {@link TransitionDrawable}'s animations to play together: similar to {@link android.animation.AnimatorSet}.
+ */
+public class TransitionDrawableGroup {
+    private final TransitionDrawable[] transitionDrawables;
+
+    public TransitionDrawableGroup(TransitionDrawable... transitionDrawables) {
+        this.transitionDrawables = transitionDrawables;
+    }
+
+    public void startTransition(final int durationMillis) {
+        // In theory, there are no guarantees these will play together.
+        // In practice, I haven't noticed any problems.
+        for (final TransitionDrawable transitionDrawable : transitionDrawables) {
+            transitionDrawable.startTransition(durationMillis);
+        }
+    }
+
+    public void resetTransition() {
+        for (final TransitionDrawable transitionDrawable : transitionDrawables) {
+            transitionDrawable.resetTransition();
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -8,20 +8,21 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <FrameLayout
+    <LinearLayout
         android:id="@+id/browser_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
         <View
-            android:id="@+id/background"
+            android:id="@+id/status_bar_background"
             android:layout_width="match_parent"
-            android:layout_height="81dp"
+            android:layout_height="25dp"
             android:background="@drawable/animated_background" />
 
         <org.mozilla.focus.widget.ResizableKeyboardCoordinatorLayout
             app:viewToHideWhenActivated="@+id/erase"
-            android:layout_marginTop="25dp"
+            android:layout_marginTop="0dp"
             android:id="@+id/main_content"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -37,20 +38,21 @@
             <android.support.design.widget.AppBarLayout
                 android:id="@+id/appbar"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@android:color/transparent"
-                app:elevation="0dp"
+                android:layout_height="56dp"
                 android:clipChildren="false">
 
                 <FrameLayout
                     android:id="@+id/urlbar"
                     android:layout_width="match_parent"
                     android:layout_height="56dp"
+                    android:background="@drawable/animated_background"
                     android:elevation="4dp"
-                    app:layout_scrollFlags="scroll|enterAlways|snap"
+                    app:layout_scrollFlags="scroll|enterAlways|snap|exitUntilCollapsed"
                     android:clipChildren="false">
 
-                    <include layout="@layout/toolbar"/>
+                    <include
+                        android:id="@+id/toolbar_content"
+                        layout="@layout/toolbar"/>
 
                     <org.mozilla.focus.widget.AnimatedProgressBar
                         android:id="@+id/progress"
@@ -83,7 +85,7 @@
                 android:contentDescription="@string/content_description_erase" />
 
         </org.mozilla.focus.widget.ResizableKeyboardCoordinatorLayout>
-    </FrameLayout>
+    </LinearLayout>
 
     <FrameLayout
         android:id="@+id/video_container"

--- a/app/src/test/java/org/mozilla/focus/animation/TransitionDrawableGroupTest.java
+++ b/app/src/test/java/org/mozilla/focus/animation/TransitionDrawableGroupTest.java
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.animation;
+
+import android.graphics.drawable.TransitionDrawable;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(RobolectricTestRunner.class)
+public class TransitionDrawableGroupTest {
+    @Test
+    public void testStartIsCalledOnAllItems() {
+        final TransitionDrawable transitionDrawable1 = mock(TransitionDrawable.class);
+        final TransitionDrawable transitionDrawable2 = mock(TransitionDrawable.class);
+
+        final TransitionDrawableGroup group = new TransitionDrawableGroup(
+                transitionDrawable1, transitionDrawable2);
+
+        group.startTransition(2500);
+
+        verify(transitionDrawable1).startTransition(2500);
+        verify(transitionDrawable2).startTransition(2500);
+    }
+
+    @Test
+    public void testResetIsCalledOnAllItems() {
+        final TransitionDrawable transitionDrawable1 = mock(TransitionDrawable.class);
+        final TransitionDrawable transitionDrawable2 = mock(TransitionDrawable.class);
+
+        final TransitionDrawableGroup group = new TransitionDrawableGroup(
+                transitionDrawable1, transitionDrawable2);
+
+        group.resetTransition();
+
+        verify(transitionDrawable1).resetTransition();
+        verify(transitionDrawable2).resetTransition();
+    }
+}


### PR DESCRIPTION
With this change we'll always cast a toolbar shadow (#1108) and prevent the loading bar from
appearing before the toolbar (#785). Additionally it adds an alpha animation to the toolbar
content when scrolling so that it does not clash with the status bar.