### PR TITLE
Fixed Github link in License page (#1172)

### DIFF
--- a/app/src/main/assets/licenses.html
+++ b/app/src/main/assets/licenses.html
@@ -7,7 +7,7 @@
 
 <h1>Licenses</h1>
 
-<p><a href="https://github.com/mozilla/focus" target="_blank">github.com/mozilla/focus</a></p>
+<p><a href="https://github.com/mozilla-mobile/focus-android" target="_blank">github.com/mozilla-mobile/focus-android</a></p>
 <div>
 
 


### PR DESCRIPTION
Originally, the link redirected to the iOS repo. Now, it's been fixed and redirects to the Android repo.