### PR TITLE
UI tests with espresso

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -170,11 +170,15 @@ dependencies {
     testCompile "org.robolectric:robolectric:3.4.2"
     testCompile 'org.mockito:mockito-core:2.7.22'
 
-    androidTestCompile 'com.android.support.test.espresso:espresso-idling-resource:3.0.0'
     androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
+    androidTestCompile 'com.android.support.test.espresso:espresso-idling-resource:3.0.0'
+    androidTestCompile 'com.android.support.test.espresso:espresso-web:3.0.0', {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
+
     androidTestCompile 'com.squareup.okhttp3:mockwebserver:3.7.0'
 }
 

--- a/app/src/androidTest/assets/plain_test.html
+++ b/app/src/androidTest/assets/plain_test.html
@@ -6,7 +6,7 @@
     <title>gigantic experience</title>
 </head>
 <body>
-<h1>focus test page</h1>
+<h1 id="header">focus test page</h1>
 <!-- More random words that should not end up on disk -->
 <p>groovy rabbits</p>
 <p>This test page does nothing.</p>

--- a/app/src/androidTest/java/org/mozilla/focus/activity/URLMismatchTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/URLMismatchTest.java
@@ -20,10 +20,9 @@ import org.junit.runner.RunWith;
 import org.mozilla.focus.R;
 
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.clearText;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.pressImeActionButton;
-import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.action.ViewActions.replaceText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.hasFocus;
 import static android.support.test.espresso.matcher.ViewMatchers.isClickable;
@@ -71,7 +70,7 @@ public class URLMismatchTest {
         onView(withId(R.id.url_edit))
                 .check(matches(isDisplayed()))
                 .check(matches(hasFocus()))
-                .perform(typeText("mozilla"));
+                .perform(click(), replaceText("mozilla"));
 
         // Verify that the search hint is displayed and click it.
         onView(withId(R.id.search_hint))
@@ -92,7 +91,7 @@ public class URLMismatchTest {
 
         // Type "moz" - Verify that it auto-completes to "mozilla.org" and then load the website
         onView(withId(R.id.url_edit))
-                .perform(clearText(), typeText("moz"))
+                .perform(click(), replaceText("mozilla"))
                 .check(matches(withText("mozilla.org")))
                 .perform(pressImeActionButton());
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/URLMismatchTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/URLMismatchTest.java
@@ -8,41 +8,51 @@ package org.mozilla.focus.activity;
 import android.content.Context;
 import android.preference.PreferenceManager;
 import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.web.webdriver.Locator;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-import android.support.test.uiautomator.UiObject;
 import android.support.test.uiautomator.UiObjectNotFoundException;
-import android.support.test.uiautomator.UiSelector;
 
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mozilla.focus.R;
 
-import static android.view.KeyEvent.KEYCODE_A;
-import static android.view.KeyEvent.KEYCODE_I;
-import static android.view.KeyEvent.KEYCODE_L;
-import static android.view.KeyEvent.KEYCODE_M;
-import static android.view.KeyEvent.KEYCODE_O;
-import static android.view.KeyEvent.KEYCODE_Z;
-import static junit.framework.Assert.assertTrue;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.clearText;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.pressImeActionButton;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.hasFocus;
+import static android.support.test.espresso.matcher.ViewMatchers.isClickable;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static android.support.test.espresso.web.assertion.WebViewAssertions.webMatches;
+import static android.support.test.espresso.web.sugar.Web.onWebView;
+import static android.support.test.espresso.web.webdriver.DriverAtoms.findElement;
+import static android.support.test.espresso.web.webdriver.DriverAtoms.getText;
+import static org.hamcrest.Matchers.containsString;
 import static org.mozilla.focus.fragment.FirstrunFragment.FIRSTRUN_PREF;
 
 // This test checks whether URL and displayed site are in sync
 @RunWith(AndroidJUnit4.class)
 public class URLMismatchTest {
+    private static final String MOZILLA_WEBSITE_SLOGAN_SELECTOR = ".content h2";
+    private static final String MOZILLA_WEBSITE_SLOGAN_TEXT = "Internet for people,\nnot profit.";
 
     @Rule
-    public ActivityTestRule<MainActivity> mActivityTestRule
-            = new ActivityTestRule<MainActivity>(MainActivity.class) {
-
+    public ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<MainActivity>(MainActivity.class) {
         @Override
         protected void beforeActivityLaunched() {
             super.beforeActivityLaunched();
 
-            Context appContext = InstrumentationRegistry.getInstrumentation()
+            final Context appContext = InstrumentationRegistry.getInstrumentation()
                     .getTargetContext()
                     .getApplicationContext();
+
             PreferenceManager.getDefaultSharedPreferences(appContext)
                     .edit()
                     .putBoolean(FIRSTRUN_PREF, true)
@@ -57,40 +67,43 @@ public class URLMismatchTest {
 
     @Test
     public void MismatchTest() throws InterruptedException, UiObjectNotFoundException {
-        final long waitingTime = TestHelper.waitingTime * 3;
+        // Type "mozilla" into the URL bar.
+        onView(withId(R.id.url_edit))
+                .check(matches(isDisplayed()))
+                .check(matches(hasFocus()))
+                .perform(typeText("mozilla"));
 
-        UiObject mozillaLogo = TestHelper.mDevice.findObject(new UiSelector()
-                .className("android.webkit.WebView")
-                .description("Internet for people, not profit — Mozilla"));
+        // Verify that the search hint is displayed and click it.
+        onView(withId(R.id.search_hint))
+                .check(matches(isDisplayed()))
+                .check(matches(withText("Search for mozilla")))
+                .check(matches(isClickable()))
+                .perform(click());
 
-        // Search for mozilla
-        TestHelper.inlineAutocompleteEditText.waitForExists(waitingTime);
-        TestHelper.inlineAutocompleteEditText.clearTextField();
-        TestHelper.mDevice.pressKeyCode(KEYCODE_M);
-        TestHelper.mDevice.pressKeyCode(KEYCODE_O);
-        TestHelper.mDevice.pressKeyCode(KEYCODE_Z);
-        TestHelper.mDevice.pressKeyCode(KEYCODE_I);
-        TestHelper.mDevice.pressKeyCode(KEYCODE_L);
-        TestHelper.mDevice.pressKeyCode(KEYCODE_L);
-        TestHelper.mDevice.pressKeyCode(KEYCODE_A);
-        assertTrue(TestHelper.hint.getText().equals("Search for mozilla"));
-        TestHelper.hint.click();
-        TestHelper.webView.waitForExists(waitingTime);
-        assertTrue (TestHelper.browserURLbar.getText().contains("mozilla"));
+        // A WebView is displayed
+        onView(withId(R.id.webview))
+                .check(matches(isDisplayed()));
 
-        // Now, go to mozilla.org directly
-        TestHelper.browserURLbar.click();
-        TestHelper.inlineAutocompleteEditText.clearTextField();;
-        TestHelper.mDevice.pressKeyCode(KEYCODE_M);
-        TestHelper.mDevice.pressKeyCode(KEYCODE_O);
-        TestHelper.mDevice.pressKeyCode(KEYCODE_Z);
-        TestHelper.hint.waitForExists(waitingTime);
-        assertTrue (TestHelper.inlineAutocompleteEditText.getText().equals("mozilla.org"));
-        TestHelper.pressEnterKey();
+        // The displayed URL contains mozilla. Click on it to edit it again.
+        onView(withId(R.id.display_url))
+                .check(matches(isDisplayed()))
+                .check(matches(withText(containsString("mozilla"))))
+                .perform(click());
 
-        TestHelper.webView.waitForExists(waitingTime);
-        mozillaLogo.waitForExists(waitingTime);
-        assertTrue(TestHelper.browserURLbar.getText().contains("www.mozilla.org"));
-        assertTrue(mozillaLogo.exists());
+        // Type "moz" - Verify that it auto-completes to "mozilla.org" and then load the website
+        onView(withId(R.id.url_edit))
+                .perform(clearText(), typeText("moz"))
+                .check(matches(withText("mozilla.org")))
+                .perform(pressImeActionButton());
+
+        // Check we loaded the mozilla.org website
+        onWebView()
+                .withElement(findElement(Locator.CSS_SELECTOR, MOZILLA_WEBSITE_SLOGAN_SELECTOR))
+                .check(webMatches(getText(), containsString(MOZILLA_WEBSITE_SLOGAN_TEXT)));
+
+        // The displayed URL contains www.mozilla.org
+        onView(withId(R.id.display_url))
+                .check(matches(isDisplayed()))
+                .check(matches(withText(containsString("www.mozilla.org"))));
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/helpers/SessionLoadedIdlingResource.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/helpers/SessionLoadedIdlingResource.java
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.activity.helpers;
+
+import android.support.test.espresso.IdlingResource;
+
+import org.mozilla.focus.session.SessionManager;
+
+/**
+ * An IdlingResource implementation that waits until the current session is not loading anymore.
+ * Only after loading has completed further actions will be performed.
+ */
+public class SessionLoadedIdlingResource implements IdlingResource {
+    private ResourceCallback resourceCallback;
+
+    @Override
+    public String getName() {
+        return SessionLoadedIdlingResource.class.getSimpleName();
+    }
+
+    @Override
+    public boolean isIdleNow() {
+        final SessionManager sessionManager = SessionManager.getInstance();
+        if (!sessionManager.hasSession()) {
+            invokeCallback();
+            return true;
+        }
+
+        if (sessionManager.getCurrentSession().getLoading().getValue()) {
+            return false;
+        } else {
+            invokeCallback();
+            return true;
+        }
+    }
+
+    private void invokeCallback() {
+        if (resourceCallback != null) {
+            resourceCallback.onTransitionToIdle();
+        }
+    }
+
+    @Override
+    public void registerIdleTransitionCallback(ResourceCallback callback) {
+        this.resourceCallback = callback;
+    }
+}

--- a/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
@@ -51,10 +51,10 @@ import java.util.Map;
      * e.g. onLoadResource().)
      */
     private static final String CLEAR_VISITED_CSS =
-            "let nSheets = document.styleSheets.length;" +
+            "var nSheets = document.styleSheets.length;" +
             "for (s=0; s < nSheets; s++) {" +
-            "  let stylesheet = document.styleSheets[s];" +
-            "  let nRules = stylesheet.cssRules ? stylesheet.cssRules.length : 0;" +
+            "  var stylesheet = document.styleSheets[s];" +
+            "  var nRules = stylesheet.cssRules ? stylesheet.cssRules.length : 0;" +
             // rules need to be removed by index. That modifies the whole list - it's easiest
             // to therefore process the list from the back, so that we don't need to care about
             // indexes changing after deletion (all indexes before the removed item are unchanged,
@@ -62,11 +62,11 @@ import java.util.Map;
             // moving in the other direction we'd need to remember to process a given index
             // again which is more complicated).
             "  for (i = nRules - 1; i >= 0; i--) {" +
-            "    let cssRule = stylesheet.cssRules[i];" +
+            "    var cssRule = stylesheet.cssRules[i];" +
             // Depending on style type, there might be no selector
             "    if (cssRule.selectorText && cssRule.selectorText.includes(':visited')) {" +
-            "      let tokens = cssRule.selectorText.split(',');" +
-            "      let j = tokens.length;" +
+            "      var tokens = cssRule.selectorText.split(',');" +
+            "      var j = tokens.length;" +
             "      while (j--) {" +
             "        if (tokens[j].includes(':visited')) {" +
             "          tokens.splice(j, 1);" +
@@ -94,7 +94,7 @@ import java.util.Map;
 
                 // Add an onLoad() listener so that we run the cleanup script every time
                 // a <link>'d css stylesheet is loaded:
-                "let links = document.getElementsByTagName('link');" +
+                "var links = document.getElementsByTagName('link');" +
                 "for (i = 0; i < links.length; i++) {" +
                 "  link = links[i];" +
                 "  if (link.rel == 'stylesheet') {" +


### PR DESCRIPTION
I updated the espresso dependencies and re-wrote some tests as pure espresso tests. No need to use uiautomator when we are only testing *inside* our app. The tests seem to be much more stable now.

I saw some issues with out autocomplete field. Espresso is typing so far that the text and the autocompleted strings somehow get mixed. I haven't seen this happening locally though - so let's see how this performs on buddybuild.