### PR TITLE
Removing superfluous shortcut intent from manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,11 +64,6 @@
                 <data android:mimeType="text/plain" />
             </intent-filter>
 
-            <intent-filter> 
-                <action android:name="android.intent.action.CREATE_SHORTCUT" />
-                 <category android:name="android.intent.category.DEFAULT" /> 
-            </intent-filter>
-
             <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts" />
         </activity>
 


### PR DESCRIPTION
This manifest intent is not necessary for Android O Add to Home screen, but I included it 