### PR TITLE
Handle encoded content-disposition headers correctly (#1165)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -63,6 +63,7 @@ import org.mozilla.focus.session.ui.SessionsSheetFragment;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.utils.Browsers;
 import org.mozilla.focus.utils.ColorUtils;
+import org.mozilla.focus.utils.DownloadUtils;
 import org.mozilla.focus.utils.DrawableUtils;
 import org.mozilla.focus.utils.UrlUtils;
 import org.mozilla.focus.web.Download;
@@ -675,8 +676,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
         }
 
         final String cookie = CookieManager.getInstance().getCookie(download.getUrl());
-        final String fileName = URLUtil.guessFileName(
-                download.getUrl(), download.getContentDisposition(), download.getMimeType());
+        final String fileName = DownloadUtils.guessFileName(download);
 
         final DownloadManager.Request request = new DownloadManager.Request(Uri.parse(download.getUrl()))
                 .addRequestHeader("User-Agent", download.getUserAgent())

--- a/app/src/main/java/org/mozilla/focus/fragment/DownloadDialogFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/DownloadDialogFragment.java
@@ -19,6 +19,7 @@ import android.widget.TextView;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
+import org.mozilla.focus.utils.DownloadUtils;
 import org.mozilla.focus.web.Download;
 
 /**
@@ -31,8 +32,7 @@ public class DownloadDialogFragment extends DialogFragment {
         DownloadDialogFragment frag = new DownloadDialogFragment();
         final Bundle args = new Bundle();
 
-        String fileName = URLUtil.guessFileName(
-                download.getUrl(), download.getContentDisposition(), download.getMimeType());
+        String fileName = DownloadUtils.guessFileName(download);
 
         args.putString("fileName", fileName);
         args.putParcelable("download", download);

--- a/app/src/main/java/org/mozilla/focus/utils/DownloadUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/DownloadUtils.java
@@ -1,0 +1,199 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 20; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *   Copyright (C) 2006 The Android Open Source Project
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License. */
+
+package org.mozilla.focus.utils;
+
+import android.net.Uri;
+import android.support.annotation.Nullable;
+import android.webkit.MimeTypeMap;
+
+import org.mozilla.focus.web.Download;
+
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DownloadUtils {
+
+    /**
+     * Guess the name of the file that should be downloaded.
+     *
+     * This method is largely identical to {@link android.webkit.URLUtil#guessFileName}
+     * which unfortunately does not implement RfC 5987.
+     *
+     * @param download the Download object containing information about the request
+     * @return file name including extension
+     */
+    public static String guessFileName(Download download) {
+        String contentDisposition = download.getContentDisposition();
+        String url = download.getUrl();
+        String mimeType = download.getMimeType();
+
+        String filename = null;
+        String extension = null;
+
+        // Extract file name from content disposition header field
+        if (contentDisposition != null) {
+            filename = parseContentDisposition(contentDisposition);
+            if (filename != null) {
+                int index = filename.lastIndexOf('/') + 1;
+                if (index > 0) {
+                    filename = filename.substring(index);
+                }
+            }
+        }
+
+        // If all the other http-related approaches failed, use the plain uri
+        if (filename == null) {
+            String decodedUrl = Uri.decode(url);
+            if (decodedUrl != null) {
+                int queryIndex = decodedUrl.indexOf('?');
+                // If there is a query string strip it, same as desktop browsers
+                if (queryIndex > 0) {
+                    decodedUrl = decodedUrl.substring(0, queryIndex);
+                }
+                if (!decodedUrl.endsWith("/")) {
+                    int index = decodedUrl.lastIndexOf('/') + 1;
+                    if (index > 0) {
+                        filename = decodedUrl.substring(index);
+                    }
+                }
+            }
+        }
+
+        // Finally, if couldn't get filename from URI, get a generic filename
+        if (filename == null) {
+            filename = "downloadfile";
+        }
+
+        // Split filename between base and extension
+        // Add an extension if filename does not have one
+        int dotIndex = filename.indexOf('.');
+        if (dotIndex < 0) {
+            if (mimeType != null) {
+                extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+                if (extension != null) {
+                    extension = "." + extension;
+                }
+            }
+            if (extension == null) {
+                if (mimeType != null && mimeType.toLowerCase(Locale.ROOT).startsWith("text/")) {
+                    if (mimeType.equalsIgnoreCase("text/html")) {
+                        extension = ".html";
+                    } else {
+                        extension = ".txt";
+                    }
+                } else {
+                    extension = ".bin";
+                }
+            }
+        } else {
+            if (mimeType != null) {
+                // Compare the last segment of the extension against the mime type.
+                // If there's a mismatch, discard the entire extension.
+                int lastDotIndex = filename.lastIndexOf('.');
+                String typeFromExt = MimeTypeMap.getSingleton().getMimeTypeFromExtension(
+                        filename.substring(lastDotIndex + 1));
+                if (typeFromExt != null && !typeFromExt.equalsIgnoreCase(mimeType)) {
+                    extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+                    if (extension != null) {
+                        extension = "." + extension;
+                    }
+                }
+            }
+            if (extension == null) {
+                extension = filename.substring(dotIndex);
+            }
+            filename = filename.substring(0, dotIndex);
+        }
+
+        return filename + extension;
+    }
+
+    /**
+     * Format as defined in RFC 2616 and RFC 5987
+     * Only the attachment type is supported.
+     */
+    private static final Pattern CONTENT_DISPOSITION_PATTERN =
+            Pattern.compile("attachment\\s*;\\s*filename\\s*=\\s*" +
+                            "(\"((?:\\\\.|[^\"\\\\])*)\"|[^;]*)\\s*" +
+                            "(?:;\\s*filename\\*\\s*=\\s*(utf-8|iso-8859-1)'[^']*'(\\S*))?",
+                    Pattern.CASE_INSENSITIVE);
+
+    @Nullable
+    private static String parseContentDisposition(String contentDisposition) {
+        try {
+            Matcher m = CONTENT_DISPOSITION_PATTERN.matcher(contentDisposition);
+
+            if (m.find()) {
+                // If escaped string is found, decode it using the given encoding.
+                String encodedFileName = m.group(4);
+                String encoding = m.group(3);
+
+                if (encodedFileName != null) {
+                    return decodeHeaderField(encodedFileName, encoding);
+                }
+
+                // Return quoted string if available and replace escaped characters.
+                String quotedFileName = m.group(2);
+
+                if (quotedFileName != null) {
+                    return quotedFileName.replaceAll("\\\\(.)", "$1");
+                }
+
+                // Otherwise try to extract the unquoted file name
+                return m.group(1);
+            }
+        } catch (IllegalStateException | UnsupportedEncodingException ex) {
+            // This function is defined as returning null when it can't parse the header
+        }
+
+        return null;
+    }
+
+    /**
+     * Definition as per RFC 5987, section 3.2.1. (value-chars)
+     */
+    private static final Pattern ENCODED_SYMBOL_PATTERN =
+            Pattern.compile("%[0-9a-f]{2}|[0-9a-z!#$&+-.^_`|~]", Pattern.CASE_INSENSITIVE);
+
+    private static String decodeHeaderField(String field, String encoding)
+            throws UnsupportedEncodingException {
+        Matcher m = ENCODED_SYMBOL_PATTERN.matcher(field);
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+
+        while (m.find()) {
+            String symbol = m.group();
+
+            if (symbol.startsWith("%")) {
+                stream.write(Integer.parseInt(symbol.substring(1), 16));
+            } else {
+                stream.write(symbol.charAt(0));
+            }
+        }
+
+        return stream.toString(encoding);
+    }
+
+}

--- a/app/src/test/java/org/mozilla/focus/utils/DownloadUtilsTest.java
+++ b/app/src/test/java/org/mozilla/focus/utils/DownloadUtilsTest.java
@@ -1,0 +1,81 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.utils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mozilla.focus.web.Download;
+import org.robolectric.RobolectricTestRunner;
+
+import static junit.framework.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+public class DownloadUtilsTest {
+
+    private static void assertContentDisposition(String expected, String contentDisposition) {
+        Download download = new Download(null, null, contentDisposition, null, 0, null);
+        assertEquals(expected, DownloadUtils.guessFileName(download));
+    }
+
+    @Test
+    public void testGuessFileName_contentDisposition() {
+        // Default file name
+        assertContentDisposition("downloadfile.bin", "");
+        assertContentDisposition("downloadfile.bin", "attachment");
+        assertContentDisposition("downloadfile.bin", "attachment;");
+        assertContentDisposition("downloadfile.bin", "attachment; filename");
+        assertContentDisposition(".bin", "attachment; filename=");
+        assertContentDisposition(".bin", "attachment; filename=\"\"");
+
+        // Provided filename field
+        assertContentDisposition("filename.jpg", "attachment; filename=\"filename.jpg\"");
+        assertContentDisposition("file\"name.jpg", "attachment; filename=\"file\\\"name.jpg\"");
+        assertContentDisposition("file\\name.jpg", "attachment; filename=\"file\\\\name.jpg\"");
+        assertContentDisposition("file\\\"name.jpg", "attachment; filename=\"file\\\\\\\"name.jpg\"");
+        assertContentDisposition("filename.jpg", "attachment; filename=filename.jpg");
+        assertContentDisposition("filename.jpg", "attachment; filename=filename.jpg; foo");
+        assertContentDisposition("filename.jpg", "attachment; filename=\"filename.jpg\"; foo");
+
+        // UTF-8 encoded filename* field
+        assertContentDisposition("\uD83E\uDD8A + x.jpg",
+                "attachment; filename=\"_.jpg\"; filename*=utf-8'en'%F0%9F%A6%8A%20+%20x.jpg");
+        assertContentDisposition("filename 的副本.jpg",
+                "attachment;filename=\"_.jpg\";" +
+                "filename*=UTF-8''filename%20%E7%9A%84%E5%89%AF%E6%9C%AC.jpg");
+        assertContentDisposition("filename.jpg",
+                "attachment; filename=_.jpg; filename*=utf-8'en'filename.jpg");
+
+        // ISO-8859-1 encoded filename* field
+        assertContentDisposition("file' 'name.jpg",
+                "attachment; filename=\"_.jpg\"; filename*=iso-8859-1'en'file%27%20%27name.jpg");
+    }
+
+    private static void assertUrl(String expected, String url) {
+        Download download = new Download(url, null, null, null, 0, null);
+        assertEquals(expected, DownloadUtils.guessFileName(download));
+    }
+
+    @Test
+    public void testGuessFileName_url() {
+        assertUrl("downloadfile.bin", "http://example.com/");
+        assertUrl("downloadfile.bin", "http://example.com/filename/");
+        assertUrl("filename.jpg", "http://example.com/filename.jpg");
+        assertUrl("filename.jpg", "http://example.com/foo/bar/filename.jpg");
+    }
+
+    private static void assertMimeType(String expected, String mimeType) {
+        Download download = new Download("ftp://example.url/test", null, null, mimeType, 0, null);
+        assertEquals(expected, DownloadUtils.guessFileName(download));
+    }
+
+    @Test
+    public void testGuessFileName_mimeType() {
+        assertMimeType("test.html", "text/html");
+        assertMimeType("test.txt", "text/plain");
+        assertMimeType("test.jpg", "image/jpeg");
+        assertMimeType("test.bin", "application/octet-stream");
+    }
+}


### PR DESCRIPTION
This commit copies a method from android.webkit.URLUtil
and modifies it to handle the Content-Disposition header
correctly.

Quoted strings now also support backslash-escaped characters
and RFC 5987 is implemented to support UTF-8 or ISO-8859-1
encoded filenames.

Furthermore, tests have been added for various kinds of
Content-Disposition header values.

Fixes #1165 

---

I added the Apache 2 license header to the new class because the `guessFileName` method is largely copied from the Android source code. This follows the guidelines as described here: https://www.mozilla.org/en-US/MPL/2.0/permissive-code-into-mpl/ (Section 3)
