### PR TITLE
Address bar regression (#1304)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/session/SessionCallbackProxy.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionCallbackProxy.java
@@ -56,6 +56,10 @@ public class SessionCallbackProxy implements IWebView.Callback {
     @Override
     public void onURLChanged(String url) {
         session.setUrl(url);
+        if (session.isSearch()) {
+            session.setSearch(false);
+            session.setSearchUrl(url);
+        }
     }
 
 


### PR DESCRIPTION
Takes care of case where user clicks link before URL bar and we need to setSearch for current session to false. 