### PR TITLE
Keep search terms until a new page is loaded triggered by a user gesture. (#1304)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -409,6 +409,9 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
             public void onURLChanged(final String url) {}
 
             @Override
+            public void onRequest(boolean isTriggeredByUserGesture) {}
+
+            @Override
             public void onProgress(int progress) {}
 
             @Override

--- a/app/src/main/java/org/mozilla/focus/fragment/InfoFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/InfoFragment.java
@@ -93,6 +93,9 @@ public class InfoFragment extends WebFragment {
             public void onURLChanged(String url) {}
 
             @Override
+            public void onRequest(boolean isTriggeredByUserGesture) {}
+
+            @Override
             public void onEnterFullScreen(@NonNull IWebView.FullscreenCallback callback, @Nullable View view) {}
 
             @Override

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.java
@@ -183,48 +183,15 @@ public class UrlInputFragment extends LocaleAwareFragment implements View.OnClic
 
         urlView.setOnCommitListener(this);
 
-        // Should we show the search terms or a URL in the urlView?
         if (session != null) {
-            final String searchURL = session.getSearchUrl();
-            final String currentURL = session.getUrl().getValue();
-            final String searchTerms = session.getSearchTerms();
-            if (!TextUtils.isEmpty(currentURL)) {
-                // If there was just a search, session will have true value for isSearch.
-                // Show search terms and set wasSearch to false so user won't see search terms if they navigate away from this page via links.
-                // Save the currentURL to the session as searchURL to compare searchURL to currentURL in the future to show search terms.
-                if (session.isSearch()) {
-                    showSearchTerms(urlView, session, searchTerms, currentURL);
-                } else if (!TextUtils.isEmpty(searchURL) && searchURL.equals(currentURL)) {
-                    // If searchURL saved in session matches the currentURL of the page, we should show the search terms instead of the URL.
-                    // We don't need to update anything in the session.
-                    showSearchTermsFromURLMatch(urlView, searchTerms, currentURL);
-                } else {
-                    // It was not a new search and currentURL doesn't match searchURL for session, let's show the URL.
-                    urlView.setText(currentURL);
-                }
+                urlView.setText(session.isSearch()
+                    ? session.getSearchTerms()
+                    : session.getUrl().getValue());
+
                 clearView.setVisibility(View.VISIBLE);
-            }
         }
 
         return view;
-    }
-
-    private void showSearchTerms(InlineAutocompleteEditText urlView, Session session, String searchTerms, String currentURL) {
-        if (!TextUtils.isEmpty(searchTerms)) {
-            urlView.setText(searchTerms);
-            session.setSearch(false);
-            session.setSearchUrl(currentURL);
-        } else {
-            urlView.setText(currentURL);
-        }
-    }
-
-    private void showSearchTermsFromURLMatch(InlineAutocompleteEditText urlView, String searchTerms, String currentURL) {
-        if ((!TextUtils.isEmpty(searchTerms))) {
-            urlView.setText(searchTerms);
-        } else {
-            urlView.setText(currentURL);
-        }
     }
 
     @Override
@@ -526,7 +493,6 @@ public class UrlInputFragment extends LocaleAwareFragment implements View.OnClic
 
     private void openUrl(String url, boolean isSearch, String searchTerms) {
         if (session != null) {
-            session.setSearch(isSearch);
             session.setSearchTerms(searchTerms);
         }
 
@@ -550,7 +516,7 @@ public class UrlInputFragment extends LocaleAwareFragment implements View.OnClic
                     .commit();
         } else {
             if (!TextUtils.isEmpty(searchTerms)) {
-                SessionManager.getInstance().createSession(Source.USER_ENTERED, url, isSearch, searchTerms);
+                SessionManager.getInstance().createSearchSession(Source.USER_ENTERED, url, searchTerms);
             } else {
                 SessionManager.getInstance().createSession(Source.USER_ENTERED, url);
             }

--- a/app/src/main/java/org/mozilla/focus/session/Session.java
+++ b/app/src/main/java/org/mozilla/focus/session/Session.java
@@ -6,6 +6,7 @@ package org.mozilla.focus.session;
 
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import org.mozilla.focus.architecture.NonNullLiveData;
 import org.mozilla.focus.architecture.NonNullMutableLiveData;
@@ -29,7 +30,6 @@ public class Session {
     private String searchTerms;
     private String searchUrl;
     private boolean isRecorded;
-    private boolean isSearch;
     private boolean isBlockingEnabled;
 
     /* package */ Session(Source source, String url) {
@@ -96,6 +96,10 @@ public class Session {
         this.trackersBlocked.postValue(trackersBlocked);
     }
 
+    /* package */ void clearSearchTerms() {
+        searchTerms = null;
+    }
+
     public NonNullLiveData<Integer> getBlockedTrackers() {
         return trackersBlocked;
     }
@@ -129,11 +133,7 @@ public class Session {
     }
 
     public boolean isSearch() {
-        return isSearch;
-    }
-
-    public void setSearch(boolean isSearch) {
-        this.isSearch = isSearch;
+        return !TextUtils.isEmpty(searchTerms);
     }
 
     public void setSearchTerms(String searchTerms) {

--- a/app/src/main/java/org/mozilla/focus/session/SessionCallbackProxy.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionCallbackProxy.java
@@ -58,6 +58,14 @@ public class SessionCallbackProxy implements IWebView.Callback {
         session.setUrl(url);
     }
 
+    @Override
+    public void onRequest(boolean isTriggeredByUserGesture) {
+        if (isTriggeredByUserGesture && session.isSearch()) {
+            // The user actively navigated away (no redirect) from the search page. Clear the
+            // search terms.
+            session.clearSearchTerms();
+        }
+    }
 
     @Override
     public void countBlockedTracker() {

--- a/app/src/main/java/org/mozilla/focus/session/SessionManager.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionManager.java
@@ -80,11 +80,16 @@ public class SessionManager {
             final String dataString = intent.getStringExtra(Intent.EXTRA_TEXT);
             if (!TextUtils.isEmpty(dataString)) {
                 final boolean isSearch = !UrlUtils.isUrl(dataString);
+
                 final String url = isSearch
                         ? UrlUtils.createSearchUrl(context, dataString)
                         : dataString;
 
-                createSession(Source.SHARE, url, isSearch);
+                if (isSearch) {
+                    createSearchSession(Source.SHARE, url, dataString);
+                } else {
+                    createSession(Source.SHARE, url);
+                }
             }
         }
     }
@@ -160,15 +165,8 @@ public class SessionManager {
         addSession(session);
     }
 
-    private void createSession(@NonNull Source source, @NonNull String url, boolean isSearch) {
+    public void createSearchSession(@NonNull Source source, @NonNull String url, String searchTerms) {
         final Session session = new Session(source, url);
-        session.setSearch(isSearch);
-        addSession(session);
-    }
-
-    public void createSession(@NonNull Source source, @NonNull String url, boolean isSearch, String searchTerms) {
-        final Session session = new Session(source, url);
-        session.setSearch(isSearch);
         session.setSearchTerms(searchTerms);
         addSession(session);
     }

--- a/app/src/main/java/org/mozilla/focus/web/IWebView.java
+++ b/app/src/main/java/org/mozilla/focus/web/IWebView.java
@@ -43,6 +43,8 @@ public interface IWebView {
 
         void onURLChanged(final String url);
 
+        void onRequest(final boolean isTriggeredByUserGesture);
+
         void onDownloadStart(Download download);
 
         void onLongPress(final HitTarget hitTarget);

--- a/app/src/test/java/org/mozilla/focus/session/SessionManagerTest.java
+++ b/app/src/test/java/org/mozilla/focus/session/SessionManagerTest.java
@@ -152,6 +152,28 @@ public class SessionManagerTest {
         assertTrue(sessionManager.hasSession());
     }
 
+    public void testShareIntentWithTextViaNewIntent() {
+        final SessionManager sessionManager = SessionManager.getInstance();
+
+        final Intent unsafeIntent = new Intent(Intent.ACTION_SEND);
+        unsafeIntent.putExtra(Intent.EXTRA_TEXT, "Hello World Focus");
+
+        sessionManager.handleNewIntent(RuntimeEnvironment.application, new SafeIntent(unsafeIntent));
+
+        final List<Session> sessions = sessionManager.getSessions().getValue();
+        assertNotNull(sessions);
+        assertEquals(1, sessions.size());
+
+        final Session session = sessions.get(0);
+        assertTrue(session.isSearch());
+        assertEquals("Hello World Focus", session.getSearchTerms());
+        assertEquals(TEST_URL, session.getUrl().getValue());
+        assertFalse(session.isCustomTab());
+        assertNull(session.getCustomTabConfig());
+
+        assertTrue(sessionManager.hasSession());
+    }
+
     @Test(expected = IllegalAccessError.class)
     public void getCurrentSessionThrowsExceptionIfThereIsNoSession() {
         final SessionManager sessionManager = SessionManager.getInstance();

--- a/app/src/test/java/org/mozilla/focus/session/SessionTest.java
+++ b/app/src/test/java/org/mozilla/focus/session/SessionTest.java
@@ -168,10 +168,16 @@ public class SessionTest {
         final Session session = new Session(Source.VIEW, TEST_URL);
         assertFalse(session.isSearch());
 
-        session.setSearch(true);
+        session.setSearchTerms("hello world");
         assertTrue(session.isSearch());
 
-        session.setSearch(false);
+        session.clearSearchTerms();
+        assertFalse(session.isSearch());
+
+        session.setSearchTerms(null);
+        assertFalse(session.isSearch());
+
+        session.setSearchTerms("");
         assertFalse(session.isSearch());
     }
 

--- a/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
+++ b/app/src/webkit/java/org/mozilla/focus/webkit/FocusWebViewClient.java
@@ -5,34 +5,22 @@
 package org.mozilla.focus.webkit;
 
 import android.content.Context;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
-import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.net.http.SslCertificate;
 import android.net.http.SslError;
 import android.os.Bundle;
-import android.support.v4.util.ArrayMap;
-import android.support.v4.view.ViewCompat;
 import android.text.TextUtils;
-import android.view.View;
 import android.webkit.SslErrorHandler;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import org.mozilla.focus.R;
 import org.mozilla.focus.browser.LocalizedContent;
-import org.mozilla.focus.locale.Locales;
-import org.mozilla.focus.utils.HtmlLoader;
 import org.mozilla.focus.utils.IntentUtils;
-import org.mozilla.focus.utils.SupportUtils;
 import org.mozilla.focus.utils.UrlUtils;
 import org.mozilla.focus.web.IWebView;
-
-import java.util.Map;
 
 /**
  * WebViewClient layer that handles browser specific WebViewClient functionality, such as error pages
@@ -43,15 +31,12 @@ import java.util.Map;
     private static final String STATE_KEY_URL = "client_last_url";
     private static final String STATE_KEY_CERTIFICATE = "client_last_certificate";
 
-    private boolean errorReceived;
-    private Context context;
-
     private String restoredUrl;
     private SslCertificate restoredCertificate;
+    private boolean errorReceived;
 
     /* package */ FocusWebViewClient(Context context) {
         super(context);
-        this.context = context;
     }
 
     /**
@@ -119,7 +104,7 @@ import java.util.Map;
     }
 
     @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    public WebResourceResponse shouldInterceptRequest(WebView view, final WebResourceRequest request) {
         // Only update the user visible URL if:
         // 1. The purported site URL has actually been requested
         // 2. And it's being loaded for the main frame (and not a fake/hidden/iframe request)
@@ -143,6 +128,10 @@ import java.util.Map;
                         }
                     }
                 });
+            }
+
+            if (callback != null) {
+                callback.onRequest(request.hasGesture());
             }
         }
 


### PR DESCRIPTION
@ekager Does this make sense?

With that we keep displaying the search term until the user has loaded a new page after clicking something etc. It looks like with that we can remove the code in the UrlInputFragment. We would loose the ability to navigate back to a search page and then display the search terms again - but I guess that's fine...