### PR TITLE
Close individual tabs by long pressing

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -296,6 +296,13 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
         final FloatingSessionsButton tabsButton = view.findViewById(R.id.tabs);
         tabsButton.setOnClickListener(this);
+        tabsButton.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View view) {
+                SessionManager.getInstance().removeAllSessions();
+                return true;
+            }
+        });
 
         sessionManager.getSessions().observe(this, new NonNullObserver<List<Session>>() {
             @Override

--- a/app/src/main/java/org/mozilla/focus/session/ui/SessionViewHolder.java
+++ b/app/src/main/java/org/mozilla/focus/session/ui/SessionViewHolder.java
@@ -36,6 +36,13 @@ public class SessionViewHolder extends RecyclerView.ViewHolder implements View.O
 
         textView = (TextView) itemView;
         textView.setOnClickListener(this);
+        textView.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View view) {
+                SessionManager.getInstance().removeCurrentSession();
+                return true;
+            }
+        });
     }
 
     /* package */ void bind(Session session) {


### PR DESCRIPTION
Currently, there's no way to close an individual tab, but to repeatedly press the back button until it closes. I've implemented a more user-intuitive way, in which the user just has to long press the tab and it will be closed.

Also, the process of closing all tabs requires two clicks at the moment. I've implemented the same functionality to close all tabs, in which the floating action button needs to be long pressed to close all tabs, which is more user-intuitive.

Closes #1362 