### PR TITLE
Change deprecated method

### DIFF
--- a/app/src/gecko/java/org/mozilla/focus/web/NestedGeckoView.java
+++ b/app/src/gecko/java/org/mozilla/focus/web/NestedGeckoView.java
@@ -6,7 +6,6 @@
 package org.mozilla.focus.web;
 
 import android.content.Context;
-import android.support.v4.view.MotionEventCompat;
 import android.support.v4.view.NestedScrollingChild;
 import android.support.v4.view.NestedScrollingChildHelper;
 import android.support.v4.view.ViewCompat;
@@ -35,7 +34,7 @@ public class NestedGeckoView extends GeckoView implements NestedScrollingChild {
         boolean eventHandled = false;
 
         final MotionEvent event = MotionEvent.obtain(ev);
-        final int action = MotionEventCompat.getActionMasked(event);
+        final int action = event.getActionMasked();
         if (action == MotionEvent.ACTION_DOWN) {
             mNestedOffsetY = 0;
         }


### PR DESCRIPTION
I changed the method which is deprecated from API level 26. I refer the documents below.
https://developer.android.com/reference/android/support/v4/view/MotionEventCompat.html#getActionMasked(android.view.MotionEvent)

It seems working well, but if there is any problem please don't hesitate to work on.
Thanks.