### PR TITLE
add link/image to README to point to F-Droid download page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@
 _Browse like no one’s watching. The new Firefox Focus automatically blocks a wide range of online trackers — from the moment you launch it to the second you leave it. Easily erase your history, passwords and cookies, so you won’t get followed by things like unwanted ads._
 
 <a href="https://play.google.com/store/apps/details?id=org.mozilla.focus" target="_blank"><img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" alt="Get it on Google Play" height="90"/></a>
+<a href="https://f-droid.org/packages/org.mozilla.klar" target="_blank"><img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="90"/></a>
+
 
 * [Google Play: Firefox Focus (All countries)](https://play.google.com/store/apps/details?id=org.mozilla.focus)
 * [Google Play: Firefox Klar (Germany, Austria, Switzerland)](https://play.google.com/store/apps/details?id=org.mozilla.klar)
+* [F-Droid: Firefox Klar](https://f-droid.org/app/org.mozilla.klar)
 * [Download APKs](https://github.com/mozilla-mobile/focus-android/releases)
 
 Getting Involved


### PR DESCRIPTION
Please include F-Droid as one of the options for getting Mozilla Klar.

Firefox Klar has been included in F-Droid since 2017-07-04, built directly from source using the official build system.  As with all apps included in f-droid.org, we also run our automatic verification process on it, you can see Klar diffs here:

* https://verification.f-droid.org/org.mozilla.klar_11.apk.diffoscope.html
* https://verification.f-droid.org/org.mozilla.klar_10.apk.diffoscope.html

It is also possible to include the Mozilla APK signature in f-droid.org provided that Klar builds reproducibly.  We test this by building from source on our own infrastructure, then copying the developer's APK signature into our APK.  If it verifies, we ship it.