### PR TITLE
Added shortcut to erase history and open browser - #1009

### DIFF
--- a/app/src/focusBeta/res/xml-v25/shortcuts.xml
+++ b/app/src/focusBeta/res/xml-v25/shortcuts.xml
@@ -16,4 +16,17 @@
                 <extra android:name="shortcut" android:value="true" />
         </intent>
     </shortcut>
+    <shortcut
+        android:shortcutId="restart"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_erase"
+        android:shortcutShortLabel="@string/shortcut_erase_and_start_short_label"
+        android:shortcutLongLabel="@string/shortcut_erase_and_start_long_label">
+        <intent
+            android:action="erase"
+            android:targetPackage="org.mozilla.focus.beta"
+            android:targetClass="org.mozilla.focus.activity.MainActivity">
+            <extra android:name="shortcut" android:value="true" />
+        </intent>
+    </shortcut>
 </shortcuts>

--- a/app/src/focusDebug/res/xml-v25/shortcuts.xml
+++ b/app/src/focusDebug/res/xml-v25/shortcuts.xml
@@ -16,4 +16,17 @@
                 <extra android:name="shortcut" android:value="true" />
         </intent>
     </shortcut>
+    <shortcut
+        android:shortcutId="restart"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_erase"
+        android:shortcutShortLabel="@string/shortcut_erase_and_start_short_label"
+        android:shortcutLongLabel="@string/shortcut_erase_and_start_long_label">
+        <intent
+            android:action="erase"
+            android:targetPackage="org.mozilla.focus.debug"
+            android:targetClass="org.mozilla.focus.activity.MainActivity">
+            <extra android:name="shortcut" android:value="true" />
+        </intent>
+    </shortcut>
 </shortcuts>

--- a/app/src/focusRelease/res/xml-v25/shortcuts.xml
+++ b/app/src/focusRelease/res/xml-v25/shortcuts.xml
@@ -16,4 +16,17 @@
                 <extra android:name="shortcut" android:value="true" />
         </intent>
     </shortcut>
+    <shortcut
+        android:shortcutId="restart"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_erase"
+        android:shortcutShortLabel="@string/shortcut_erase_and_start_short_label"
+        android:shortcutLongLabel="@string/shortcut_erase_and_start_long_label">
+        <intent
+            android:action="erase"
+            android:targetPackage="org.mozilla.focus"
+            android:targetClass="org.mozilla.focus.activity.MainActivity">
+            <extra android:name="shortcut" android:value="true" />
+        </intent>
+    </shortcut>
 </shortcuts>

--- a/app/src/klarBeta/res/xml-v25/shortcuts.xml
+++ b/app/src/klarBeta/res/xml-v25/shortcuts.xml
@@ -16,4 +16,17 @@
                 <extra android:name="shortcut" android:value="true" />
         </intent>
     </shortcut>
+    <shortcut
+        android:shortcutId="restart"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_erase"
+        android:shortcutShortLabel="@string/shortcut_erase_and_start_short_label"
+        android:shortcutLongLabel="@string/shortcut_erase_and_start_long_label">
+        <intent
+            android:action="erase"
+            android:targetPackage="org.mozilla.klar.beta"
+            android:targetClass="org.mozilla.focus.activity.MainActivity">
+            <extra android:name="shortcut" android:value="true" />
+        </intent>
+    </shortcut>
 </shortcuts>

--- a/app/src/klarDebug/res/xml-v25/shortcuts.xml
+++ b/app/src/klarDebug/res/xml-v25/shortcuts.xml
@@ -16,4 +16,17 @@
                 <extra android:name="shortcut" android:value="true" />
         </intent>
     </shortcut>
+    <shortcut
+        android:shortcutId="restart"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_erase"
+        android:shortcutShortLabel="@string/shortcut_erase_and_start_short_label"
+        android:shortcutLongLabel="@string/shortcut_erase_and_start_long_label">
+        <intent
+            android:action="erase"
+            android:targetPackage="org.mozilla.klar.debug"
+            android:targetClass="org.mozilla.focus.activity.MainActivity">
+            <extra android:name="shortcut" android:value="true" />
+        </intent>
+    </shortcut>
 </shortcuts>

--- a/app/src/klarRelease/res/xml-v25/shortcuts.xml
+++ b/app/src/klarRelease/res/xml-v25/shortcuts.xml
@@ -16,4 +16,17 @@
                 <extra android:name="shortcut" android:value="true" />
         </intent>
     </shortcut>
+    <shortcut
+        android:shortcutId="restart"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_erase"
+        android:shortcutShortLabel="@string/shortcut_erase_and_start_short_label"
+        android:shortcutLongLabel="@string/shortcut_erase_and_start_long_label">
+        <intent
+            android:action="erase"
+            android:targetPackage="org.mozilla.klar"
+            android:targetClass="org.mozilla.focus.activity.MainActivity">
+            <extra android:name="shortcut" android:value="true" />
+        </intent>
+    </shortcut>
 </shortcuts>

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -62,6 +62,12 @@ public class MainActivity extends LocaleAwareAppCompatActivity {
 
         final SafeIntent intent = new SafeIntent(getIntent());
 
+        final String action = intent.getAction();
+
+        if (ACTION_ERASE.equals(action)) {
+            processEraseAction(intent);
+        }
+
         sessionManager.handleIntent(this, intent, savedInstanceState);
 
         sessionManager.getSessions().observe(this,  new NonNullObserver<List<Session>>() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,15 @@
          of 25 characters. -->
     <string name="shortcut_erase_long_label">Erase browsing history</string>
 
+    <!-- On Android 7+ users can add a shortcut for erasing and then opening the browser.
+         This is the label for this shortcut. Android recommends a maximum length of 10 characters.  -->
+    <string name="shortcut_erase_and_start_short_label">Restart</string>
+
+    <!-- The same as 'shortcut_erase_and_start_short_label' but more descriptive. The launcher shows
+         this instead of the short title when it has enough space. Android recommends a maximum
+          length of 25 characters. -->
+    <string name="shortcut_erase_and_start_long_label">Erase and open browser</string>
+
     <!-- This is the label of an action we offer when the user selects text in other third-party apps.
          Clicking this action will launch Focus and perform a search in the default search engine. -->
     <string name="text_selection_search_action">Search Privately</string>

--- a/app/src/main/res/xml-v25/shortcuts.xml
+++ b/app/src/main/res/xml-v25/shortcuts.xml
@@ -16,4 +16,17 @@
                 <extra android:name="shortcut" android:value="true" />
         </intent>
     </shortcut>
+    <shortcut
+        android:shortcutId="restart"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_erase"
+        android:shortcutShortLabel="@string/shortcut_erase_and_start_short_label"
+        android:shortcutLongLabel="@string/shortcut_erase_and_start_long_label">
+        <intent
+            android:action="erase"
+            android:targetPackage="${applicationId}"
+            android:targetClass="org.mozilla.focus.activity.MainActivity">
+            <extra android:name="shortcut" android:value="true" />
+        </intent>
+    </shortcut>
 </shortcuts>


### PR DESCRIPTION
The previous shortcut only erased history. This new shortcuts enables the user
to open the browser at the same time.

I added it in a response to issue #1009. Maybe also add a quick-search shortcut?