### PR TITLE
Fix #1148 - String import for unsupported locales

### DIFF
--- a/tools/l10n/android2po/commands.py
+++ b/tools/l10n/android2po/commands.py
@@ -12,6 +12,7 @@ from babel.messages import pofile, Catalog
 from termcolor import colored
 
 import convert
+from patch import read_po
 from env import resolve_locale
 
 __all__ = ('CommandError', 'ExportCommand', 'ImportCommand', 'InitCommand',)
@@ -26,7 +27,7 @@ def read_catalog(filename, **kwargs):
     """
     f = open(filename, 'r')
     try:
-        return pofile.read_po(f, **kwargs)
+        return read_po(f, **kwargs)
     finally:
         f.close()
 

--- a/tools/l10n/android2po/env.py
+++ b/tools/l10n/android2po/env.py
@@ -59,27 +59,32 @@ MISSING_LOCALES = {
     'cak': {
         'name': "Kaqchikel",
         'local_name': "Kaqchikel",
-        'plural_rule': 'az'
+        'plural_rule': 'az',
+        'team': 'cak <LL@li.org>\n'
     },
     'zam': {
         'name': "Miahuatlán Zapotec",
         'local_name': "DíɁztè",
-        'plural_rule': 'az'
+        'plural_rule': 'az',
+        'team': 'zam <LL@li.org>\n'
     },
     'trs': {
         'name': "Chicahuaxtla Triqui",
         'local_name': "Triqui",
-        'plural_rule': 'az'
+        'plural_rule': 'az',
+        'team': 'trs <LL@li.org>\n'
     },
     'meh': {
         'name': "Mixteco Yucuhiti",
         'local_name': "Tu´un savi ñuu Yasi'í Yuku Iti",
-        'plural_rule': 'id'
+        'plural_rule': 'id',
+        'team': 'meh <LL@li.org>\n'
     },
     'mix': {
         'name': "Mixtepec Mixtec",
         'local_name': "Tu'un savi",
-        'plural_rule': 'id'
+        'plural_rule': 'id',
+        'team': 'mix <LL@li.org>\n'
     }
 }
 

--- a/tools/l10n/android2po/env.py
+++ b/tools/l10n/android2po/env.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
@@ -54,15 +55,47 @@ We can not simply ignore middle element in transition from android
 to Babel locale mapping.
 """
 
+MISSING_LOCALES = {
+    'cak': {
+        'name': "Kaqchikel",
+        'local_name': "Kaqchikel",
+        'plural_rule': 'az'
+    },
+    'zam': {
+        'name': "Miahuatlán Zapotec",
+        'local_name': "DíɁztè",
+        'plural_rule': 'az'
+    },
+    'trs': {
+        'name': "Chicahuaxtla Triqui",
+        'local_name': "Triqui",
+        'plural_rule': 'az'
+    },
+    'meh': {
+        'name': "Mixteco Yucuhiti",
+        'local_name': "Tu´un savi ñuu Yasi'í Yuku Iti",
+        'plural_rule': 'id'
+    },
+    'mix': {
+        'name': "Mixtepec Mixtec",
+        'local_name': "Tu'un savi",
+        'plural_rule': 'id'
+    }
+}
+
 
 class Language(object):
-    """Represents a single language.
-    """
+    """Represents a single language."""
 
     def __init__(self, code, env=None):
         self.code = code
         self.env = env
-        self.locale = Locale.parse(code, sep='-') if code else None
+        if code and code in MISSING_LOCALES:
+            self.locale = Locale.parse(MISSING_LOCALES[code]['plural_rule'], sep='-')
+        elif code:
+            self.locale = Locale.parse(code, sep='-')
+        else:
+            self.locale = None
 
     def __unicode__(self):  # pragma: no cover
         return str(self.code)

--- a/tools/l10n/android2po/patch.py
+++ b/tools/l10n/android2po/patch.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+from env import MISSING_LOCALES
+from cgi import parse_header
+from datetime import datetime, time as time_
+from babel import __version__ as VERSION
+from babel.core import Locale
+from babel._compat import number_types
+from babel.dates import format_datetime
+from babel.messages import pofile, Catalog
+from babel.messages.catalog import _parse_datetime_header
+
+
+class PatchedCatalog(Catalog):
+    def _get_mime_headers(self):
+        headers = []
+        headers.append(('Project-Id-Version',
+                        '%s %s' % (self.project, self.version)))
+        headers.append(('Report-Msgid-Bugs-To', self.msgid_bugs_address))
+        headers.append(('POT-Creation-Date',
+                        format_datetime(self.creation_date, 'yyyy-MM-dd HH:mmZ',
+                                        locale='en')))
+        if isinstance(self.revision_date, (datetime, time_) + number_types):
+            headers.append(('PO-Revision-Date',
+                            format_datetime(self.revision_date,
+                                            'yyyy-MM-dd HH:mmZ', locale='en')))
+        else:
+            headers.append(('PO-Revision-Date', self.revision_date))
+        headers.append(('Last-Translator', self.last_translator))
+        if self.locale is not None:
+            headers.append(('Language', str(self.locale)))
+        if (self.locale is not None) and ('LANGUAGE' in self.language_team):
+            headers.append(('Language-Team',
+                            self.language_team.replace('LANGUAGE',
+                                                       str(self.locale))))
+        else:
+            headers.append(('Language-Team', self.language_team))
+        if self.locale is not None:
+            headers.append(('Plural-Forms', self.plural_forms))
+        headers.append(('MIME-Version', '1.0'))
+        headers.append(('Content-Type',
+                        'text/plain; charset=%s' % self.charset))
+        headers.append(('Content-Transfer-Encoding', '8bit'))
+        headers.append(('Generated-By', 'Babel %s\n' % VERSION))
+        return headers
+
+    def _set_mime_headers(self, headers):
+        for name, value in headers:
+            name = name.lower()
+            if name == 'project-id-version':
+                parts = value.split(' ')
+                self.project = u' '.join(parts[:-1])
+                self.version = parts[-1]
+            elif name == 'report-msgid-bugs-to':
+                self.msgid_bugs_address = value
+            elif name == 'last-translator':
+                self.last_translator = value
+            elif name == 'language':
+                if value in MISSING_LOCALES:
+                    self.locale = Locale.parse(MISSING_LOCALES[value]['plural_rule'])
+                else:
+                    self.locale = Locale.parse(value)
+            elif name == 'language-team':
+                self.language_team = value
+            elif name == 'content-type':
+                mimetype, params = parse_header(value)
+                if 'charset' in params:
+                    self.charset = params['charset'].lower()
+            elif name == 'plural-forms':
+                _, params = parse_header(' ;' + value)
+                self._num_plurals = int(params.get('nplurals', 2))
+                self._plural_expr = params.get('plural', '(n != 1)')
+            elif name == 'pot-creation-date':
+                self.creation_date = _parse_datetime_header(value)
+            elif name == 'po-revision-date':
+                # Keep the value if it's not the default one
+                if 'YEAR' not in value:
+                    self.revision_date = _parse_datetime_header(value)
+
+    mime_headers = property(_get_mime_headers, _set_mime_headers)
+
+
+def read_po(fileobj, locale=None, domain=None, ignore_obsolete=False, charset=None):
+    catalog = PatchedCatalog(locale=locale, domain=domain, charset=charset)
+    parser = pofile.PoFileParser(catalog, ignore_obsolete)
+    parser.parse(fileobj)
+    return catalog


### PR DESCRIPTION
This is import only. Export is not supported.

Solved using list of missing locales and matched them with locales that has same plural rules with them (using info from pontoon).