### PR TITLE
Improve docker image

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get install -y openjdk-8-jdk \
 					   ruby-dev \
 					   ruby-build \
 					   python \
+					   python-pip \
 					   optipng \
 					   imagemagick \
 					   locales
@@ -89,6 +90,11 @@ RUN git clone https://github.com/mozilla-mobile/focus-android.git
 # Build project once to pull all dependencies
 WORKDIR /opt/focus-android
 RUN ./gradlew assemble
+
+# -- Post setup -------------------------------------------------------------------------
+
+# Install dependencies needed to run Android2Po
+RUN pip install -r tools/l10n/android2po/requirements.txt
 
 # -- Cleanup ----------------------------------------------------------------------------
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -87,9 +87,9 @@ WORKDIR /opt
 # Checkout source code
 RUN git clone https://github.com/mozilla-mobile/focus-android.git
 
-# Build project once to pull all dependencies
+# Build project and run gradle tasks once to pull all dependencies
 WORKDIR /opt/focus-android
-RUN ./gradlew assemble
+RUN ./gradlew assemble testFocusWebviewDebugUnitTest lint pmd checkstyle findbugs
 
 # -- Post setup -------------------------------------------------------------------------
 


### PR DESCRIPTION
There are two things I want to update:
* Install pip and all dependencies for android2po. This will allow us to run the import/export scripts on taskcluster. And I want to use pip for something else - so it's a good time to do this now. :)
* Previously we only ran "gradle assemble" to fetch dependencies and cache them in the docker image. However we now run a lot of more gradle commands and they all need to pull dependencies. To avoid that we run those commands when creating the image and then those dependencies will already be available.