### PR TITLE
Added try catch blocks for downloads (#1436)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -28,6 +28,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -650,14 +651,25 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
                 .addRequestHeader("User-Agent", download.getUserAgent())
                 .addRequestHeader("Cookie", cookie)
                 .addRequestHeader("Referer", getUrl())
-                .setDestinationInExternalPublicDir(download.getDestinationDirectory(), fileName)
                 .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
                 .setMimeType(download.getMimeType());
 
+        try {
+            request.setDestinationInExternalPublicDir(
+                    download.getDestinationDirectory(), fileName);
+        } catch (IllegalStateException e) {
+            Log.e(FRAGMENT_TAG, "Cannot create download directory");
+            return;
+        }
+
         request.allowScanningByMediaScanner();
 
-        long downloadReference = manager.enqueue(request);
-        downloadBroadcastReceiver.addQueuedDownload(downloadReference);
+        try {
+            long downloadReference = manager.enqueue(request);
+            downloadBroadcastReceiver.addQueuedDownload(downloadReference);
+        } catch (RuntimeException e) {
+            Log.e(FRAGMENT_TAG, "Download failed: " + e);
+        }
     }
 
     public boolean onBackPressed() {


### PR DESCRIPTION
Added some error handling for queuing downloads [copied from Firefox ](https://dxr.mozilla.org/mozilla-central/source/mobile/android/base/java/org/mozilla/gecko/BrowserApp.java#2175)
Not sure how to reproduce the original NPE error, but can continue to investigate. I thought if I tried to switch sessions while the download was queuing it would lead to a NPE because maybe the manager would be null, but I couldn't switch sessions fast enough. What do you think? 