### PR TITLE
UI polishing: Add to home screen dialog etc (#1260) 

### DIFF
--- a/app/src/main/java/org/mozilla/focus/broadcastreceiver/DownloadBroadcastReceiver.java
+++ b/app/src/main/java/org/mozilla/focus/broadcastreceiver/DownloadBroadcastReceiver.java
@@ -85,7 +85,7 @@ public class DownloadBroadcastReceiver extends BroadcastReceiver {
                     context.startActivity(openFileIntent);
                 }
             });
-            snackbar.setActionTextColor(ContextCompat.getColor(context, R.color.download_dialog_text));
+            snackbar.setActionTextColor(ContextCompat.getColor(context, R.color.snackbarActionText));
         }
         snackbar.show();
     }

--- a/app/src/main/res/layout/add_to_homescreen.xml
+++ b/app/src/main/res/layout/add_to_homescreen.xml
@@ -12,7 +12,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:padding="16dp">
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="10dp">
 
         <ImageView
             android:id="@+id/homescreen_icon"
@@ -27,8 +30,7 @@
             android:layout_gravity="center_vertical"
             android:backgroundTint="@color/add_to_homescreen_button_text"
             android:inputType="text"
-            android:paddingEnd="8dp"
-            android:paddingStart="8dp"
+            android:paddingStart="10dp"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:textColor="@color/add_to_homescreen_text"
             android:textColorHighlight="@color/colorAccent"
@@ -57,7 +59,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAllCaps="true"
-            android:textColor="@color/download_dialog_text" />
+            android:textColor="@color/download_dialog_text"
+            android:textSize="14sp"
+            android:fontFamily="@string/font_roboto_medium" />
 
         <Button
             android:id="@+id/addtohomescreen_dialog_add"
@@ -66,7 +70,9 @@
             android:layout_height="wrap_content"
             android:layout_gravity="end"
             android:textAllCaps="true"
-            android:textColor="@color/download_dialog_text" />
+            android:textColor="@color/download_dialog_text"
+            android:textSize="14sp"
+            android:fontFamily="@string/font_roboto_medium" />
     </LinearLayout>
 
 
@@ -95,8 +101,9 @@
             android:background="#ff262626"
             android:paddingStart="10dp"
             android:text="@string/dialog_addtohomescreen_tracking_protection"
-            android:textColor="#ff8b8b8b"
-            android:textSize="12sp" />
+            android:textColor="#66ffffff"
+            android:textSize="12sp"
+            android:fontFamily="@string/font_roboto_regular" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/add_to_homescreen.xml
+++ b/app/src/main/res/layout/add_to_homescreen.xml
@@ -12,8 +12,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:paddingStart="24dp"
-        android:paddingEnd="24dp"
+        android:paddingStart="@dimen/dialogHorizontalPadding"
+        android:paddingEnd="@dimen/dialogHorizontalPadding"
         android:paddingTop="16dp"
         android:paddingBottom="10dp">
 
@@ -28,7 +28,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
-            android:backgroundTint="@color/add_to_homescreen_button_text"
+            android:backgroundTint="@color/dialogAccent"
             android:inputType="text"
             android:paddingStart="10dp"
             android:textAppearance="?android:attr/textAppearanceMedium"
@@ -59,7 +59,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAllCaps="true"
-            android:textColor="@color/download_dialog_text"
+            android:textColor="@color/dialogAccent"
             android:textSize="14sp"
             android:fontFamily="@string/font_roboto_medium" />
 
@@ -70,7 +70,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="end"
             android:textAllCaps="true"
-            android:textColor="@color/download_dialog_text"
+            android:textColor="@color/dialogAccent"
             android:textSize="14sp"
             android:fontFamily="@string/font_roboto_medium" />
     </LinearLayout>
@@ -83,8 +83,8 @@
         android:background="#ff262626"
         android:orientation="horizontal"
         android:paddingBottom="16dp"
-        android:paddingEnd="24dp"
-        android:paddingStart="24dp"
+        android:paddingEnd="@dimen/dialogHorizontalPadding"
+        android:paddingStart="@dimen/dialogHorizontalPadding"
         android:paddingTop="16dp"
         android:visibility="gone">
 

--- a/app/src/main/res/layout/context_menu.xml
+++ b/app/src/main/res/layout/context_menu.xml
@@ -25,8 +25,8 @@
         android:textColor="#66ffffff"
         android:textSize="12sp"
         android:fontFamily="@string/font_roboto_regular"
-        android:paddingStart="24dp"
-        android:paddingEnd="24dp"
+        android:paddingStart="@dimen/dialogHorizontalPadding"
+        android:paddingEnd="@dimen/dialogHorizontalPadding"
         android:paddingTop="16dp"
         android:paddingBottom="16dp" />
 

--- a/app/src/main/res/layout/context_menu_title.xml
+++ b/app/src/main/res/layout/context_menu_title.xml
@@ -10,7 +10,10 @@
     android:gravity="center_vertical"
     android:ellipsize="end"
     android:textSize="14sp"
-    android:padding="24dp"
+    android:paddingStart="@dimen/dialogHorizontalPadding"
+    android:paddingEnd="@dimen/dialogHorizontalPadding"
+    android:paddingTop="24dp"
+    android:paddingBottom="24dp"
     android:textColor="#ffb2b2b2"
     tools:text="http://www.mozilla.org"
     android:fontFamily="@string/font_roboto_regular" />

--- a/app/src/main/res/layout/download_dialog.xml
+++ b/app/src/main/res/layout/download_dialog.xml
@@ -50,7 +50,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:textAllCaps="true"
-            android:textColor="@color/download_dialog_text" />
+            android:textColor="@color/dialogAccent" />
 
         <Button
             android:id="@+id/download_dialog_download"
@@ -60,7 +60,7 @@
             android:layout_gravity="end"
             android:layout_weight="1"
             android:textAllCaps="true"
-            android:textColor="@color/download_dialog_text" />
+            android:textColor="@color/dialogAccent" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -54,7 +54,7 @@
     <color name="colorAction">@color/photonBlue50</color>
 
     <color name="add_to_homescreen_button_text">@color/photonBlue50</color>
-    <color name="add_to_homescreen_text">#FFFFFF</color>
+    <color name="add_to_homescreen_text">#B3FFFFFF</color>
     <color name="add_to_homescreen_icon_background">#4C0074</color>
 
     <color name="firefoxInstallHint">@color/photonMagenta70</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -42,18 +42,18 @@
 
     <color name="snackbarBackground">#FF414146</color>
     <color name="snackbarTextColor">#ffffffff</color>
+    <color name="snackbarActionText">@color/photonBlue50</color>
 
     <color name="searchHintTextColor">#ffffffff</color>
 
     <color name="onboarding_indicator_default">#7FFFFFFF</color>
     <color name="onboarding_indicator_selected">#FFFFFFFF</color>
 
-    <color name="download_dialog_text">@color/photonBlue50</color>
+    <color name="dialogAccent">@color/photonBlue50</color>
 
     <color name="colorSession">#272727</color>
     <color name="colorAction">@color/photonBlue50</color>
 
-    <color name="add_to_homescreen_button_text">@color/photonBlue50</color>
     <color name="add_to_homescreen_text">#B3FFFFFF</color>
     <color name="add_to_homescreen_icon_background">#4C0074</color>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -29,4 +29,6 @@
     <dimen name="floating_action_button_size">56dp</dimen>
 
     <dimen name="adaptive_icon_drawable_dimen">108dp</dimen> <!-- Specified in AdaptiveIconDrawable docs. -->
+
+    <dimen name="dialogHorizontalPadding">24dp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -61,8 +61,8 @@
               Check design_navigation_item.xml source here :
               https://android.googlesource.com/platform/frameworks/support.git/+/master/design/res/layout/design_navigation_item.xml
             -->
-        <item name="listPreferredItemPaddingLeft">24dp</item>
-        <item name="listPreferredItemPaddingRight">24dp</item>
+        <item name="listPreferredItemPaddingLeft">@dimen/dialogHorizontalPadding</item>
+        <item name="listPreferredItemPaddingRight">@dimen/dialogHorizontalPadding</item>
     </style>
 
     <style name="ContextMenuTextAppearence">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,6 +17,8 @@
 
     <style name="DialogTitleStyle" parent="TextAppearance.AppCompat.Title">
         <item name="android:textColor">#FFFFFF</item>
+        <item name="android:textSize">20sp</item>
+        <item name="android:fontFamily">@string/font_roboto_medium</item>
     </style>
 
     <!-- Setting this via alertDialogStyle in AppTheme results in crashes. You need to
@@ -26,6 +28,7 @@
     <style name="DialogStyle" parent="Theme.AppCompat.Dialog.Alert">
         <item name="colorAccent">#FF00A4DC</item>
         <item name="android:windowTitleStyle">@style/DialogTitleStyle</item>
+        <item name="dialogPreferredPadding">24dp</item>
     </style>
 
     <style name="SettingsTheme" parent="Theme.AppCompat.NoActionBar">


### PR DESCRIPTION
@mcomella, please have a look here.

![screenshot-2017-10-20 30620468-61691760-9d5a-11e7-9ba5-400c67231760 png png image 1450 x 1490 pixels](https://user-images.githubusercontent.com/19215803/31805343-78286dae-b54f-11e7-9f96-3bfd1a3ed3c3.png)

## Note: 

Some corrections were made here -->

- **Add button** color must be 0A84FF (100%) instead of 009688
- **Scene.ca** text color is FFFFFF 70% (Not in the mock)