### PR TITLE
Release builds automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ infer-out/
 fastlane/
 Screengrabfile
 
+# Adjust token file
+.adjust_token
+

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -35,7 +35,7 @@ tasks:
           git fetch {{ event.head.repo.url }} {{ event.head.repo.branch }}
           && git config advice.detachedHead false
           && git checkout {{event.head.sha}}
-          && export ADJUST_TOKEN_FOCUS='..no..value..'
+          && echo "--" > .adjust_token
           && ./gradlew clean assemble test lint pmd checkstyle findbugs
       artifacts:
         'public':
@@ -76,7 +76,7 @@ tasks:
           git fetch origin
           && git config advice.detachedHead false
           && git checkout {{event.head.sha}}
-          && export ADJUST_TOKEN_FOCUS='..no..value..'
+          && echo "--" > .adjust_token
           && ./gradlew clean assemble test lint pmd checkstyle findbugs
       artifacts:
         'public':

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,6 +7,12 @@ allowPullRequests: public
 tasks:
 ###############################################################################
 # Task: Pull requests
+#
+# Triggered whenever a pull request is opened or updated.
+#
+# - Build the app (all flavors)
+# - Run unit tests
+# - Run code quality tools (findbugs, lint, checkstyle etc.)
 ###############################################################################
   - provisionerId: '{{ taskcluster.docker.provisionerId }}'
     workerType: '{{ taskcluster.docker.workerType }}'
@@ -43,6 +49,12 @@ tasks:
       source: '{{ event.head.repo.url }}'
 ###############################################################################
 # Task: Master builds
+#
+# Triggered whenever something is pushed/merged to the master branch.
+#
+# - Build the app (all flavors)
+# - Run unit tests
+# - Run code quality tools (findbugs, lint, checkstyle etc.)
 ###############################################################################
   - provisionerId: '{{ taskcluster.docker.provisionerId }}'
     workerType: '{{ taskcluster.docker.workerType }}'
@@ -74,5 +86,46 @@ tasks:
     metadata:
       name: Focus for Android - Build - Master
       description: Building Focus for Android (via Gradle) - Master
+      owner: '{{ event.head.user.email }}'
+      source: '{{ event.head.repo.url }}'
+###############################################################################
+# Task: Release builds
+#
+# Triggered when a new tag or release is published (in any branch)
+#
+# - Build (unsigned) release versions of the app with release translations and
+#   adjust token.
+###############################################################################
+  - provisionerId: '{{ taskcluster.docker.provisionerId }}'
+    workerType: '{{ taskcluster.docker.workerType }}'
+    extra:
+      github:
+        events:
+          - release
+    payload:
+      maxRunTime: 3600
+      deadline: "{{ '2 hours' | $fromNow }}"
+      image: 'mozillamobile/focus-android'
+      command:
+        - /bin/bash
+        - '--login'
+        - '-c'
+        - >-
+          git fetch origin --tags
+          && git config advice.detachedHead false
+          && git checkout {{ event.version }}
+          && python tools/taskcluster/get-adjust-token.py
+          && python tools/l10n/filter-release-translations.py
+          && ./gradlew clean test assembleRelease
+      artifacts:
+        'public':
+          type: 'directory'
+          path: '/opt/focus-android/app/build/outputs/apk'
+          expires: "{{ '1 week' | $fromNow }}"
+      features:
+        taskclusterProxy: true
+    metadata:
+      name: Focus for Android - Release build ({{ event.version }})
+      description: Building release versions of Firefox Focus/Klar
       owner: '{{ event.head.user.email }}'
       source: '{{ event.head.repo.url }}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 
 script:
   - ./gradlew clean assemble
-  - export ADJUST_TOKEN_FOCUS='..no..value..'
+  - echo "--" > .adjust_token
   - ./gradlew jacocoTestReport
 
 after_success:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -239,7 +239,7 @@ tasks.whenTaskAdded { task ->
 }
 
 // -------------------------------------------------------------------------------------------------
-// Adjust: Read token from environment variable (Only release builds)
+// Adjust: Read token from locale file if it exists (Only release builds)
 // -------------------------------------------------------------------------------------------------
 
 android.applicationVariants.all { variant ->
@@ -248,12 +248,11 @@ android.applicationVariants.all { variant ->
     print("Adjust token (" + variantName + "): ")
 
     if (variantName.contains("Release") && variantName.contains("focus")) {
-        def token = System.getenv("ADJUST_TOKEN_FOCUS") ?: null
-
-        if (token != null) {
+        try {
+            def token = new File("${rootDir}/.adjust_token").text.trim()
             buildConfigField 'String', 'ADJUST_TOKEN', '"' + token + '"'
-            println "(Added from environment variable)"
-        } else {
+            println "(Added from .adjust_token file"
+        } catch (java.io.FileNotFoundException e) {
             buildConfigField 'String', 'ADJUST_TOKEN', 'null'
             println("X_X")
         }

--- a/tools/l10n/filter-release-translations.py
+++ b/tools/l10n/filter-release-translations.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+This script takes the list of release locales defined in locales.py
+and removes all non-release translations from the application's
+resource folder.
+This script is run before building a release version so that
+those builds only contain locales we actually want to ship.
+"""
+
+import os
+import re
+import shutil
+
+from locales import RELEASE_LOCALES
+
+LANGUAGE_REGEX = re.compile('^[a-z]{2,3}$')
+LANGUAGE_REGION_REGEX = re.compile('^([a-z]{2})-r([A-Z]{2})$')
+
+# Get all resource directories that start with "values-" (and remove the "values-" prefix)
+resources_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'app', 'src', 'main', 'res')
+locale_dirs = [localeDir.replace('values-', '') for localeDir in os.listdir(resources_dir)
+		if os.path.isdir(os.path.join(resources_dir, localeDir))
+		and localeDir.startswith('values-')]
+
+# Remove everything that doesn't look like it's a resource folder for a specific language (e.g. sw600dp)
+locale_dirs = filter(lambda x: LANGUAGE_REGEX.match(x) or LANGUAGE_REGION_REGEX.match(x), locale_dirs)
+
+# Android prefixes regions with an "r" (de-rDE). Remove the prefix.
+locale_dirs = [item.replace('-r','-') for item in locale_dirs]
+
+# Now determine the list of locales that are not in our release list
+locales_to_remove = list(set(locale_dirs) - set(RELEASE_LOCALES))
+
+print "RELEASE LOCALES:", ", ".join(RELEASE_LOCALES)
+print "APP LOCALES:", ", ".join(locale_dirs)
+print "REMOVE:", ", ".join(locales_to_remove) if len(locales_to_remove) > 0 else "-Nothing-"
+
+# Remove unneeded resource folders
+for locale in locales_to_remove:
+	# Build resource folder names from locale: de -> values-de, de-DE -> vlaues-de-rDE
+	parts = locale.split("-")
+	folder = "values-" + (parts[0] if len(parts) == 1 else parts[0] + "-r" + parts[1])
+	path = os.path.join(resources_dir, folder)
+	
+	print "* Removing: ", path
+	shutil.rmtree(path)

--- a/tools/taskcluster/get-adjust-token.py
+++ b/tools/taskcluster/get-adjust-token.py
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+This script talks to the taskcluster secrets service to obtain the
+Adjust token and write it to the .adjust_token file in the root
+directory.
+"""
+
+import taskcluster
+
+# Get JSON data from taskcluster secrets service
+secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
+data = secrets.get('project/focus/tokens')
+
+token_file_path = os.path.join(os.path.dirname(__file__), '../../.adjust_token')
+with open(token_file_path, 'w') as token_file:
+	token_file.write(data['secret']['adjustToken'])
+
+print("Imported adjust token from secrets service")


### PR DESCRIPTION
After landing this taskcluster will automatically build release builds of Focus/Klar when a [release is created on GitHub](https://github.com/mozilla-mobile/focus-android/releases). With that all the manual building and taking care of the Adjust token etc. will not be needed anymore.

For now those builds will be unsigned. That's one of the next steps. However now we only need to create a release on GitHub, open a Bugzilla bug for signing & uploading and drop the taskcluster link with the builds attached into the Bugzilla bug.