### PR TITLE
Closes #1560. Update Search Engine UI Test to handle new nested Settings screen

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/SearchEngineSelectionTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SearchEngineSelectionTest.java
@@ -14,6 +14,7 @@ import android.support.test.uiautomator.UiObject;
 import android.support.test.uiautomator.UiObjectNotFoundException;
 import android.support.test.uiautomator.UiScrollable;
 import android.support.test.uiautomator.UiSelector;
+import android.widget.RadioButton;
 
 import org.junit.After;
 import org.junit.Rule;
@@ -63,14 +64,7 @@ public class SearchEngineSelectionTest {
         UiObject searchName = SearchEngineSelection.getChild(new UiSelector()
                 .resourceId("android:id/title")
                 .enabled(true));
-        UiObject SearchEngineList = new UiScrollable(new UiSelector()
-                .resourceId("android:id/select_dialog_listview").enabled(true));
-        UiObject GoogleSelection = SearchEngineList.getChild(new UiSelector()
-                .resourceId("org.mozilla.focus.debug:id/title")
-                .text("Google"));
-        UiObject YahooSelection = SearchEngineList.getChild(new UiSelector()
-                .resourceId("org.mozilla.focus.debug:id/title")
-                .text("Yahoo"));
+
         UiObject googleWebView = TestHelper.mDevice.findObject(new UiSelector()
                 .description("mozilla focus - Google Search")
                 .className("android.webkit.WebView"));
@@ -85,8 +79,19 @@ public class SearchEngineSelectionTest {
 
         /* Set the search engine to Google */
         SearchEngineSelection.click();
+
+        /* Get the dynamically generated search engine list from this settings page */
+        UiScrollable SearchEngineList = new UiScrollable(new UiSelector()
+                .resourceId("org.mozilla.focus.debug:id/search_engine_group").enabled(true));
+
+        UiObject GoogleSelection = SearchEngineList.getChildByText(new UiSelector()
+                .className(RadioButton.class), "Google");
+        UiObject YahooSelection = SearchEngineList.getChildByText(new UiSelector()
+                .className(RadioButton.class), "Yahoo");
+
         GoogleSelection.waitForExists(waitingTime);
         GoogleSelection.click();
+        TestHelper.pressBackKey();
         // Now it's changed to Google
         assertTrue(searchName.getText().equals("Google"));
         TestHelper.settingsHeading.waitForExists(waitingTime);
@@ -132,6 +137,7 @@ public class SearchEngineSelectionTest {
         SearchEngineSelection.click();
         YahooSelection.waitForExists(waitingTime);
         YahooSelection.click();
+        TestHelper.pressBackKey();
         assertTrue(searchName.getText().equals("Yahoo"));
         TestHelper.pressBackKey();
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/screenshots/SettingsScreenshots.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/screenshots/SettingsScreenshots.java
@@ -76,15 +76,10 @@ public class SettingsScreenshots extends ScreenshotTest {
                 .instance(1));
         SearchEngineSelection.click();
         TestHelper.settingsHeading.waitUntilGone(waitingTime);
-        UiObject SearchEngineList = new UiScrollable(new UiSelector()
-                .resourceId("android:id/select_dialog_listview").enabled(true));
-        UiObject FirstSelection = SearchEngineList.getChild(new UiSelector()
-                .className("android.widget.LinearLayout")
-                .instance(0));
         Screengrab.screenshot("SearchEngine_Selection");
 
         /* scroll down */
-        FirstSelection.click();
+        TestHelper.pressBackKey();
         assertTrue(TestHelper.settingsHeading.waitForExists(waitingTime));
         UiScrollable settingsView = new UiScrollable(new UiSelector().scrollable(true));
         settingsView.scrollToEnd(4);


### PR DESCRIPTION
#1484 added another screen to Settings, so I'm updating the two broken tests from master (SettingsScreenshots, SearchEngineSelectionTest) here.

Not sure if we wanted to define all the UIObjects before starting to run the tests (because that seems to be the style of the SearchEngineSelectionTest) to avoid intermittents?