### PR TITLE
Closes #1492: Don't delete cache files on disk; update test.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/WebViewDataTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/WebViewDataTest.java
@@ -67,7 +67,7 @@ public class WebViewDataTest {
     private static final Set<String> WHITELIST_DATA_DIR_CONTENTS;
     static {
         final Set<String> whitelistDataDirContents = new HashSet<>(Arrays.asList(
-                "cache", // We assert that this folder is empty
+                "cache",
                 "code_cache",
                 "shared_prefs",
                 "app_dxmaker_cache",
@@ -225,7 +225,7 @@ public class WebViewDataTest {
         assertEquals("WebView directory contains one subdirectory", 1, webViewDirectory.list().length);
         assertEquals("WebView subdirectory is local storage directory", "Local Storage", webViewDirectory.list()[0]);
 
-        assertIsEmpty(appContext.getCacheDir());
+        assertCacheDirContentsPostErase();
 
         for (final String name : dataDir.list()) {
             if (WHITELIST_EMPTY_FOLDERS.contains(name)) {
@@ -280,8 +280,26 @@ public class WebViewDataTest {
         }
     }
 
-    private void assertIsEmpty(File directory) {
-        assertTrue(directory.isDirectory() && directory.list().length == 0);
+    private void assertCacheDirContentsPostErase() {
+        final File cacheDir = appContext.getCacheDir();
+        assertTrue(cacheDir.isDirectory());
+
+        final File[] cacheContents = cacheDir.listFiles();
+        assertEquals(1, cacheContents.length);
+
+        // Concern: different versions of WebView may have different structures to their files:
+        // we'll cross that bridge when we come to it.
+        final File webViewCacheDir = cacheContents[0];
+        assertEquals("org.chromium.android_webview", webViewCacheDir.getName());
+        assertTrue(webViewCacheDir.isDirectory());
+
+        final List<File> webviewCacheContents = Arrays.asList(webViewCacheDir.listFiles());
+        assertEquals(2, webviewCacheContents.size());
+
+        // WebView leaves these index files around.
+        Collections.sort(webviewCacheContents);
+        assertEquals("index", webviewCacheContents.get(0).getName());
+        assertEquals("index-dir", webviewCacheContents.get(1).getName());
     }
 
 

--- a/app/src/main/java/org/mozilla/focus/utils/FileUtils.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/FileUtils.kt
@@ -10,16 +10,20 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 
 import java.io.File
 
+// WebView directory and contents.
 private const val WEBVIEW_DIRECTORY = "app_webview"
 private const val LOCAL_STORAGE_DIR = "Local Storage"
+
+// Cache directory contents.
+private const val WEBVIEW_CACHE_DIR = "org.chromium.android_webview"
 
 class FileUtils {
     companion object {
         @JvmStatic
-        fun truncateCacheDirectory(context: Context): Boolean {
-            val cacheDirectory = context.cacheDir
-            return cacheDirectory.exists() && deleteContent(cacheDirectory)
-        }
+        fun truncateCacheDirectory(context: Context) = deleteContent(context.cacheDir, doNotEraseWhitelist = setOf(
+                // If the folder or its contents are deleted, WebView will stop using the disk cache entirely.
+                WEBVIEW_CACHE_DIR
+        ))
 
         @JvmStatic
         fun deleteWebViewDirectory(context: Context): Boolean {


### PR DESCRIPTION
#1492

After we manually delete the cache files, WebView will no longer use the disk
cache, which means Focus uses much more network data. Therefore, we no longer
delete the cache.

While we could have erased all the contents of cache/ except the WebView
directory, I opted not to: different versions of WebView could have different
file hierarchies and so this bug would still happen if that's the case. Instead,
we no longer delete any of cache/. As far as I know, WebView is currently the
only user of cache/ so it should have the same effect.

I tested the updated test on an Android API 23 & 26 emulator.