### PR TITLE
README.md: Fix link to "good first issue" label

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We encourage you to participate in this open source project. We love Pull Reques
 
 * Wiki: [https://github.com/mozilla-mobile/focus-android/wiki](https://github.com/mozilla-mobile/focus-android/wiki)
 
-Watch out for [issues with the "good first bug" label](https://github.com/mozilla-mobile/focus-android/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+bug%22). Those are easy starter bugs that are available to work on!
+Watch out for [issues with the "good first issue" label](https://github.com/mozilla-mobile/focus-android/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). Those are easy starter bugs that are available to work on!
 
 Build instructions
 ------------------


### PR DESCRIPTION
Looking at the labels of closed issues, it appears that the project is actually using "good first issue" as the label for issues that would be good for new contributors. The README suggests that good issues for would-be new contributors are labeled "good first bug".