### PR TITLE
Make vertical scrollbar actually visible

### DIFF
--- a/app/src/main/res/drawable/scrollbar_thumb.xml
+++ b/app/src/main/res/drawable/scrollbar_thumb.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/scrollbarThumb" />
+    <size android:width="4dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -37,7 +37,8 @@
                 <org.mozilla.focus.web.IWebView
                     android:id="@+id/webview"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent" />
+                    android:layout_height="match_parent"
+                    android:scrollbarThumbVertical="@drawable/scrollbar_thumb" />
 
             </android.support.v4.widget.SwipeRefreshLayout>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -61,5 +61,5 @@
 
     <color name="preference_row_selected">#414146</color>
 
-    <color name="scrollbarThumb">#aaaaaaaa</color>
+    <color name="scrollbarThumb">#b2b2b2b2</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -60,4 +60,6 @@
     <color name="firefoxInstallHint">@color/photonMagenta70</color>
 
     <color name="preference_row_selected">#414146</color>
+
+    <color name="scrollbarThumb">#aaaaaaaa</color>
 </resources>


### PR DESCRIPTION
Per default, the scrollbar is very light and almost
completely transparent. This patch changes the style
of the scrollbar to a less transparent and much darker
color so that it actually gets visible.

Fixes #1447