### PR TITLE
Fix scrolling in NestedWebView

### DIFF
--- a/app/src/webview/java/org/mozilla/focus/webview/NestedWebView.java
+++ b/app/src/webview/java/org/mozilla/focus/webview/NestedWebView.java
@@ -17,6 +17,10 @@ import android.webkit.WebView;
 /**
  * WebView that supports nested scrolls (for using in a CoordinatorLayout).
  *
+ * This code is a simplified version of the NestedScrollView implementation
+ * which can be found in the support library:
+ *   {@link android.support.v4.widget.NestedScrollView}
+ *
  * Based on:
  *   https://github.com/takahirom/webview-in-coordinatorlayout
  */
@@ -36,13 +40,13 @@ public class NestedWebView extends WebView implements NestedScrollingChild {
 
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
-        boolean eventHandled = false;
-
         final MotionEvent event = MotionEvent.obtain(ev);
-        final int action = MotionEventCompat.getActionMasked(event);
+        final int action = ev.getActionMasked();
+
         if (action == MotionEvent.ACTION_DOWN) {
             mNestedOffsetY = 0;
         }
+
         final int eventY = (int) event.getY();
         event.offsetLocation(0, mNestedOffsetY);
 
@@ -52,30 +56,26 @@ public class NestedWebView extends WebView implements NestedScrollingChild {
 
                 if (dispatchNestedPreScroll(0, deltaY, mScrollConsumed, mScrollOffset)) {
                     deltaY -= mScrollConsumed[1];
-                    mLastY = eventY - mScrollOffset[1];
                     event.offsetLocation(0, -mScrollOffset[1]);
                     mNestedOffsetY += mScrollOffset[1];
                 }
 
-                eventHandled = super.onTouchEvent(event);
+                mLastY = eventY - mScrollOffset[1];
 
                 if (dispatchNestedScroll(0, mScrollOffset[1], 0, deltaY, mScrollOffset)) {
+                    mLastY -= mScrollOffset[1];
                     event.offsetLocation(0, mScrollOffset[1]);
                     mNestedOffsetY += mScrollOffset[1];
-                    mLastY -= mScrollOffset[1];
                 }
                 break;
 
             case MotionEvent.ACTION_DOWN:
-                eventHandled = super.onTouchEvent(event);
                 mLastY = eventY;
-
                 startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL);
                 break;
 
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_CANCEL:
-                eventHandled = super.onTouchEvent(event);
                 stopNestedScroll();
                 break;
 
@@ -83,8 +83,16 @@ public class NestedWebView extends WebView implements NestedScrollingChild {
                 // We don't care about other touch events
         }
 
+        // Execute event handler from parent class in all cases
+        boolean eventHandled = super.onTouchEvent(event);
+
+        // Recycle previously obtained event
+        event.recycle();
+
         return eventHandled;
     }
+
+    // NestedScrollingChild
 
     @Override
     public void setNestedScrollingEnabled(boolean enabled) {


### PR DESCRIPTION
Calling super.onTouchEvent in all cases fixes more
complicated gestures like zooming on Google Maps.

The other change in the ACTION_MOVE case is required
for the SwipeRefreshLayout to work (see follow up pr).