### PR TITLE
Add SwipeRefreshLayout to BrowserFragment

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -27,6 +27,7 @@ import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -104,6 +105,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
     private ImageButton menuView;
     private View statusBar;
     private View urlBar;
+    private SwipeRefreshLayout swipeRefresh;
     private WeakReference<BrowserMenu> menuWeakReference = new WeakReference<>(null);
 
     /**
@@ -206,6 +208,16 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
         progressView = (AnimatedProgressBar) view.findViewById(R.id.progress);
 
+        swipeRefresh = (SwipeRefreshLayout) view.findViewById(R.id.swipe_refresh);
+        swipeRefresh.setColorSchemeResources(R.color.colorAccent);
+
+        swipeRefresh.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+            @Override
+            public void onRefresh() {
+                reload();
+            }
+        });
+
         session.getUrl().observe(this, new Observer<String>() {
             @Override
             public void onChanged(@Nullable String url) {
@@ -228,6 +240,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
                     progressView.setProgress(progressView.getMax());
                     progressView.setVisibility(View.GONE);
+                    swipeRefresh.setRefreshing(false);
                 }
 
                 updateBlockingBadging(loading || session.isBlockingEnabled());

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -28,11 +28,18 @@
             android:orientation="vertical"
             android:clipChildren="false">
 
-            <org.mozilla.focus.web.IWebView
-                android:id="@+id/webview"
+            <android.support.v4.widget.SwipeRefreshLayout
+                android:id="@+id/swipe_refresh"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+                app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+                <org.mozilla.focus.web.IWebView
+                    android:id="@+id/webview"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent" />
+
+            </android.support.v4.widget.SwipeRefreshLayout>
 
             <include
                 layout="@layout/browser_display_toolbar"/>


### PR DESCRIPTION
This allows the user to swipe down from the top of the page
to reload the site. The action is indicated by the standard
spinning circular arrow from the Android support library.

This pull request depends on #1622 to be merged.