### PR TITLE
Add taskcluster scripts to import strings and create pull requests.

### DIFF
--- a/tools/taskcluster/create-pull-request.py
+++ b/tools/taskcluster/create-pull-request.py
@@ -1,0 +1,64 @@
+ # This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+This scripts pushes the passed in branch (argument) to the bot's
+repository and creates a pull request for it.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import taskcluster
+
+from github import Github
+
+# Make sure we have all needed arguments
+if len(sys.argv) != 2:
+	print "Usage", sys.argv[0], "BRANCH"
+	exit(1)
+
+BRANCH = sys.argv[1]
+OWNER = 'mozilla-mobile'
+USER = 'MickeyMoz'
+REPO = 'focus-android'
+BASE = 'master'
+HEAD = "MickeyMoz:%s" % BRANCH
+
+# Get token for GitHub bot account from secrets service
+secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
+data = secrets.get('project/focus/github')
+token = data['secret']['botAccountToken']
+
+# Push local state to branch
+URL = "https://%s:%s@github.com/%s/%s/" % (USER, token, USER, REPO)
+print subprocess.check_output(['git', 'push', URL, BRANCH])
+
+# Read the log file and create the pull request body from it
+log_path = os.path.join(os.path.dirname(__file__), '../../import-log.txt')
+with open(log_path) as log_file:
+	# Remove color codes from android2po output
+	ansi_escape = re.compile(r'\x1b[^m]*m')
+	log = ansi_escape.sub('', log_file.read())
+
+body = """
+Automated import %s
+
+Log:
+```
+%s
+```
+""" % (BRANCH, log)
+
+# Create pull request
+github = Github(login_or_token=token)
+repo = github.get_user(OWNER).get_repo(REPO)
+pull_request = repo.create_pull(title='String import ' + BRANCH, body=body, base=BASE, head=HEAD)
+print pull_request
+
+# Add the [needs merge] label to the pull request
+issue = repo.get_issue(pull_request.number)
+issue.add_to_labels("needs merge")
+print issue

--- a/tools/taskcluster/import_strings_and_create_pull_request.sh
+++ b/tools/taskcluster/import_strings_and_create_pull_request.sh
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This script imports the latest strings, creates a commit, pushes
+# it to the bot's repository and creates a pull request.
+
+# If a command fails then do not proceed and fail this script too.
+set -e
+
+# Go to project root
+cd "$(dirname "$0")"
+cd ../..
+
+# Update local checkout
+git fetch origin
+git reset --mixed origin/master
+
+# Import strings from L10N repository
+tools/l10n/import-strings.sh > import-log.txt
+cat import-log.txt
+
+# Timestamp used in branch name and commit
+TIMESTAMP=`date "+%Y%m%d-%H%M%S"`
+
+# Create a branch and commit local changes
+git checkout -b $TIMESTAMP
+git add app/src/main/res/
+git commit -m "Import translations from L10N repository ($TIMESTAMP)" --author="MickeyMoz <sebastian@mozilla.com>"
+
+# Create a pull request for the current state of the repo
+python tools/taskcluster/create-pull-request.py $TIMESTAMP


### PR DESCRIPTION
Those scripts can run on taskcluster and will import strings, create a
commit, push them to the bot's repository and create a new pull request
to be merged by a human.

Example merge request:
https://github.com/mozilla-mobile/focus-android/pull/1643

This is not running automatically yet. If this is proving to be useful
I want to run it regularly via taskcluster's hooks service [1].

Later this commit could be merged automatically. But for now I think
it's a good idea to let a human review it first.

[1] https://tools.taskcluster.net/hooks/