### PR TITLE
Add manual searchengine screen behind feature flag

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/screenshots/SettingsScreenshots.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/screenshots/SettingsScreenshots.java
@@ -19,6 +19,7 @@ import org.mozilla.focus.R;
 import org.mozilla.focus.activity.MainActivity;
 import org.mozilla.focus.activity.TestHelper;
 import org.mozilla.focus.activity.helpers.MainActivityFirstrunTestRule;
+import org.mozilla.focus.utils.AppConstants;
 
 import tools.fastlane.screengrab.Screengrab;
 import tools.fastlane.screengrab.locale.LocaleTestRule;
@@ -77,6 +78,16 @@ public class SettingsScreenshots extends ScreenshotTest {
         SearchEngineSelection.click();
         TestHelper.settingsHeading.waitUntilGone(waitingTime);
         Screengrab.screenshot("SearchEngine_Selection");
+
+        /* Manual Search Engine Page */
+        if (AppConstants.FLAG_MANUAL_SEARCH_ENGINE) {
+            final String addEngineLabel = getString(R.string.preference_search_add2);
+            onData(withTitleText(addEngineLabel))
+                    .perform(click());
+            TestHelper.settingsHeading.waitUntilGone(waitingTime);
+            Screengrab.screenshot("SearchEngine_Add_Search_Engine");
+            TestHelper.pressBackKey();
+        }
 
         /* scroll down */
         TestHelper.pressBackKey();

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -80,7 +80,8 @@
         <!-- SettingsActivity title is set dynamically for multilocale support -->
         <activity android:name=".activity.SettingsActivity"
             android:theme="@style/SettingsTheme"
-            android:configChanges="locale" />
+            android:configChanges="locale"
+            android:windowSoftInputMode="adjustPan" />
 
         <activity android:name=".activity.InfoActivity"
                   android:theme="@style/InfoTheme"/>

--- a/app/src/main/java/org/mozilla/focus/activity/SettingsActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/SettingsActivity.java
@@ -9,11 +9,10 @@ import android.preference.PreferenceFragment;
 import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.Toolbar;
-import android.view.View;
+import android.view.MenuItem;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.locale.LocaleAwareAppCompatActivity;
-import org.mozilla.focus.settings.ManualAddSearchEngineSettingsFragment;
 import org.mozilla.focus.settings.SettingsFragment;
 
 public class SettingsActivity extends LocaleAwareAppCompatActivity implements SettingsFragment.ActionBarUpdater {
@@ -33,27 +32,7 @@ public class SettingsActivity extends LocaleAwareAppCompatActivity implements Se
 
         actionBar.setDisplayHomeAsUpEnabled(true);
 
-        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                finish();
-            }
-        });
-
-        final Bundle extras = getIntent().getExtras();
-        final PreferenceFragment fragment;
-        if (extras != null && extras.containsKey(SettingsFragment.FRAGMENT_CLASS_INTENT_EXTRA)) {
-            switch (extras.getInt(SettingsFragment.FRAGMENT_CLASS_INTENT_EXTRA)) {
-                case ManualAddSearchEngineSettingsFragment.FRAGMENT_CLASS_TYPE:
-                    fragment = new ManualAddSearchEngineSettingsFragment();
-                    break;
-                default:
-                    fragment = new SettingsFragment();
-            }
-        } else {
-            fragment = new SettingsFragment();
-        }
-        fragment.setArguments(getIntent().getExtras());
+        final PreferenceFragment fragment = SettingsFragment.newInstance(getIntent().getExtras(), R.xml.settings, R.string.menu_settings);
 
         getFragmentManager().beginTransaction()
                 .replace(R.id.container, fragment)
@@ -63,6 +42,16 @@ public class SettingsActivity extends LocaleAwareAppCompatActivity implements Se
         // anywhere before now (the title can only be set via AndroidManifest, and ensuring
         // that that loads the correct locale string is tricky).
         applyLocale();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/focus/activity/SettingsActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/SettingsActivity.java
@@ -15,7 +15,7 @@ import org.mozilla.focus.R;
 import org.mozilla.focus.locale.LocaleAwareAppCompatActivity;
 import org.mozilla.focus.settings.SettingsFragment;
 
-public class SettingsActivity extends LocaleAwareAppCompatActivity implements SettingsFragment.TitleUpdater {
+public class SettingsActivity extends LocaleAwareAppCompatActivity implements SettingsFragment.ActionBarUpdater {
     public static final int ACTIVITY_RESULT_LOCALE_CHANGED = 1;
 
     @Override
@@ -60,5 +60,10 @@ public class SettingsActivity extends LocaleAwareAppCompatActivity implements Se
     @Override
     public void updateTitle(int titleResId) {
         setTitle(titleResId);
+    }
+
+    @Override
+    public void updateIcon(int iconResId) {
+        getSupportActionBar().setHomeAsUpIndicator(iconResId);
     }
 }

--- a/app/src/main/java/org/mozilla/focus/activity/SettingsActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/SettingsActivity.java
@@ -13,6 +13,7 @@ import android.view.View;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.locale.LocaleAwareAppCompatActivity;
+import org.mozilla.focus.settings.ManualAddSearchEngineSettingsFragment;
 import org.mozilla.focus.settings.SettingsFragment;
 
 public class SettingsActivity extends LocaleAwareAppCompatActivity implements SettingsFragment.ActionBarUpdater {
@@ -39,7 +40,19 @@ public class SettingsActivity extends LocaleAwareAppCompatActivity implements Se
             }
         });
 
-        final PreferenceFragment fragment = new SettingsFragment();
+        final Bundle extras = getIntent().getExtras();
+        final PreferenceFragment fragment;
+        if (extras != null && extras.containsKey(SettingsFragment.FRAGMENT_CLASS_INTENT_EXTRA)) {
+            switch (extras.getInt(SettingsFragment.FRAGMENT_CLASS_INTENT_EXTRA)) {
+                case ManualAddSearchEngineSettingsFragment.FRAGMENT_CLASS_TYPE:
+                    fragment = new ManualAddSearchEngineSettingsFragment();
+                    break;
+                default:
+                    fragment = new SettingsFragment();
+            }
+        } else {
+            fragment = new SettingsFragment();
+        }
         fragment.setArguments(getIntent().getExtras());
 
         getFragmentManager().beginTransaction()

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
@@ -15,14 +15,25 @@ import org.mozilla.focus.R;
 public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
     public static final int FRAGMENT_CLASS_TYPE = 1; // Unique SettingsFragment identifier
 
+    public static SettingsFragment newInstance(Bundle intentArgs, int prefsResId, int titleResId) {
+        SettingsFragment f = new ManualAddSearchEngineSettingsFragment();
+        f.setArguments(makeArgumentBundle(intentArgs, prefsResId, titleResId));
+        return f;
+    }
+
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
 
         // We've checked that this cast is legal in super.onAttach.
         ((ActionBarUpdater) getActivity()).updateIcon(R.drawable.ic_close);
-        setHasOptionsMenu(true);
-    }
+   }
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.settings;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+
+import org.mozilla.focus.R;
+
+public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
+    public static final int FRAGMENT_CLASS_TYPE = 1; // Unique SettingsFragment identifier
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // We've checked that this cast is legal in super.onAttach.
+        ((ActionBarUpdater) getActivity()).updateIcon(R.drawable.ic_close);
+        setHasOptionsMenu(true);
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.menu_search_engine_manual_add, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.menu_save_search_engine:
+                // TODO: Save engineName and searchString
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -31,34 +31,46 @@ import java.util.Locale;
 public class SettingsFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
     public static final String FRAGMENT_RESID_INTENT_EXTRA = "extra_frament_resid";
     public static final String TITLE_RESID_INTENT_EXTRA = "extra_title_resid";
+    public static final String ACTIONBAR_ICON_INTENT_EXTRA = "extra_actionbar_icon_resid";
+
+    public static final int EXTRA_VALUE_NONE = -1;
 
     private boolean localeUpdated;
 
-    public interface TitleUpdater {
-        void updateTitle(int stringResId);
+    public interface ActionBarUpdater {
+        void updateTitle(int titleResId);
+        void updateIcon(int iconResId);
     }
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        final Bundle args = getArguments();
-        final int prefResId = args != null ? args.getInt(FRAGMENT_RESID_INTENT_EXTRA) : R.xml.settings;
-        final int titleResId = args != null ? args.getInt(TITLE_RESID_INTENT_EXTRA) : R.string.menu_settings;
 
-       // We've checked that this cast is legal in onAttach.
-        final TitleUpdater titleUpdater = (TitleUpdater) getActivity();
-        if (titleUpdater != null) {
-            titleUpdater.updateTitle(titleResId);
+        // We've checked that this cast is legal in onAttach.
+        final ActionBarUpdater updater = (ActionBarUpdater) getActivity();
+
+        final Bundle args = getArguments();
+        int prefResId = R.xml.settings;
+        int titleResId = R.string.menu_settings;
+
+        if (args != null) {
+            prefResId = args.getInt(FRAGMENT_RESID_INTENT_EXTRA, R.xml.settings);
+            titleResId = args.getInt(TITLE_RESID_INTENT_EXTRA, R.string.menu_settings);
+
+            if (args.containsKey(ACTIONBAR_ICON_INTENT_EXTRA)) {
+                updater.updateIcon(args.getInt(ACTIONBAR_ICON_INTENT_EXTRA));
+            }
         }
 
+        updater.updateTitle(titleResId);
         addPreferencesFromResource(prefResId);
     }
 
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        if (!(context instanceof TitleUpdater)) {
+        if (!(getActivity() instanceof ActionBarUpdater)) {
             throw new IllegalArgumentException("Parent activity must implement TitleUpdater");
         }
     }
@@ -88,8 +100,7 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
             startActivity(intent);
         } else if (preference.getKey().equals(resources.getString(R.string.pref_key_manual_add_search_engine))) {
             final Intent intent = getSettingsIntent(getActivity(),
-                    R.xml.manual_add_search_engine,
-                    R.string.tutorial_search_title);
+                    R.xml.manual_add_search_engine, R.string.tutorial_search_title, R.drawable.ic_close);
             startActivity(intent);
         }
 
@@ -97,9 +108,16 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
     }
 
     private static Intent getSettingsIntent(Context context, int fragmentResId, int titleResId) {
+        return getSettingsIntent(context, fragmentResId, titleResId, EXTRA_VALUE_NONE);
+    }
+
+    private static Intent getSettingsIntent(Context context, int fragmentResId, int titleResId, int actionbarIconResId) {
         final Intent intent = new Intent(context, SettingsActivity.class);
         intent.putExtra(FRAGMENT_RESID_INTENT_EXTRA, fragmentResId);
         intent.putExtra(TITLE_RESID_INTENT_EXTRA, titleResId);
+        if (actionbarIconResId != EXTRA_VALUE_NONE) {
+            intent.putExtra(ACTIONBAR_ICON_INTENT_EXTRA, actionbarIconResId);
+        }
         return intent;
     }
 

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -23,6 +23,7 @@ import org.mozilla.focus.activity.SettingsActivity;
 import org.mozilla.focus.locale.LocaleManager;
 import org.mozilla.focus.locale.Locales;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
+import org.mozilla.focus.utils.AppConstants;
 import org.mozilla.focus.widget.DefaultBrowserPreference;
 
 import java.util.Locale;
@@ -82,9 +83,11 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
             startActivity(intent);
         } else if (preference.getKey().equals(resources.getString(R.string.pref_key_search_engine))) {
             final Intent intent = new Intent(getActivity(), SettingsActivity.class);
-            intent.putExtra(FRAGMENT_RESID_INTENT_EXTRA, R.xml.search_engine_settings);
+            intent.putExtra(FRAGMENT_RESID_INTENT_EXTRA, AppConstants.FLAG_MANUAL_SEARCH_ENGINE ? R.xml.search_engine_settings_featureflag_manual : R.xml.search_engine_settings);
             intent.putExtra(TITLE_RESID_INTENT_EXTRA, R.string.preference_search_installed_search_engines);
             startActivity(intent);
+        } else if (preference.getKey().equals(resources.getString(R.string.pref_key_manual_add_search_engine))) {
+            // TODO: Show add search engine page
         }
 
         return super.onPreferenceTreeClick(preferenceScreen, preference);

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -31,7 +31,7 @@ import org.mozilla.focus.widget.DefaultBrowserPreference;
 import java.util.Locale;
 
 public class SettingsFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
-    public static final String FRAGMENT_RESID_INTENT_EXTRA = "extra_frament_resid";
+    public static final String PREFERENCES_RESID_INTENT_EXTRA = "extra_preferences_resid";
     public static final String TITLE_RESID_INTENT_EXTRA = "extra_title_resid";
     public static final String MENU_RESID_INTENT_EXTRA = "extra_menu_resid";
     public static final String ACTIONBAR_ICON_INTENT_EXTRA = "extra_actionbar_icon_resid";
@@ -58,7 +58,7 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         int titleResId = R.string.menu_settings;
 
         if (args != null) {
-            prefResId = args.getInt(FRAGMENT_RESID_INTENT_EXTRA, R.xml.settings);
+            prefResId = args.getInt(PREFERENCES_RESID_INTENT_EXTRA, R.xml.settings);
             titleResId = args.getInt(TITLE_RESID_INTENT_EXTRA, R.string.menu_settings);
 
             setHasOptionsMenu(args.containsKey(MENU_RESID_INTENT_EXTRA));
@@ -107,7 +107,7 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
             startActivity(intent);
         } else if (preference.getKey().equals(resources.getString(R.string.pref_key_search_engine))) {
             final Intent intent = getSettingsIntent(getActivity(),
-                    AppConstants.FLAG_MANUAL_SEARCH_ENGINE ? R.xml.search_engine_settings_featureflag_manual: R.xml.search_engine_settings,
+                    AppConstants.FLAG_MANUAL_SEARCH_ENGINE ? R.xml.search_engine_settings_featureflag_manual : R.xml.search_engine_settings,
                     R.string.preference_search_installed_search_engines);
             startActivity(intent);
         } else if (preference.getKey().equals(resources.getString(R.string.pref_key_manual_add_search_engine))) {
@@ -122,13 +122,13 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         return super.onPreferenceTreeClick(preferenceScreen, preference);
     }
 
-    private static Intent getSettingsIntent(Context context, int fragmentResId, int titleResId) {
-        return getSettingsIntent(context, fragmentResId, titleResId, EXTRA_VALUE_NONE, EXTRA_VALUE_NONE);
+    private static Intent getSettingsIntent(Context context, int prefsResId, int titleResId) {
+        return getSettingsIntent(context, prefsResId, titleResId, EXTRA_VALUE_NONE, EXTRA_VALUE_NONE);
     }
 
-    private static Intent getSettingsIntent(Context context, int fragmentResId, int titleResId, int actionbarIconResId, int menuResId) {
+    private static Intent getSettingsIntent(Context context, int prefsResId, int titleResId, int actionbarIconResId, int menuResId) {
         final Intent intent = new Intent(context, SettingsActivity.class);
-        intent.putExtra(FRAGMENT_RESID_INTENT_EXTRA, fragmentResId);
+        intent.putExtra(PREFERENCES_RESID_INTENT_EXTRA, prefsResId);
         intent.putExtra(TITLE_RESID_INTENT_EXTRA, titleResId);
         if (actionbarIconResId != EXTRA_VALUE_NONE) {
             intent.putExtra(ACTIONBAR_ICON_INTENT_EXTRA, actionbarIconResId);

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -16,8 +16,6 @@ import android.preference.PreferenceFragment;
 import android.preference.PreferenceScreen;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
-import android.view.Menu;
-import android.view.MenuInflater;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.activity.InfoActivity;
@@ -31,10 +29,9 @@ import org.mozilla.focus.widget.DefaultBrowserPreference;
 import java.util.Locale;
 
 public class SettingsFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
+    public static final String FRAGMENT_CLASS_INTENT_EXTRA = "extra_fragment_class";
     public static final String PREFERENCES_RESID_INTENT_EXTRA = "extra_preferences_resid";
     public static final String TITLE_RESID_INTENT_EXTRA = "extra_title_resid";
-    public static final String MENU_RESID_INTENT_EXTRA = "extra_menu_resid";
-    public static final String ACTIONBAR_ICON_INTENT_EXTRA = "extra_actionbar_icon_resid";
 
     public static final int EXTRA_VALUE_NONE = -1;
 
@@ -49,7 +46,6 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-
         // We've checked that this cast is legal in onAttach.
         final ActionBarUpdater updater = (ActionBarUpdater) getActivity();
 
@@ -60,12 +56,6 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         if (args != null) {
             prefResId = args.getInt(PREFERENCES_RESID_INTENT_EXTRA, R.xml.settings);
             titleResId = args.getInt(TITLE_RESID_INTENT_EXTRA, R.string.menu_settings);
-
-            setHasOptionsMenu(args.containsKey(MENU_RESID_INTENT_EXTRA));
-
-            if (args.containsKey(ACTIONBAR_ICON_INTENT_EXTRA)) {
-                updater.updateIcon(args.getInt(ACTIONBAR_ICON_INTENT_EXTRA));
-            }
         }
 
         updater.updateTitle(titleResId);
@@ -78,12 +68,6 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         if (!(getActivity() instanceof ActionBarUpdater)) {
             throw new IllegalArgumentException("Parent activity must implement ActionBarUpdater");
         }
-    }
-
-    @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        final Bundle args = getArguments();
-        inflater.inflate(args.getInt(MENU_RESID_INTENT_EXTRA), menu);
     }
 
     @Override
@@ -111,11 +95,9 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
                     R.string.preference_search_installed_search_engines);
             startActivity(intent);
         } else if (preference.getKey().equals(resources.getString(R.string.pref_key_manual_add_search_engine))) {
-            final Intent intent = getSettingsIntent(getActivity(),
+            final Intent intent = getSettingsIntent(getActivity(), ManualAddSearchEngineSettingsFragment.FRAGMENT_CLASS_TYPE,
                     R.xml.manual_add_search_engine,
-                    R.string.tutorial_search_title,
-                    R.drawable.ic_close,
-                    R.menu.menu_search_engine_manual_add);
+                    R.string.tutorial_search_title);
             startActivity(intent);
         }
 
@@ -123,18 +105,16 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
     }
 
     private static Intent getSettingsIntent(Context context, int prefsResId, int titleResId) {
-        return getSettingsIntent(context, prefsResId, titleResId, EXTRA_VALUE_NONE, EXTRA_VALUE_NONE);
+        return getSettingsIntent(context, EXTRA_VALUE_NONE, prefsResId, titleResId);
     }
 
-    private static Intent getSettingsIntent(Context context, int prefsResId, int titleResId, int actionbarIconResId, int menuResId) {
+    private static Intent getSettingsIntent(Context context, int fragmentClassType, int prefsResId, int titleResId) {
         final Intent intent = new Intent(context, SettingsActivity.class);
         intent.putExtra(PREFERENCES_RESID_INTENT_EXTRA, prefsResId);
         intent.putExtra(TITLE_RESID_INTENT_EXTRA, titleResId);
-        if (actionbarIconResId != EXTRA_VALUE_NONE) {
-            intent.putExtra(ACTIONBAR_ICON_INTENT_EXTRA, actionbarIconResId);
-        }
-        if (menuResId != EXTRA_VALUE_NONE) {
-            intent.putExtra(MENU_RESID_INTENT_EXTRA, menuResId);
+
+        if (fragmentClassType != EXTRA_VALUE_NONE) {
+            intent.putExtra(FRAGMENT_CLASS_INTENT_EXTRA, fragmentClassType);
         }
         return intent;
     }

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -16,6 +16,8 @@ import android.preference.PreferenceFragment;
 import android.preference.PreferenceScreen;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
+import android.view.Menu;
+import android.view.MenuInflater;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.activity.InfoActivity;
@@ -31,6 +33,7 @@ import java.util.Locale;
 public class SettingsFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
     public static final String FRAGMENT_RESID_INTENT_EXTRA = "extra_frament_resid";
     public static final String TITLE_RESID_INTENT_EXTRA = "extra_title_resid";
+    public static final String MENU_RESID_INTENT_EXTRA = "extra_menu_resid";
     public static final String ACTIONBAR_ICON_INTENT_EXTRA = "extra_actionbar_icon_resid";
 
     public static final int EXTRA_VALUE_NONE = -1;
@@ -58,6 +61,8 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
             prefResId = args.getInt(FRAGMENT_RESID_INTENT_EXTRA, R.xml.settings);
             titleResId = args.getInt(TITLE_RESID_INTENT_EXTRA, R.string.menu_settings);
 
+            setHasOptionsMenu(args.containsKey(MENU_RESID_INTENT_EXTRA));
+
             if (args.containsKey(ACTIONBAR_ICON_INTENT_EXTRA)) {
                 updater.updateIcon(args.getInt(ACTIONBAR_ICON_INTENT_EXTRA));
             }
@@ -71,9 +76,16 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
     public void onAttach(Context context) {
         super.onAttach(context);
         if (!(getActivity() instanceof ActionBarUpdater)) {
-            throw new IllegalArgumentException("Parent activity must implement TitleUpdater");
+            throw new IllegalArgumentException("Parent activity must implement ActionBarUpdater");
         }
     }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        final Bundle args = getArguments();
+        inflater.inflate(args.getInt(MENU_RESID_INTENT_EXTRA), menu);
+    }
+
     @Override
     public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen, Preference preference) {
         final Resources resources = getResources();
@@ -100,7 +112,10 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
             startActivity(intent);
         } else if (preference.getKey().equals(resources.getString(R.string.pref_key_manual_add_search_engine))) {
             final Intent intent = getSettingsIntent(getActivity(),
-                    R.xml.manual_add_search_engine, R.string.tutorial_search_title, R.drawable.ic_close);
+                    R.xml.manual_add_search_engine,
+                    R.string.tutorial_search_title,
+                    R.drawable.ic_close,
+                    R.menu.menu_search_engine_manual_add);
             startActivity(intent);
         }
 
@@ -108,15 +123,18 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
     }
 
     private static Intent getSettingsIntent(Context context, int fragmentResId, int titleResId) {
-        return getSettingsIntent(context, fragmentResId, titleResId, EXTRA_VALUE_NONE);
+        return getSettingsIntent(context, fragmentResId, titleResId, EXTRA_VALUE_NONE, EXTRA_VALUE_NONE);
     }
 
-    private static Intent getSettingsIntent(Context context, int fragmentResId, int titleResId, int actionbarIconResId) {
+    private static Intent getSettingsIntent(Context context, int fragmentResId, int titleResId, int actionbarIconResId, int menuResId) {
         final Intent intent = new Intent(context, SettingsActivity.class);
         intent.putExtra(FRAGMENT_RESID_INTENT_EXTRA, fragmentResId);
         intent.putExtra(TITLE_RESID_INTENT_EXTRA, titleResId);
         if (actionbarIconResId != EXTRA_VALUE_NONE) {
             intent.putExtra(ACTIONBAR_ICON_INTENT_EXTRA, actionbarIconResId);
+        }
+        if (menuResId != EXTRA_VALUE_NONE) {
+            intent.putExtra(MENU_RESID_INTENT_EXTRA, menuResId);
         }
         return intent;
     }

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -82,15 +82,25 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
             final Intent intent = InfoActivity.getPrivacyNoticeIntent(getActivity());
             startActivity(intent);
         } else if (preference.getKey().equals(resources.getString(R.string.pref_key_search_engine))) {
-            final Intent intent = new Intent(getActivity(), SettingsActivity.class);
-            intent.putExtra(FRAGMENT_RESID_INTENT_EXTRA, AppConstants.FLAG_MANUAL_SEARCH_ENGINE ? R.xml.search_engine_settings_featureflag_manual : R.xml.search_engine_settings);
-            intent.putExtra(TITLE_RESID_INTENT_EXTRA, R.string.preference_search_installed_search_engines);
+            final Intent intent = getSettingsIntent(getActivity(),
+                    AppConstants.FLAG_MANUAL_SEARCH_ENGINE ? R.xml.search_engine_settings_featureflag_manual: R.xml.search_engine_settings,
+                    R.string.preference_search_installed_search_engines);
             startActivity(intent);
         } else if (preference.getKey().equals(resources.getString(R.string.pref_key_manual_add_search_engine))) {
-            // TODO: Show add search engine page
+            final Intent intent = getSettingsIntent(getActivity(),
+                    R.xml.manual_add_search_engine,
+                    R.string.tutorial_search_title);
+            startActivity(intent);
         }
 
         return super.onPreferenceTreeClick(preferenceScreen, preference);
+    }
+
+    private static Intent getSettingsIntent(Context context, int fragmentResId, int titleResId) {
+        final Intent intent = new Intent(context, SettingsActivity.class);
+        intent.putExtra(FRAGMENT_RESID_INTENT_EXTRA, fragmentResId);
+        intent.putExtra(TITLE_RESID_INTENT_EXTRA, titleResId);
+        return intent;
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
+++ b/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
@@ -35,4 +35,6 @@ public final class AppConstants {
     public static boolean supportsDownloadingFiles() {
         return true;
     }
+
+    public static final boolean FLAG_MANUAL_SEARCH_ENGINE = isDevBuild();
 }

--- a/app/src/main/res/layout/preference_manual_add_search_engine.xml
+++ b/app/src/main/res/layout/preference_manual_add_search_engine.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="@dimen/preference_root_layout_padding">
+
+    <TextView
+        android:defaultFocusHighlightEnabled="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/search_add_manually_name"
+        android:paddingStart="5dp"
+        android:paddingLeft="5dp"
+        android:paddingTop="@dimen/preference_padding_vertical"/>
+
+    <EditText
+        android:id="@+id/edit_engine_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/search_add_manually_name_hint"
+        android:inputType="text"
+        android:nextFocusDown="@+id/edit_search_string"/>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/search_add_manually_string"
+        android:paddingStart="5dp"
+        android:paddingLeft="5dp"
+        android:paddingTop="@dimen/preference_padding_vertical"/>
+
+    <EditText
+        android:id="@id/edit_search_string"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/search_add_manually_string_hint"
+        android:nextFocusUp="@id/edit_engine_name"/>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/search_add_manually_example"
+        android:textColor="@android:color/tertiary_text_dark"
+        android:paddingStart="5dp"
+        android:paddingLeft="5dp"/>
+</LinearLayout>

--- a/app/src/main/res/menu/menu_search_engine_manual_add.xml
+++ b/app/src/main/res/menu/menu_search_engine_manual_add.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:id="@+id/menu_save_search_engine"
+        android:title="@string/search_add_manually_save"
+        app:showAsAction="always"/>
+</menu>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -32,6 +32,7 @@
 
     <dimen name="dialogHorizontalPadding">24dp</dimen>
 
+    <dimen name="preference_root_layout_padding">5dp</dimen>
     <dimen name="preference_icon_drawable_size">24dp</dimen>
     <dimen name="preference_drawable_padding">32dp</dimen>
     <dimen name="preference_padding_top">8dp</dimen>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="pref_key_search_engine" translatable="false"><xliff:g id="preference_key">pref_search_engine</xliff:g></string>
+    <string name="pref_key_manual_add_search_engine" translatable="false"><xliff:g id="preference_key">pref_manual_add_search_engine</xliff:g></string>
 
     <string name="pref_key_privacy_block_ads" translatable="false"><xliff:g id="preference_key">pref_privacy_block_ads</xliff:g></string>
     <string name="pref_key_privacy_block_analytics" translatable="false"><xliff:g id="preference_key">pref_privacy_block_analytics</xliff:g></string>

--- a/app/src/main/res/xml/manual_add_search_engine.xml
+++ b/app/src/main/res/xml/manual_add_search_engine.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <Preference android:layout="@layout/preference_manual_add_search_engine"/>
+</PreferenceScreen>

--- a/app/src/main/res/xml/search_engine_settings_featureflag_manual.xml
+++ b/app/src/main/res/xml/search_engine_settings_featureflag_manual.xml
@@ -3,7 +3,11 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<!-- Changes should be mirrored to search_engine_settings_featureflag_manual, which is behind a feature flag. -->
+<!-- This preffed off by feature flag FLAG_MANUAL_SEARCH_ENGINE and corresponds to
+search_engine_settings.xml -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <org.mozilla.focus.search.SearchEngineChooserPreference />
+    <Preference
+        android:title="@string/preference_search_add2"
+        android:key="@string/pref_key_manual_add_search_engine"/>
 </PreferenceScreen>


### PR DESCRIPTION
This is for adding the code for adding a "add search engine manually" preference screen.

The next step is to add xml handling for committing the search engines, but that is getting long and isn't done yet, so since this is behind a feature flag anyway, opening a PR and then splitting off committing into a separate issue.