### PR TITLE
setCompoundDrawables method for sizing of search icon closes #1618

### DIFF
--- a/app/src/main/java/org/mozilla/focus/search/SearchEngineChooserPreference.java
+++ b/app/src/main/java/org/mozilla/focus/search/SearchEngineChooserPreference.java
@@ -79,7 +79,7 @@ public class SearchEngineChooserPreference extends Preference implements RadioGr
         final int iconSize = (int) res.getDimension(R.dimen.preference_icon_drawable_size);
         final BitmapDrawable engineIcon = new BitmapDrawable(res, engine.getIcon());
         engineIcon.setBounds(0, 0, iconSize, iconSize);
-        radioButton.setCompoundDrawablesWithIntrinsicBounds(engineIcon, null, null, null);
+        radioButton.setCompoundDrawables(engineIcon, null, null, null);
         return radioButton;
     }
 }


### PR DESCRIPTION
IntrinsicBounds method did not hold my setBounds resizing. 