### PR TITLE
Save custom search engine

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,7 +81,7 @@
         <activity android:name=".activity.SettingsActivity"
             android:theme="@style/SettingsTheme"
             android:configChanges="locale"
-            android:windowSoftInputMode="adjustPan" />
+            android:windowSoftInputMode="adjustResize" />
 
         <activity android:name=".activity.InfoActivity"
                   android:theme="@style/InfoTheme"/>

--- a/app/src/main/java/org/mozilla/focus/search/SearchEngine.java
+++ b/app/src/main/java/org/mozilla/focus/search/SearchEngine.java
@@ -5,44 +5,17 @@
 
 package org.mozilla.focus.search;
 
-import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.net.Uri;
-import android.util.Log;
 
-import org.mozilla.focus.shortcut.IconGenerator;
-import org.mozilla.focus.utils.BitmapUtils;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-
-import java.io.StringWriter;
-import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
-
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class SearchEngine {
-    private static final String LOGTAG = "SearchEngine";
     public static final String PREF_FILE_SEARCH_ENGINES = "custom-search-engines";
-    public static final String PREF_KEY_CUSTOM_SEARCH_ENGINES = "pref_custom_search_engines";
-    private static final String PREF_KEY_CUSTOM_SEARCH_VERSION = "pref_custom_search_version";
-    private static final int CUSTOM_SEARCH_VERSION = 1;
 
     // Parameters copied from nsSearchService.js
     private static final String MOZ_PARAM_LOCALE = "\\{moz:locale\\}";
@@ -131,78 +104,4 @@ public class SearchEngine {
         return template;
     }
 
-    public static boolean addSearchEngine(SharedPreferences sharedPreferences, Context context, String engineName, String searchQuery) {
-        final Bitmap iconBitmap = IconGenerator.generateLauncherIcon(context, searchQuery);
-        final String searchEngineXml = buildSearchEngineXML(engineName, searchQuery, iconBitmap);
-        if (searchEngineXml == null) {
-            return false;
-        }
-        final Set<String> existingEngines = sharedPreferences.getStringSet(PREF_KEY_CUSTOM_SEARCH_ENGINES, Collections.<String>emptySet());
-        final Set<String> newEngines = new LinkedHashSet<>();
-        newEngines.addAll(existingEngines);
-        newEngines.add(engineName);
-
-        sharedPreferences.edit().putInt(PREF_KEY_CUSTOM_SEARCH_VERSION, CUSTOM_SEARCH_VERSION)
-                .putStringSet(PREF_KEY_CUSTOM_SEARCH_ENGINES, newEngines)
-                .putString(engineName, searchEngineXml)
-                .apply();
-
-        // Force SearchEngineManager to refetch, to get the newest search engine.
-        SearchEngineManager.getInstance().init(context);
-        return true;
-    }
-
-    public static String buildSearchEngineXML(String engineName, String searchQuery, Bitmap iconBitmap) {
-        Document document = null;
-        try {
-            document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
-            final Element rootElement = document.createElement("OpenSearchDescription");
-            rootElement.setAttribute("xmlns", "http://a9.com/-/spec/opensearch/1.1/");
-            document.appendChild(rootElement);
-
-            final Element shortNameElement = document.createElement("ShortName");
-            shortNameElement.setTextContent(engineName);
-            rootElement.appendChild(shortNameElement);
-
-            final Element imageElement = document.createElement("Image");
-            imageElement.setAttribute("width", "16");
-            imageElement.setAttribute("height", "16");
-            imageElement.setTextContent(BitmapUtils.getBase64EncodedDataUriFromBitmap(iconBitmap));
-            rootElement.appendChild(imageElement);
-
-            final Element descriptionElement = document.createElement("Description");
-            descriptionElement.setTextContent(engineName);
-            rootElement.appendChild(descriptionElement);
-
-            final Element urlElement = document.createElement("Url");
-            urlElement.setAttribute("type", "text/html");
-            // Simple implementation that assumes "%s" terminator from UrlUtils.isValidSearchEngineQueryUrl
-            final String templateSearchString = searchQuery.substring(0, searchQuery.length() - 2) + "{searchTerms}";
-            urlElement.setAttribute("template", templateSearchString);
-            rootElement.appendChild(urlElement);
-
-        } catch (ParserConfigurationException e) {
-            Log.e(LOGTAG, "Couldn't create new Document for building search engine XML", e);
-            return null;
-        }
-        return XMLtoString(document);
-    }
-
-    private static String XMLtoString(Document doc) {
-        if (doc == null) {
-            return null;
-        }
-
-        final Writer writer = new StringWriter();
-        try {
-            final Transformer tf = TransformerFactory.newInstance().newTransformer();
-            tf.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
-            tf.transform(new DOMSource(doc), new StreamResult(writer));
-        } catch (TransformerConfigurationException e) {
-            return null;
-        } catch (TransformerException e) {
-            return null;
-        }
-        return writer.toString();
-    }
 }

--- a/app/src/main/java/org/mozilla/focus/search/SearchEngine.java
+++ b/app/src/main/java/org/mozilla/focus/search/SearchEngine.java
@@ -146,6 +146,9 @@ public class SearchEngine {
                 .putStringSet(PREF_KEY_CUSTOM_SEARCH_ENGINES, newEngines)
                 .putString(engineName, searchEngineXml)
                 .apply();
+
+        // Force SearchEngineManager to refetch, to get the newest search engine.
+        SearchEngineManager.getInstance().init(context);
         return true;
     }
 

--- a/app/src/main/java/org/mozilla/focus/search/SearchEngineChooserPreference.java
+++ b/app/src/main/java/org/mozilla/focus/search/SearchEngineChooserPreference.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 public class SearchEngineChooserPreference extends Preference implements RadioGroup.OnCheckedChangeListener {
     private List<SearchEngine> searchEngines;
+    private RadioGroup searchEngineGroup;
 
     public SearchEngineChooserPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -38,9 +39,9 @@ public class SearchEngineChooserPreference extends Preference implements RadioGr
     @Override
     protected View onCreateView(ViewGroup parent) {
         final View layoutView = super.onCreateView(parent);
-        final RadioGroup searchEngineGroup = layoutView.findViewById(R.id.search_engine_group);
+        searchEngineGroup = layoutView.findViewById(R.id.search_engine_group);
         searchEngineGroup.setOnCheckedChangeListener(this);
-        refreshSearchEngines(searchEngineGroup);
+        refreshSearchEngines();
         return layoutView;
     }
 
@@ -49,15 +50,19 @@ public class SearchEngineChooserPreference extends Preference implements RadioGr
         Settings.getInstance(group.getContext()).setDefaultSearchEngine(searchEngines.get(checkedId));
     }
 
-    private void refreshSearchEngines(final RadioGroup engineRadioGroup) {
+    public void refreshSearchEngines() {
+        if (searchEngineGroup == null) {
+            // There is no search engine group yet.
+            return;
+        }
         final SearchEngineManager sem = SearchEngineManager.getInstance();
-        final Context context = engineRadioGroup.getContext();
+        final Context context = searchEngineGroup.getContext();
         final Resources resources = context.getResources();
 
         searchEngines = sem.getSearchEngines();
         final String defaultSearchEngine = sem.getDefaultSearchEngine(context).getIdentifier();
 
-        engineRadioGroup.removeAllViews();
+        searchEngineGroup.removeAllViews();
 
         final LayoutInflater layoutInflater = LayoutInflater.from(context);
         final RecyclerView.LayoutParams layoutParams = new RecyclerView.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -69,7 +74,7 @@ public class SearchEngineChooserPreference extends Preference implements RadioGr
             if (engine.getIdentifier().equals(defaultSearchEngine)) {
                 engineItem.setChecked(true);
             }
-            engineRadioGroup.addView(engineItem, layoutParams);
+            searchEngineGroup.addView(engineItem, layoutParams);
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/search/SearchEngineParser.java
+++ b/app/src/main/java/org/mozilla/focus/search/SearchEngineParser.java
@@ -8,6 +8,7 @@ package org.mozilla.focus.search;
 import android.content.res.AssetManager;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
+import android.support.annotation.VisibleForTesting;
 import android.util.Base64;
 
 import org.xmlpull.v1.XmlPullParser;
@@ -38,7 +39,7 @@ import java.nio.charset.StandardCharsets;
         }
     }
 
-    public static SearchEngine load(String identifier, InputStream stream) throws IOException, XmlPullParserException {
+    /* package */ @VisibleForTesting static SearchEngine load(String identifier, InputStream stream) throws IOException, XmlPullParserException {
         final SearchEngine searchEngine = new SearchEngine(identifier);
 
         XmlPullParser parser = XmlPullParserFactory.newInstance().newPullParser();

--- a/app/src/main/java/org/mozilla/focus/search/SearchEngineParser.java
+++ b/app/src/main/java/org/mozilla/focus/search/SearchEngineParser.java
@@ -8,7 +8,6 @@ package org.mozilla.focus.search;
 import android.content.res.AssetManager;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
-import android.support.annotation.VisibleForTesting;
 import android.util.Base64;
 
 import org.xmlpull.v1.XmlPullParser;
@@ -39,7 +38,7 @@ import java.nio.charset.StandardCharsets;
         }
     }
 
-    @VisibleForTesting static SearchEngine load(String identifier, InputStream stream) throws IOException, XmlPullParserException {
+    public static SearchEngine load(String identifier, InputStream stream) throws IOException, XmlPullParserException {
         final SearchEngine searchEngine = new SearchEngine(identifier);
 
         XmlPullParser parser = XmlPullParserFactory.newInstance().newPullParser();

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
@@ -18,6 +18,7 @@ import android.widget.EditText;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.search.SearchEngine;
+import org.mozilla.focus.search.SearchEngineManager;
 import org.mozilla.focus.utils.UrlUtils;
 
 import java.util.Collections;
@@ -63,9 +64,9 @@ public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
                 if (!validateSearchFields(engineName, searchQuery, sharedPreferences)) {
                     Snackbar.make(rootView, R.string.search_add_error, Snackbar.LENGTH_SHORT).show();
                 } else {
-                    SearchEngine.addSearchEngine(sharedPreferences, getActivity(), engineName, searchQuery);
+                    SearchEngineManager.addSearchEngine(sharedPreferences, getActivity(), engineName, searchQuery);
                     Snackbar.make(rootView, R.string.search_add_confirmation, Snackbar.LENGTH_SHORT).show();
-                    getActivity().onBackPressed();
+                    getFragmentManager().popBackStack();
                 }
                 return true;
             default:
@@ -78,7 +79,7 @@ public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
             return false;
         }
 
-        if (sharedPreferences.getStringSet(SearchEngine.PREF_KEY_CUSTOM_SEARCH_ENGINES,
+        if (sharedPreferences.getStringSet(SearchEngineManager.PREF_KEY_CUSTOM_SEARCH_ENGINES,
                 Collections.<String>emptySet()).contains(engineName)) {
             return false;
         }

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
@@ -6,11 +6,16 @@ package org.mozilla.focus.settings;
 
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
+import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
+import android.widget.EditText;
 
 import org.mozilla.focus.R;
+import org.mozilla.focus.utils.UrlUtils;
 
 public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
     public static final int FRAGMENT_CLASS_TYPE = 1; // Unique SettingsFragment identifier
@@ -44,10 +49,23 @@ public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.menu_save_search_engine:
-                // TODO: Save engineName and searchString
+                final View rootView = getView();
+                final String engineName = ((EditText) rootView.findViewById(R.id.edit_engine_name)).getText().toString();
+                final String searchString = ((EditText) rootView.findViewById(R.id.edit_search_string)).getText().toString();
+                if (!validateSearchFields(engineName, searchString)) {
+                    Snackbar.make(rootView, R.string.search_add_error, Snackbar.LENGTH_SHORT).show();
+                }
                 return true;
             default:
                 return super.onOptionsItemSelected(item);
         }
+    }
+
+    private static boolean validateSearchFields(String engineName, String searchString) {
+        if (TextUtils.isEmpty(engineName)) {
+            return false;
+        }
+
+        return UrlUtils.isValidSearchQueryUrl(searchString);
     }
 }

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -21,6 +21,7 @@ import org.mozilla.focus.activity.InfoActivity;
 import org.mozilla.focus.activity.SettingsActivity;
 import org.mozilla.focus.locale.LocaleManager;
 import org.mozilla.focus.locale.Locales;
+import org.mozilla.focus.search.SearchEngineChooserPreference;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.utils.AppConstants;
 import org.mozilla.focus.widget.DefaultBrowserPreference;
@@ -144,6 +145,18 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
                 R.string.menu_settings;
         updater.updateTitle(titleResId);
         updater.updateIcon(R.drawable.ic_back);
+
+        // TODO: #1671 would add Enum types so figuring out the current Settings screen is cleaner
+        if (args != null && args.getInt(PREFERENCES_RESID_INTENT_EXTRA, 0) == R.xml.search_engine_settings_featureflag_manual) {
+            final PreferenceScreen prefScreen = getPreferenceScreen();
+            final int prefCount = prefScreen.getPreferenceCount();
+            for (int i = 0; i < prefCount; i++) {
+                final Preference pref = prefScreen.getPreference(i);
+                if (pref instanceof SearchEngineChooserPreference) {
+                    ((SearchEngineChooserPreference) pref).refreshSearchEngines();
+                }
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/focus/utils/BitmapUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/BitmapUtils.java
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.focus.utils;
+
+import android.graphics.Bitmap;
+import android.util.Base64;
+
+import java.io.ByteArrayOutputStream;
+
+public class BitmapUtils {
+    public static String getBase64EncodedDataUriFromBitmap(Bitmap bitmap) {
+        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+        final String encodedImage = Base64.encodeToString(stream.toByteArray(), Base64.DEFAULT);
+        return "data:image/png;base64," + encodedImage;
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
@@ -10,6 +10,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
+import android.webkit.URLUtil;
 
 import org.mozilla.focus.search.SearchEngine;
 import org.mozilla.focus.search.SearchEngineManager;
@@ -41,6 +42,24 @@ public class UrlUtils {
         }
 
         return trimmedUrl.contains(".") || trimmedUrl.contains(":");
+    }
+
+    public static boolean isValidSearchQueryUrl(String url) {
+        String trimmedUrl = url.trim();
+        if (!trimmedUrl.matches("^.+?://.+?")) {
+            // UI hint url doesn't have http scheme, so add it if necessary
+            trimmedUrl = "http://" + trimmedUrl;
+        }
+
+        if (!URLUtil.isNetworkUrl(trimmedUrl)) {
+            return false;
+        }
+
+        if (!trimmedUrl.matches(".*%s$")) {
+            return false;
+        }
+
+        return true;
     }
 
     public static boolean isHttpOrHttps(String url) {

--- a/app/src/test/java/org/mozilla/focus/utils/UrlUtilsTest.java
+++ b/app/src/test/java/org/mozilla/focus/utils/UrlUtilsTest.java
@@ -13,6 +13,19 @@ import static org.junit.Assert.assertTrue;
 @RunWith(RobolectricTestRunner.class)
 public class UrlUtilsTest {
     @Test
+    public void isValidSearchQueryUrl() {
+        assertTrue(UrlUtils.isValidSearchQueryUrl("https://example.com/search/?q=%s"));
+        assertTrue(UrlUtils.isValidSearchQueryUrl("http://example.com/search/?q=%s"));
+        assertTrue(UrlUtils.isValidSearchQueryUrl("http-test-site.com/search/?q=%s"));
+        assertFalse(UrlUtils.isValidSearchQueryUrl("httpss://example.com/search/?q=%s"));
+
+        assertTrue(UrlUtils.isValidSearchQueryUrl("example.com/search/?q=%s"));
+        assertTrue(UrlUtils.isValidSearchQueryUrl(" example.com/search/?q=%s "));
+
+        assertFalse(UrlUtils.isValidSearchQueryUrl("htps://example.com/search/?q=%s"));
+    }
+
+    @Test
     public void urlsMatchExceptForTrailingSlash() throws Exception {
         assertTrue(UrlUtils.urlsMatchExceptForTrailingSlash("http://www.mozilla.org", "http://www.mozilla.org"));
         assertTrue(UrlUtils.urlsMatchExceptForTrailingSlash("http://www.mozilla.org/", "http://www.mozilla.org"));


### PR DESCRIPTION
This adds the functionality behind the "Save" on the (manual) add search engine page.

The search engines are saved in the OpenSearch xml format, so we can reuse code and to be forward-compatible if we fetch OpenSearch search engines from webpages that supply them for search engines.

(Sorry about the commits covering multiple topics - I accidentally combined some commits during a rebase!)