### PR TITLE
Closes #1671. Use enum for settings screen types.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/SettingsActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/SettingsActivity.java
@@ -32,7 +32,7 @@ public class SettingsActivity extends LocaleAwareAppCompatActivity implements Se
 
         actionBar.setDisplayHomeAsUpEnabled(true);
 
-        final PreferenceFragment fragment = SettingsFragment.newInstance(getIntent().getExtras(), R.xml.settings, R.string.menu_settings);
+        final PreferenceFragment fragment = SettingsFragment.newInstance(getIntent().getExtras(), SettingsFragment.SettingsScreen.MAIN);
 
         getFragmentManager().beginTransaction()
                 .replace(R.id.container, fragment)

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
@@ -24,14 +24,6 @@ import org.mozilla.focus.utils.UrlUtils;
 import java.util.Collections;
 
 public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
-    public static final int FRAGMENT_CLASS_TYPE = 1; // Unique SettingsFragment identifier
-
-    public static SettingsFragment newInstance(Bundle intentArgs, int prefsResId, int titleResId) {
-        SettingsFragment f = new ManualAddSearchEngineSettingsFragment();
-        f.setArguments(makeArgumentBundle(intentArgs, prefsResId, titleResId));
-        return f;
-    }
-
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);


### PR DESCRIPTION
Use an enum instead of crazy pairings of resource ids.