### PR TITLE
Disable swipe to refresh on error pages closes #1685

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -299,6 +299,13 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
             initialiseNormalBrowserUi(view);
         }
 
+        session.getIsErrorPage().observe(this, new Observer<Boolean>() {
+            @Override
+            public void onChanged(Boolean isErrorPage) {
+                swipeRefresh.setEnabled(!isErrorPage);
+            }
+        });
+
         return view;
     }
 
@@ -414,7 +421,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
     public IWebView.Callback createCallback() {
         return new SessionCallbackProxy(session, new IWebView.Callback() {
             @Override
-            public void onPageStarted(final String url) {}
+            public void onPageStarted(final String url, final boolean isErrorPage) {}
 
             @Override
             public void onPageFinished(boolean isSecure) {}

--- a/app/src/main/java/org/mozilla/focus/fragment/InfoFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/InfoFragment.java
@@ -61,7 +61,7 @@ public class InfoFragment extends WebFragment {
     public IWebView.Callback createCallback() {
         return new IWebView.Callback() {
             @Override
-            public void onPageStarted(final String url) {
+            public void onPageStarted(final String url, final boolean isErrorPage) {
                 progressView.announceForAccessibility(getString(R.string.accessibility_announcement_loading));
 
                 progressView.setVisibility(View.VISIBLE);

--- a/app/src/main/java/org/mozilla/focus/session/Session.java
+++ b/app/src/main/java/org/mozilla/focus/session/Session.java
@@ -23,6 +23,7 @@ public class Session {
     private final NonNullMutableLiveData<String> url;
     private final NonNullMutableLiveData<Integer> progress;
     private final NonNullMutableLiveData<Boolean> secure;
+    private final NonNullMutableLiveData<Boolean> isErrorPage;
     private final NonNullMutableLiveData<Boolean> loading;
     private final NonNullMutableLiveData<Integer> trackersBlocked;
     private CustomTabConfig customTabConfig;
@@ -39,6 +40,7 @@ public class Session {
         this.url = new NonNullMutableLiveData<>(url);
         this.progress = new NonNullMutableLiveData<>(0);
         this.secure = new NonNullMutableLiveData<>(false);
+        this.isErrorPage = new NonNullMutableLiveData<>(false);
         this.loading = new NonNullMutableLiveData<>(false);
         this.trackersBlocked = new NonNullMutableLiveData<>(0);
 
@@ -82,6 +84,14 @@ public class Session {
 
     public NonNullLiveData<Boolean> getSecure() {
         return secure;
+    }
+
+    /* package */ void setIsErrorPage(boolean isErrorPage) {
+        this.isErrorPage.setValue(isErrorPage);
+    }
+
+    public NonNullLiveData<Boolean> getIsErrorPage() {
+        return isErrorPage;
     }
 
     /* package */ void setLoading(boolean loading) {

--- a/app/src/main/java/org/mozilla/focus/session/SessionCallbackProxy.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionCallbackProxy.java
@@ -23,9 +23,10 @@ public class SessionCallbackProxy implements IWebView.Callback {
     }
 
     @Override
-    public void onPageStarted(String url) {
+    public void onPageStarted(String url, boolean isErrorPage) {
         session.setLoading(true);
         session.setSecure(false);
+        session.setIsErrorPage(isErrorPage);
 
         // We are always setting the progress to 5% when a new page starts loading. Otherwise it might
         // look like the browser is doing nothing (on a slow network) until we receive a progress

--- a/app/src/main/java/org/mozilla/focus/web/IWebView.java
+++ b/app/src/main/java/org/mozilla/focus/web/IWebView.java
@@ -36,7 +36,7 @@ public interface IWebView {
     }
 
     interface Callback {
-        void onPageStarted(String url);
+        void onPageStarted(String url, boolean isErrorPage);
 
         void onPageFinished(boolean isSecure);
         void onProgress(int progress);

--- a/app/src/webview/java/org/mozilla/focus/webview/FocusWebViewClient.java
+++ b/app/src/webview/java/org/mozilla/focus/webview/FocusWebViewClient.java
@@ -151,8 +151,11 @@ import org.mozilla.focus.web.IWebView;
             // Since the final onPageFinished isn't guaranteed (and we know we're showing an error
             // page already), we don't need to send the onPageStarted() callback a second time anyway.
             errorReceived = false;
+            if (callback != null) {
+                callback.onPageStarted(url, true);
+            }
         } else if (callback != null) {
-            callback.onPageStarted(url);
+            callback.onPageStarted(url, false);
         }
 
         super.onPageStarted(view, url, favicon);


### PR DESCRIPTION
This would be a quick fix to disable the swipe to refresh on error pages. I think a problem lies in that the second onPageFinished is not called for error pages, and so the swipe reload animation never ends? 