### PR TITLE
Record when user opens Focus via tap on Focus app icon closes #1635

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -62,6 +62,10 @@ public class MainActivity extends LocaleAwareAppCompatActivity {
 
         final SafeIntent intent = new SafeIntent(getIntent());
 
+        if (intent.isLauncherIntent()) {
+            TelemetryWrapper.openFromIconEvent();
+        }
+
         sessionManager.handleIntent(this, intent, savedInstanceState);
 
         sessionManager.getSessions().observe(this,  new NonNullObserver<List<Session>>() {
@@ -145,6 +149,10 @@ public class MainActivity extends LocaleAwareAppCompatActivity {
 
         if (ACTION_ERASE.equals(action)) {
             processEraseAction(intent);
+        }
+
+        if (intent.isLauncherIntent()) {
+            TelemetryWrapper.resumeFromIconEvent();
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
@@ -91,6 +91,7 @@ public final class TelemetryWrapper {
         private static final String HOMESCREEN_SHORTCUT = "homescreen_shortcut";
         private static final String TABS_TRAY = "tabs_tray";
         private static final String RECENT_APPS = "recent_apps";
+        private static final String APP_ICON = "app_icon";
     }
 
     private static class Value {
@@ -114,6 +115,7 @@ public final class TelemetryWrapper {
         private static final String ADD_TO_HOMESCREEN = "add_to_homescreen";
         private static final String TAB = "tab";
         private static final String WHATS_NEW = "whats_new";
+        private static final String RESUME = "resume";
     }
 
     private static class Extra {
@@ -428,6 +430,14 @@ public final class TelemetryWrapper {
 
     public static void openDefaultAppEvent() {
         TelemetryEvent.create(Category.ACTION, Method.OPEN, Object.MENU, Value.DEFAULT).queue();
+    }
+
+    public static void openFromIconEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.APP_ICON, Value.OPEN).queue();
+    }
+
+    public static void resumeFromIconEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.APP_ICON, Value.RESUME).queue();
     }
 
     public static void openFirefoxEvent() {

--- a/app/src/main/java/org/mozilla/focus/utils/SafeIntent.java
+++ b/app/src/main/java/org/mozilla/focus/utils/SafeIntent.java
@@ -18,6 +18,7 @@ import android.support.annotation.Nullable;
 import android.util.Log;
 
 import java.util.ArrayList;
+import java.util.Set;
 
 /**
  * External applications can pass values into Intents that can cause us to crash: in defense,
@@ -189,6 +190,23 @@ public class SafeIntent {
             Log.w(LOGTAG, "Couldn't get intent data.", e);
             return null;
         }
+    }
+
+    public Set<String> getCategories() {
+        try {
+            return intent.getCategories();
+        } catch (OutOfMemoryError e) {
+            Log.w(LOGTAG, "Couldn't get intent categories: OOM. Malformed?");
+            return null;
+        } catch (RuntimeException e) {
+            Log.w(LOGTAG, "Couldn't get intent categories.", e);
+            return null;
+        }
+    }
+
+    public boolean isLauncherIntent() {
+        final Set<String> intentCategories = intent.getCategories();
+        return (intentCategories != null && intentCategories.contains(Intent.CATEGORY_LAUNCHER) && intent.getAction().equals(Intent.ACTION_MAIN));
     }
 
     public Intent getUnsafe() {


### PR DESCRIPTION
@bbinto This would add a telemetry probe to record opening Focus ("actual app launches") from an icon if it is *not* currently open; the first option @pocmo gave you in #1635 . Wasn't sure from the discussion if we want two probes or to record all clicks on the App Icon, so I can change this to include "app resumed from the launcher icon" case as well if you like!