### PR TITLE
Swipe to close tab

### DIFF
--- a/app/src/main/java/org/mozilla/focus/session/SessionManager.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionManager.java
@@ -230,6 +230,15 @@ public class SessionManager {
         removeSession(currentSessionUUID);
     }
 
+    /**
+     * Remove the session by its UUID.
+     */
+    public void removeSessionByUUID(@NonNull int position) {
+        final Session session = this.sessions.getValue().get(position);
+        final String deleteId = session.getUUID();
+        removeSession(deleteId);
+    }
+
     @VisibleForTesting void removeSession(String uuid) {
         final List<Session> sessions = new ArrayList<>();
 

--- a/app/src/main/java/org/mozilla/focus/session/SessionManager.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionManager.java
@@ -227,19 +227,22 @@ public class SessionManager {
      * Remove the current (selected) session.
      */
     public void removeCurrentSession() {
-        removeSession(currentSessionUUID);
+        removeSessionByUUID(currentSessionUUID);
     }
 
     /**
-     * Remove the session by its UUID.
+     * Remove a session by its position.
      */
-    public void removeSessionByUUID(@NonNull int position) {
+    public void removeSessionByPosition(@NonNull int position) {
         final Session session = this.sessions.getValue().get(position);
         final String deleteId = session.getUUID();
-        removeSession(deleteId);
+        removeSessionByUUID(deleteId);
     }
 
-    @VisibleForTesting void removeSession(String uuid) {
+    /**
+     * Remove a session by its UUID.
+     */
+    @VisibleForTesting void removeSessionByUUID(String uuid) {
         final List<Session> sessions = new ArrayList<>();
 
         int removedFromPosition = -1;

--- a/app/src/main/java/org/mozilla/focus/session/ui/SessionsSheetFragment.java
+++ b/app/src/main/java/org/mozilla/focus/session/ui/SessionsSheetFragment.java
@@ -6,10 +6,18 @@ package org.mozilla.focus.session.ui;
 
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.helper.ItemTouchHelper;
+import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewAnimationUtils;
@@ -55,8 +63,74 @@ public class SessionsSheetFragment extends LocaleAwareFragment implements View.O
         sessionView.setLayoutManager(new LinearLayoutManager(getContext(), LinearLayoutManager.VERTICAL, false));
         sessionView.setAdapter(sessionsAdapter);
 
+        ItemTouchHelper itemTouchHelper = new ItemTouchHelper(simpleCallback);
+        itemTouchHelper.attachToRecyclerView(sessionView);
+
         return view;
     }
+
+    public static Bitmap getBitmapFromVectorDrawable(Context context, int drawableId) {
+        Drawable drawable = ContextCompat.getDrawable(context, drawableId);
+
+        Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(),
+                drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        drawable.draw(canvas);
+
+        return bitmap;
+    }
+
+    ItemTouchHelper.SimpleCallback simpleCallback = new ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT ) {
+        @Override
+        public boolean onMove(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, RecyclerView.ViewHolder target) {
+            return false;
+        }
+
+        public static final float ALPHA_FULL = 1.0f;
+
+        public void onChildDraw(Canvas c, RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, float dX, float dY, int actionState, boolean isCurrentlyActive) {
+            if (actionState == ItemTouchHelper.ACTION_STATE_SWIPE) {
+                View itemView = viewHolder.itemView;
+
+                Paint paint = new Paint();
+                Bitmap icon;
+
+                if (!(dX > 0)) {
+                    icon = getBitmapFromVectorDrawable (getContext(), R.drawable.ic_delete);
+
+                    int color = getContext().getResources().getColor(R.color.photonMagenta80);
+                    paint.setColor(color);
+
+                    c.drawRect((float) itemView.getRight() + dX, (float) itemView.getTop(),
+                            (float) itemView.getRight(), (float) itemView.getBottom(), paint);
+
+                    c.drawBitmap(icon,
+                            (float) itemView.getRight() - convertDpToPx(16) - icon.getWidth(),
+                            (float) itemView.getTop() + ((float) itemView.getBottom() - (float) itemView.getTop() - icon.getHeight()) / 2,
+                            paint);
+                }
+
+                final float alpha = ALPHA_FULL - Math.abs(dX) / (float) viewHolder.itemView.getWidth();
+                viewHolder.itemView.setAlpha(alpha);
+                viewHolder.itemView.setTranslationX(dX);
+
+            } else {
+                super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive);
+            }
+        }
+
+        private int convertDpToPx(int dp) {
+            return Math.round(dp * (getResources().getDisplayMetrics().xdpi / DisplayMetrics.DENSITY_DEFAULT));
+        }
+
+        @Override
+        public void onSwiped(final RecyclerView.ViewHolder viewHolder, int direction) {
+            if (direction == ItemTouchHelper.LEFT) {
+                SessionManager.getInstance().removeCurrentSession();
+            }
+        }
+    };
 
     private Animator playAnimation(final boolean reverse) {
         isAnimating = true;

--- a/app/src/main/java/org/mozilla/focus/session/ui/SessionsSheetFragment.java
+++ b/app/src/main/java/org/mozilla/focus/session/ui/SessionsSheetFragment.java
@@ -32,6 +32,7 @@ import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.utils.OneShotOnPreDrawListener;
 
 public class SessionsSheetFragment extends LocaleAwareFragment implements View.OnClickListener {
+    private static final String TAG = "SessionsSheetFragment";
     public static final String FRAGMENT_TAG = "tab_sheet";
 
     private static final int ANIMATION_DURATION = 200;
@@ -127,7 +128,8 @@ public class SessionsSheetFragment extends LocaleAwareFragment implements View.O
         @Override
         public void onSwiped(final RecyclerView.ViewHolder viewHolder, int direction) {
             if (direction == ItemTouchHelper.LEFT) {
-                SessionManager.getInstance().removeCurrentSession();
+                final int deleteIndex = viewHolder.getAdapterPosition();
+                SessionManager.getInstance().removeSessionByUUID(deleteIndex);
             }
         }
     };

--- a/app/src/main/java/org/mozilla/focus/session/ui/SessionsSheetFragment.java
+++ b/app/src/main/java/org/mozilla/focus/session/ui/SessionsSheetFragment.java
@@ -32,7 +32,6 @@ import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.utils.OneShotOnPreDrawListener;
 
 public class SessionsSheetFragment extends LocaleAwareFragment implements View.OnClickListener {
-    private static final String TAG = "SessionsSheetFragment";
     public static final String FRAGMENT_TAG = "tab_sheet";
 
     private static final int ANIMATION_DURATION = 200;
@@ -129,7 +128,7 @@ public class SessionsSheetFragment extends LocaleAwareFragment implements View.O
         public void onSwiped(final RecyclerView.ViewHolder viewHolder, int direction) {
             if (direction == ItemTouchHelper.LEFT) {
                 final int deleteIndex = viewHolder.getAdapterPosition();
-                SessionManager.getInstance().removeSessionByUUID(deleteIndex);
+                SessionManager.getInstance().removeSessionByPosition(deleteIndex);
             }
         }
     };

--- a/app/src/test/java/org/mozilla/focus/session/SessionManagerTest.java
+++ b/app/src/test/java/org/mozilla/focus/session/SessionManagerTest.java
@@ -285,7 +285,7 @@ public class SessionManagerTest {
     @Test
     public void testRemovingUnknownSessionHasNoEffect() {
         final SessionManager sessionManager = SessionManager.getInstance();
-        sessionManager.removeSession(UUID.randomUUID().toString());
+        sessionManager.removeSessionByUUID(UUID.randomUUID().toString());
 
         assertFalse(sessionManager.hasSession());
         assertEquals(0, sessionManager.getSessions().getValue().size());


### PR DESCRIPTION
Implemented a way to close individual tabs, wherein the user has to swipe left on the tab to close it.
It is consistent with material design guidelines as Google also uses this functionality in its apps, like the Gmail app.

Closes #1362 