### PR TITLE
Update manual search engine error strings.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
@@ -50,8 +50,12 @@ public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
                 final String searchQuery = ((EditText) rootView.findViewById(R.id.edit_search_string)).getText().toString();
 
                 final SharedPreferences sharedPreferences = getSearchEngineSharedPreferences();
-                if (!validateSearchFields(engineName, searchQuery, sharedPreferences)) {
-                    Snackbar.make(rootView, R.string.search_add_error, Snackbar.LENGTH_SHORT).show();
+                if (TextUtils.isEmpty(engineName)) {
+                    Snackbar.make(rootView, R.string.search_add_error_empty_name, Snackbar.LENGTH_SHORT).show();
+                } else if (TextUtils.isEmpty(searchQuery)) {
+                    Snackbar.make(rootView, R.string.search_add_error_empty_search, Snackbar.LENGTH_SHORT).show();
+                } else if (!validateSearchFields(engineName, searchQuery, sharedPreferences)) {
+                    Snackbar.make(rootView, R.string.search_add_error_format, Snackbar.LENGTH_SHORT).show();
                 } else {
                     SearchEngineManager.addSearchEngine(sharedPreferences, getActivity(), engineName, searchQuery);
                     Snackbar.make(rootView, R.string.search_add_confirmation, Snackbar.LENGTH_SHORT).show();
@@ -64,10 +68,6 @@ public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
     }
 
     private static boolean validateSearchFields(String engineName, String searchString, SharedPreferences sharedPreferences) {
-        if (TextUtils.isEmpty(engineName)) {
-            return false;
-        }
-
         if (sharedPreferences.getStringSet(SearchEngineManager.PREF_KEY_CUSTOM_SEARCH_ENGINES,
                 Collections.<String>emptySet()).contains(engineName)) {
             return false;


### PR DESCRIPTION
Incorporate the new error strings in the feature.

I didn't remove the existing string because it still exists in a lot of translations, but we can do that in a subsequent string export - import and then export again to clear out the strings. Since this is before code freeze, this shouldn't be a problem.