### PR TITLE
LearnMoreSwitchPreference: Let Android add the switch widget. (#1830)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
@@ -44,15 +44,6 @@ abstract class LearnMoreSwitchPreference(context: Context?, attrs: AttributeSet?
         val backgroundDrawable = backgroundDrawableArray.getDrawable(0)
         backgroundDrawableArray.recycle()
         learnMoreLink.background = backgroundDrawable
-
-        val switchView = view.findViewById<Switch>(android.R.id.switch_widget)
-
-        // We still want to allow toggling the pref by touching any part of the pref (except for
-        // the "learn more" link)
-        onPreferenceClickListener = OnPreferenceClickListener {
-            switchView.toggle()
-            true
-        }
     }
 
     open fun getDescription(): String? = null

--- a/app/src/main/res/layout/preference_switch_learn_more.xml
+++ b/app/src/main/res/layout/preference_switch_learn_more.xml
@@ -50,20 +50,11 @@
     </RelativeLayout>
 
     <LinearLayout
+        android:id="@android:id/widget_frame"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:minWidth="58dip"
         android:gravity="end|center_vertical"
-        android:orientation="vertical">
-
-        <Switch xmlns:android="http://schemas.android.com/apk/res/android"
-            android:id="@+android:id/switch_widget"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:focusable="false"
-            android:clickable="false"
-            android:background="@null" />
-
-    </LinearLayout>
+        android:orientation="vertical" />
 
 </LinearLayout>


### PR DESCRIPTION
The previous version of the code added a switch with the id "android:id/switch_widget".
This ID doesn't seem to be used by earlier versions of Android. The easiest way to fix
this is to add the "widget_frame" id to the parent layout and let Android add the
widget with whatever ID it needs.