### PR TITLE
Closes #1842: Whitelist AS profiler files. 

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/WebViewDataTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/WebViewDataTest.java
@@ -202,7 +202,8 @@ public class WebViewDataTest {
                 continue;
             }
 
-            assertTrue("Check '" + name + "' is in whitelist", WHITELIST_DATA_DIR_CONTENTS.contains(name));
+            assertTrue("Expected file '" + name + "' to be in the app's data dir whitelist",
+                    WHITELIST_DATA_DIR_CONTENTS.contains(name));
         }
 
         assertNoTraces(dataDir);

--- a/app/src/androidTest/java/org/mozilla/focus/activity/WebViewDataTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/WebViewDataTest.java
@@ -54,7 +54,19 @@ public class WebViewDataTest {
             "app_dxmaker_cache",
             "telemetry",
             "databases",
-            "app_webview"
+            "app_webview",
+
+            // Android Studio will inject these files if you:
+            // - Build with Android Studio 3.0+
+            // - Have opened the "Android Profiler" tab at least once since the AS process started
+            // - Run on an API 26+ device (or maybe when explicitly enabling advanced debugging on older devices)
+            //
+            // This should only affect local builds and we don't want to risk breaking the profiler so
+            // we whitelist them. Additional details around when these files are added can be found in:
+            //   https://github.com/mozilla-mobile/focus-android/issues/1842#issuecomment-348038392
+            "libperfa_x86.so",
+            "perfa.jar",
+            "perfd"
     );
 
     // We expect those folders to exist but they should be empty.

--- a/app/src/androidTest/java/org/mozilla/focus/activity/WebViewDataTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/WebViewDataTest.java
@@ -47,7 +47,7 @@ import static org.mozilla.focus.fragment.FirstrunFragment.FIRSTRUN_PREF;
  */
 @RunWith(AndroidJUnit4.class)
 public class WebViewDataTest {
-    private static final List<String> WHITELIST = Arrays.asList(
+    private static final List<String> WHITELIST_DATA_DIR_CONTENTS = Arrays.asList(
             "cache", // We assert that this folder is empty
             "code_cache",
             "shared_prefs",
@@ -202,7 +202,7 @@ public class WebViewDataTest {
                 continue;
             }
 
-            assertTrue("Check '" + name + "' is in whitelist", WHITELIST.contains(name));
+            assertTrue("Check '" + name + "' is in whitelist", WHITELIST_DATA_DIR_CONTENTS.contains(name));
         }
 
         assertNoTraces(dataDir);


### PR DESCRIPTION
#1842 

Given the conditions under which I've noticed these files are added, it's only
likely to occur in local builds. However, if we wanted to be extra safe that
these files aren't kept on disk in release builds, we could explicitly delete
them but then we'd presumably have to add a branch to allow developer builds to
use these files without problems. For simplicity, I've opted for the whitelist.