### PR TITLE
Closes #1656 "Open with..." does not show Rocket when user has default browser

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/Browsers.java
+++ b/app/src/main/java/org/mozilla/focus/utils/Browsers.java
@@ -29,6 +29,7 @@ public class Browsers {
         FIREFOX_BETA("org.mozilla.firefox_beta"),
         FIREFOX_AURORA("org.mozilla.fennec_aurora"),
         FIREFOX_NIGHTLY("org.mozilla.fennec"),
+        FIREFOX_ROCKET("org.mozilla.rocket"),
 
         CHROME("com.android.chrome"),
         CHROME_BETA("com.chrome.beta"),


### PR DESCRIPTION
… #1656 

I noticed while fixing #1656 that the two functions below do not include Firefox Rocket:
findFirefoxBrandedBrowser()
isFirefoxDefaultBrowser()

Should these also be updated with Rocket? 

