### PR TITLE
Add autocomplete settings to core ping. (#1771)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.java
@@ -181,7 +181,9 @@ public final class TelemetryWrapper {
                             resources.getString(R.string.pref_key_performance_block_webfonts),
                             resources.getString(R.string.pref_key_locale),
                             resources.getString(R.string.pref_key_secure),
-                            resources.getString(R.string.pref_key_default_browser))
+                            resources.getString(R.string.pref_key_default_browser),
+                            resources.getString(R.string.pref_key_autocomplete_preinstalled),
+                            resources.getString(R.string.pref_key_autocomplete_custom))
                     .setSettingsProvider(new TelemetrySettingsProvider(context))
                     .setCollectionEnabled(telemetryEnabled)
                     .setUploadEnabled(telemetryEnabled);


### PR DESCRIPTION
Having those two settings in the core ping makes it easier for us to look at the distribution of the setting across our user base:

* How many % of our users have autocomplete enabled/disabled?