### PR TITLE
Add telemetry for search engine UI

### DIFF
--- a/app/src/main/java/org/mozilla/focus/search/RadioSearchEngineListPreference.java
+++ b/app/src/main/java/org/mozilla/focus/search/RadioSearchEngineListPreference.java
@@ -45,7 +45,10 @@ public class RadioSearchEngineListPreference extends SearchEngineListPreference 
 
     @Override
     public void onCheckedChanged (RadioGroup group, int checkedId) {
-        Settings.getInstance(group.getContext()).setDefaultSearchEngine(searchEngines.get(checkedId));
-        TelemetryWrapper.setDefaultSearchEngineEvent();
+        final SearchEngine newDefaultEngine = searchEngines.get(checkedId);
+        Settings.getInstance(group.getContext()).setDefaultSearchEngine(newDefaultEngine);
+        final String source = SearchEngineManager.getInstance().isCustomSearchEngine(newDefaultEngine.getIdentifier(), getContext()) ?
+                SearchEngineManager.ENGINE_TYPE_CUSTOM : SearchEngineManager.ENGINE_TYPE_BUNDLED;
+        TelemetryWrapper.setDefaultSearchEngineEvent(source);
     }
 }

--- a/app/src/main/java/org/mozilla/focus/search/RadioSearchEngineListPreference.java
+++ b/app/src/main/java/org/mozilla/focus/search/RadioSearchEngineListPreference.java
@@ -12,6 +12,7 @@ import android.widget.CompoundButton;
 import android.widget.RadioGroup;
 
 import org.mozilla.focus.R;
+import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.utils.Settings;
 
 public class RadioSearchEngineListPreference extends SearchEngineListPreference implements RadioGroup.OnCheckedChangeListener {
@@ -45,5 +46,6 @@ public class RadioSearchEngineListPreference extends SearchEngineListPreference 
     @Override
     public void onCheckedChanged (RadioGroup group, int checkedId) {
         Settings.getInstance(group.getContext()).setDefaultSearchEngine(searchEngines.get(checkedId));
+        TelemetryWrapper.setDefaultSearchEngineEvent();
     }
 }

--- a/app/src/main/java/org/mozilla/focus/search/SearchEngineManager.java
+++ b/app/src/main/java/org/mozilla/focus/search/SearchEngineManager.java
@@ -63,6 +63,9 @@ public class SearchEngineManager extends BroadcastReceiver {
     private static final String PREF_KEY_CUSTOM_SEARCH_VERSION = "pref_custom_search_version";
     private static final int CUSTOM_SEARCH_VERSION = 1;
 
+    public static final String ENGINE_TYPE_CUSTOM = "custom";
+    public static final String ENGINE_TYPE_BUNDLED = "bundled";
+
     private static SearchEngineManager instance = new SearchEngineManager();
 
     private List<SearchEngine> searchEngines;
@@ -231,20 +234,29 @@ public class SearchEngineManager extends BroadcastReceiver {
     }
 
     private List<SearchEngine> loadCustomSearchEngines(Context context) {
-        final List<SearchEngine> searchEngines = new LinkedList<>();
+        final List<SearchEngine> customEngines = new LinkedList<>();
         final SharedPreferences prefs = context.getSharedPreferences(PREF_FILE_SEARCH_ENGINES, Context.MODE_PRIVATE);
         final Set<String> engines = prefs.getStringSet(PREF_KEY_CUSTOM_SEARCH_ENGINES, Collections.<String>emptySet());
         try {
             for (String engine : engines) {
                 final InputStream engineInputStream = new ByteArrayInputStream(prefs.getString(engine, "").getBytes(StandardCharsets.UTF_8));
-                searchEngines.add(SearchEngineParser.load(engine, engineInputStream));
+                customEngines.add(SearchEngineParser.load(engine, engineInputStream));
             }
         } catch (IOException e) {
             Log.e(LOG_TAG, "IOException while loading custom search engines", e);
         } catch (XmlPullParserException e) {
             Log.e(LOG_TAG, "Couldn't load custom search engines", e);
         }
-        return searchEngines;
+        return customEngines;
+    }
+
+    public boolean isCustomSearchEngine(String engineId, Context context) {
+        for (SearchEngine e : loadCustomSearchEngines(context)) {
+            if (e.getIdentifier().equals(engineId)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private JSONArray loadSearchEngineListForLocale(Context context) throws IOException {

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
@@ -17,6 +17,7 @@ import android.widget.EditText;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.search.SearchEngineManager;
+import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.utils.UrlUtils;
 
 import java.util.Collections;
@@ -50,6 +51,7 @@ public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
                 final String searchQuery = ((EditText) rootView.findViewById(R.id.edit_search_string)).getText().toString();
 
                 final SharedPreferences sharedPreferences = getSearchEngineSharedPreferences();
+                boolean isSuccess = false;
                 if (TextUtils.isEmpty(engineName)) {
                     Snackbar.make(rootView, R.string.search_add_error_empty_name, Snackbar.LENGTH_SHORT).show();
                 } else if (TextUtils.isEmpty(searchQuery)) {
@@ -58,9 +60,11 @@ public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
                     Snackbar.make(rootView, R.string.search_add_error_format, Snackbar.LENGTH_SHORT).show();
                 } else {
                     SearchEngineManager.addSearchEngine(sharedPreferences, getActivity(), engineName, searchQuery);
+                    isSuccess = true;
                     Snackbar.make(rootView, R.string.search_add_confirmation, Snackbar.LENGTH_SHORT).show();
                     getFragmentManager().popBackStack();
                 }
+                TelemetryWrapper.saveCustomSearchEngineEvent(isSuccess);
                 return true;
             default:
                 return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -122,17 +122,20 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         switch (item.getItemId()) {
             case R.id.menu_remove_search_engines:
                 showSettingsFragment(SettingsScreen.REMOVE_ENGINES);
+                TelemetryWrapper.menuRemoveEnginesEvent();
                 return true;
             case R.id.menu_delete_items:
                 final Preference pref = getPreferenceScreen()
                         .findPreference(getResources().getString(
                                 R.string.pref_key_multiselect_search_engine_list));
                 final Set<String> enginesToRemove = ((MultiselectSearchEngineListPreference) pref).getCheckedEngineIds();
+                TelemetryWrapper.removeSearchEnginesEvent(enginesToRemove.size());
                 SearchEngineManager.removeSearchEngines(enginesToRemove, getSearchEngineSharedPreferences());
                 getFragmentManager().popBackStack();
                 return true;
             case R.id.menu_restore_default_engines:
                 SearchEngineManager.restoreDefaultSearchEngines(getSearchEngineSharedPreferences());
+                TelemetryWrapper.menuRestoreEnginesEvent();
                 refetchSearchEngines();
                 return true;
             default:
@@ -161,8 +164,10 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
             startActivity(intent);
         } else if (preference.getKey().equals(resources.getString(R.string.pref_key_search_engine))) {
             showSettingsFragment(SettingsScreen.SEARCH_ENGINES);
+            TelemetryWrapper.openSearchSettingsEvent();
         } else if (preference.getKey().equals(resources.getString(R.string.pref_key_manual_add_search_engine))) {
             showSettingsFragment(SettingsScreen.ADD_SEARCH);
+            TelemetryWrapper.menuAddSearchEngineEvent();
         } else if (preference.getKey().equals(resources.getString(R.string.pref_key_screen_autocomplete))) {
             getFragmentManager().beginTransaction()
                     .replace(R.id.container, new AutocompleteSettingsFragment())

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -70,6 +70,8 @@ object TelemetryWrapper {
         val SHARE_INTENT = "share_intent"
         val REMOVE = "remove"
         val REORDER = "reorder"
+        val NEW = "new"
+        val RESTORE = "restore"
     }
 
     private object Object {
@@ -96,6 +98,9 @@ object TelemetryWrapper {
         val APP_ICON = "app_icon"
         val AUTOCOMPLETE_DOMAIN = "autocomplete_domain"
         val AUTOFILL = "autofill"
+        val SEARCH_ENGINE_SETTING = "search_engine_setting"
+        val CUSTOM_SEARCH_ENGINE = "custom_search_engine"
+        val REMOVE_SEARCH_ENGINES = "remove_search_engines"
     }
 
     private object Value {
@@ -131,6 +136,7 @@ object TelemetryWrapper {
         val HIGHLIGHTED = "highlighted"
         val AUTOCOMPLETE = "autocomplete"
         val SOURCE = "source"
+        val SUCCESS = "success"
     }
 
     @JvmStatic
@@ -601,5 +607,44 @@ object TelemetryWrapper {
     @JvmStatic
     fun autofillPerformedEvent() {
         TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.AUTOFILL).queue()
+    }
+
+    @JvmStatic
+    fun setDefaultSearchEngineEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.SAVE, Object.SEARCH_ENGINE_SETTING).queue()
+    }
+
+    @JvmStatic
+    fun openSearchSettingsEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.OPEN, Object.SEARCH_ENGINE_SETTING).queue()
+    }
+
+    @JvmStatic
+    fun menuRemoveEnginesEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.REMOVE, Object.SEARCH_ENGINE_SETTING).queue()
+    }
+
+    @JvmStatic
+    fun menuRestoreEnginesEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.RESTORE, Object.SEARCH_ENGINE_SETTING).queue()
+    }
+
+    @JvmStatic
+    fun menuAddSearchEngineEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.NEW, Object.SEARCH_ENGINE_SETTING).queue()
+    }
+
+    @JvmStatic
+    fun saveCustomSearchEngineEvent(success: Boolean) {
+        TelemetryEvent.create(Category.ACTION, Method.SAVE, Object.CUSTOM_SEARCH_ENGINE)
+                .extra(Extra.SUCCESS, success.toString())
+                .queue()
+    }
+
+    @JvmStatic
+    fun removeSearchEnginesEvent(selected: Int) {
+        TelemetryEvent.create(Category.ACTION, Method.REMOVE, Object.REMOVE_SEARCH_ENGINES)
+                .extra(Extra.SELECTED, selected.toString())
+                .queue()
     }
 }

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -70,7 +70,6 @@ object TelemetryWrapper {
         val SHARE_INTENT = "share_intent"
         val REMOVE = "remove"
         val REORDER = "reorder"
-        val NEW = "new"
         val RESTORE = "restore"
     }
 
@@ -610,8 +609,10 @@ object TelemetryWrapper {
     }
 
     @JvmStatic
-    fun setDefaultSearchEngineEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.SAVE, Object.SEARCH_ENGINE_SETTING).queue()
+    fun setDefaultSearchEngineEvent(source: String) {
+        TelemetryEvent.create(Category.ACTION, Method.SAVE, Object.SEARCH_ENGINE_SETTING)
+                .extra(Extra.SOURCE, source)
+                .queue()
     }
 
     @JvmStatic
@@ -631,7 +632,7 @@ object TelemetryWrapper {
 
     @JvmStatic
     fun menuAddSearchEngineEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.NEW, Object.SEARCH_ENGINE_SETTING).queue()
+        TelemetryEvent.create(Category.ACTION, Method.SHOW, Object.CUSTOM_SEARCH_ENGINE).queue()
     }
 
     @JvmStatic


### PR DESCRIPTION
This adds basic telemetry for the search engines UI:
- Clicks on menu items (Remove, Restore defaults, Add another search engine)
- Setting a default (2nd patch includes whether it's custom or not)
- Clicking "save" on the manual search engine page, and whether there was an error or not
- Clicking "remove/trashcan" on the Remove page, and how many engines are deleted

I included the second patch because it adds a perf hit (SharedPreferences access) instead of just caching the custom search engines (for simplicity this close to the end of the sprint).

---- 
# Request for data collection review form

The documentation for this will added to the Focus-Android [telemetry wiki](url) under the Settings section, with the probe keys and the values listed in this document.

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

1) What questions will you answer with this data?
How and whether users are using settings to control their default search engine

2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?

Determine whether custom search engines and changing defaults is an actually used feature on Focus - there are a lot of requests for the feature, so now that we've implemented it we'd like to know if people use custom search engines, as well as if they create custom search engines, and if they have problems creating them.

3) What alternative methods did you consider to answer these questions? Why were they not sufficient?
No existing probes for search engines

4) Can current instrumentation answer these questions?
No

5) List all proposed measurements and indicate the category of data collection for each measurement, using the Firefox [data c](https://wiki.mozilla.org/Firefox/Data_Collection)[ollection ](https://wiki.mozilla.org/Firefox/Data_Collection)[categories](https://wiki.mozilla.org/Firefox/Data_Collection) on the found on the Mozilla wiki.   

**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**

All probes tracked in Issue #1856, and will add measurement descriptions to Telemetry wiki.
<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
  </tr>
  <tr>
    <td>Number of clicks on "Search" settings item</td>
    <td>Type 2</td>
  </tr>
  <tr>
    <td>Number of clicks on menu item "Remove" for search engines</td>
    <td>Type 2</td>
  </tr>
  <tr>
    <td>Number of clicks on menu item"Restore default search engines"</td>
    <td>Type 2</td>
  </tr>
  <tr>
    <td>Number of clicks on "+Add another search engine" to add custom search engine</td>
    <td>Type 2</td>
  </tr>
  <tr>
    <td>Number of times clicking to set a default search engine: **value**: custom or bundled</td>
    <td>Type 2</td>
  </tr>
  <tr>
    <td>Number of clicks on trashcan to remove search engines: **value**: number of items selected</td>
    <td>Type 2</td>
  </tr>
  <tr>
    <td>Number of clicks on "Save" to save custom search engine: **value**: true if successful, false if validation error</td>
    <td>Type 2</td>
  </tr>
</table>


6) How long will this data be collected?  Choose one of the following:
* I want to permanently monitor this data. (@bbinto / Barbara Bermes)

7) What populations will you measure?
All populations

* Which release channels?
all channels

* Which countries?
All Focus countries opt-out, Klar/Germany opt-out

* Which locales?
All locales

* Any other filters?  Please describe in detail below.
none

8) Please provide a general description of how you will analyze this data.
Through redash and parquet, look at usage compared to other settings, see if users hit errors while creating custom search engines, will be a baseline for v2 non-manual adding search engine

9) Where do you intend to share the results of your analysis?
Internal reports, NMX/Focus meetings, Product meetings
