### PR TITLE
Print output of import-strings.sh even if the script fails. (#1832)

### DIFF
--- a/tools/taskcluster/import_strings_and_create_pull_request.sh
+++ b/tools/taskcluster/import_strings_and_create_pull_request.sh
@@ -13,8 +13,7 @@ cd "$(dirname "$0")"
 cd ../..
 
 # Import strings from L10N repository
-tools/l10n/import-strings.sh > import-log.txt
-cat import-log.txt
+tools/l10n/import-strings.sh | tee import-log.txt ; test ${PIPESTATUS[0]} -eq 0
 
 # Timestamp used in branch name and commit
 TIMESTAMP=`date "+%Y%m%d-%H%M%S"`


### PR DESCRIPTION
The tee command copies standard input to standard output and also to
any files given as arguments.

With that we can print the output and save it to a file - even if
the command fails. However now the whole script would not fail
because "tee" exists without an error. That's why we check
"${PIPESTATUS[0]}" to fail in case import-strings.sh failed.