### PR TITLE
Closes #1875: Remove cookies on new session.

### DIFF
--- a/app/src/webview/java/org/mozilla/focus/web/WebViewProvider.java
+++ b/app/src/webview/java/org/mozilla/focus/web/WebViewProvider.java
@@ -14,6 +14,7 @@ import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
+import android.webkit.CookieManager;
 import android.webkit.WebSettings;
 import android.webkit.WebStorage;
 import android.webkit.WebView;
@@ -48,6 +49,9 @@ public class WebViewProvider {
      * This function must be called before WebView.loadUrl to avoid erasing current session data.
      */
     public static void performNewBrowserSessionCleanup() {
+        // If the app is closed in certain ways, WebView.cleanup will not get called and we don't clear cookies.
+        CookieManager.getInstance().removeAllCookies(null);
+
         // We run this on the main thread to guarantee it occurs before loadUrl so we don't erase current session data.
         final StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskWrites();
 


### PR DESCRIPTION
#1875

This is the simplest fix that aims to avoid unwanted side effects: this means
there may be other hidden issues we're not fixing here. We should try to
comprehensively fix this bug in issue #1569.

A better fix with potential side effects would be forcing WebView.cleanup to
run on a new browser session, not just deleting cookies.

@liuche, @pocmo: if we review this soon, we could consider uplifting and fixing it for v4.0. CC @Sdaswani @npark-mozilla 