### PR TITLE
Detekt: No thresholds

### DIFF
--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteListFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteListFragment.kt
@@ -136,7 +136,10 @@ open class AutocompleteListFragment : Fragment() {
         val isEnabled = !isSelectionMode()
                 || (domainList.adapter as DomainListAdapter).selection().isNotEmpty()
         removeItem?.isEnabled = isEnabled
-        removeItem?.icon?.mutate()?.alpha = if (isEnabled) SettingsFragment.ALPHA_ENABLED else SettingsFragment.ALPHA_DISABLED
+        removeItem?.icon?.mutate()?.alpha = if (isEnabled)
+            SettingsFragment.ALPHA_ENABLED
+        else
+            SettingsFragment.ALPHA_DISABLED
     }
 
     override fun onOptionsItemSelected(item: MenuItem?): Boolean = when (item?.itemId) {

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -1,5 +1,4 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -33,8 +32,11 @@ import org.mozilla.focus.whatsnew.WhatsNew
 import org.mozilla.focus.widget.InlineAutocompleteEditText
 
 /**
- * Fragment for displaying he URL input controls.
+ * Fragment for displaying the URL input controls.
  */
+// Refactoring the size and function count of this fragment is non-trivial at this point.
+// Therefore we ignore those violations for now.
+@Suppress("LargeClass", "TooManyFunctions")
 class UrlInputFragment :
         LocaleAwareFragment(),
         View.OnClickListener,
@@ -218,6 +220,8 @@ class UrlInputFragment :
         ViewUtils.showKeyboard(urlView)
     }
 
+    // This method triggers the complexity warning. However it's actually not that hard to understand.
+    @Suppress("ComplexMethod")
     override fun onClick(view: View) {
         when (view.id) {
             R.id.clearView -> clear()
@@ -304,6 +308,9 @@ class UrlInputFragment :
      * different depending on whether this fragment is shown as an overlay on top of other fragments
      * or if it draws its own background.
      */
+    // This method correctly triggers a complexity warning. This method is indeed very and too complex.
+    // However refactoring it is not trivial at this point so we ignore the warning for now.
+    @Suppress("ComplexMethod")
     private fun playVisibilityAnimation(reverse: Boolean) {
         if (isAnimating) {
             // We are already animating, let's ignore another request.

--- a/app/src/main/java/org/mozilla/focus/shortcut/IconGenerator.kt
+++ b/app/src/main/java/org/mozilla/focus/shortcut/IconGenerator.kt
@@ -38,11 +38,11 @@ class IconGenerator {
          * on top of a generic launcher icon shape that we provide.
          */
         @JvmStatic
-        fun generateCharacterIcon(context: Context, character: Char) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            generateAdaptiveLauncherIcon(context, character)
-        } else {
-            generateLauncherIconPreOreo(context, character)
-        }
+        private fun generateCharacterIcon(context: Context, character: Char) =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+                    generateAdaptiveLauncherIcon(context, character)
+                else
+                    generateLauncherIconPreOreo(context, character)
 
         /*
          * This method needs to be separate from generateAdaptiveLauncherIcon so that we can generate

--- a/quality/detekt.yml
+++ b/quality/detekt.yml
@@ -18,8 +18,8 @@ test-pattern: # Configure exclusions for test sources
     - 'StringLiteralDuplication'
 
 build:
-  warningThreshold: 5
-  failThreshold: 10
+  warningThreshold: 0
+  failThreshold: 0
   weights:
     complexity: 2
     formatting: 1


### PR DESCRIPTION
By default detekt has some thresholds defined. For example it won't fail the build if there are less than 5 warnings. I think we should see and deal with every warning (fix or suppress) and therefore removed all threshold in this PR.