### PR TITLE
Closes #1886: Use constant for detekt version in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,15 +23,15 @@ buildscript {
 }
 
 plugins {
-    //The version number is duplicated in the detekt block. We are unable to use constants due to
-    //limitations of the gradle plugin. We've decided to stick with duplication for now since the
-    //other methods involve using undocumented APIs
-    //https://docs.gradle.org/current/userguide/plugins.html#plugins_dsl_limitations
+    // The version number is duplicated in the detekt block. We are unable to use constants due to
+    // limitations of the gradle plugin. We've decided to stick with duplication for now since the
+    // other methods involve using undocumented APIs
+    // https://docs.gradle.org/current/userguide/plugins.html#plugins_dsl_limitations
     id "io.gitlab.arturbosch.detekt" version "1.0.0.RC5-6"
 }
 
 detekt {
-    //The version number is duplicated, please refer to plugins block for more details
+    // The version number is duplicated, please refer to plugins block for more details
     version = "1.0.0.RC5-6"
     profile("main") {
         input = "$projectDir"

--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,15 @@ buildscript {
 }
 
 plugins {
+    //The version number is duplicated in the detekt block. We are unable to use constants due to
+    //limitations of the gradle plugin. We've decided to stick with duplication for now since the
+    //other methods involve using undocumented APIs
+    //https://docs.gradle.org/current/userguide/plugins.html#plugins_dsl_limitations
     id "io.gitlab.arturbosch.detekt" version "1.0.0.RC5-6"
 }
 
 detekt {
+    //The version number is duplicated, please refer to plugins block for more details
     version = "1.0.0.RC5-6"
     profile("main") {
         input = "$projectDir"


### PR DESCRIPTION

Added comments explaining the rationale for persisting with the duplicate values for Detekt versions