### PR TITLE
 Keyboard stays up after adding new search engine or autocomplete domain

### DIFF
--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteAddFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteAddFragment.kt
@@ -8,6 +8,7 @@ import android.app.Fragment
 import android.content.Context
 import android.os.Bundle
 import android.view.*
+import android.view.inputmethod.InputMethodManager
 import org.mozilla.focus.R
 import org.mozilla.focus.settings.SettingsFragment
 
@@ -34,6 +35,16 @@ class AutocompleteAddFragment : Fragment() {
         val updater = activity as SettingsFragment.ActionBarUpdater
         updater.updateTitle(R.string.preference_autocomplete_title_add)
         updater.updateIcon(R.drawable.ic_close)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        val view = activity.currentFocus
+        if (view != null) {
+            val imm = activity
+                    .getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            imm.hideSoftInputFromWindow(view.windowToken, 0)
+        }
     }
 
     override fun onCreateView(inflater: LayoutInflater?, container: ViewGroup?, savedInstanceState: Bundle?): View =

--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteAddFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteAddFragment.kt
@@ -8,7 +8,6 @@ import android.app.Fragment
 import android.content.Context
 import android.os.Bundle
 import android.view.*
-import android.view.inputmethod.InputMethodManager
 import org.mozilla.focus.R
 import org.mozilla.focus.settings.SettingsFragment
 
@@ -39,12 +38,7 @@ class AutocompleteAddFragment : Fragment() {
 
     override fun onPause() {
         super.onPause()
-        val view = activity.currentFocus
-        if (view != null) {
-            val imm = activity
-                    .getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            imm.hideSoftInputFromWindow(view.windowToken, 0)
-        }
+        ViewUtils.hideKeyboard(activity.currentFocus)
     }
 
     override fun onCreateView(inflater: LayoutInflater?, container: ViewGroup?, savedInstanceState: Bundle?): View =

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
@@ -4,7 +4,6 @@
 
 package org.mozilla.focus.settings;
 
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -14,13 +13,13 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.search.SearchEngineManager;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.utils.UrlUtils;
+import org.mozilla.focus.utils.ViewUtils;
 
 import java.util.Collections;
 
@@ -76,12 +75,7 @@ public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
     @Override
     public void onPause() {
         super.onPause();
-        View view = getActivity().getCurrentFocus();
-        if (view != null) {
-            InputMethodManager imm = (InputMethodManager) getActivity()
-                    .getSystemService(Context.INPUT_METHOD_SERVICE);
-            imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
-        }
+        ViewUtils.hideKeyboard(getActivity().getCurrentFocus());
     }
 
     private static boolean validateSearchFields(String engineName, String searchString, SharedPreferences sharedPreferences) {

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
@@ -4,6 +4,7 @@
 
 package org.mozilla.focus.settings;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -13,6 +14,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
 import org.mozilla.focus.R;
@@ -68,6 +70,17 @@ public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
                 return true;
             default:
                 return super.onOptionsItemSelected(item);
+        }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        View view = getActivity().getCurrentFocus();
+        if (view != null) {
+            InputMethodManager imm = (InputMethodManager) getActivity()
+                    .getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/utils/ViewUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/ViewUtils.java
@@ -104,6 +104,9 @@ public class ViewUtils {
     }
 
     public static void hideKeyboard(View view) {
+        if (view == null) {
+            return;
+        }
         InputMethodManager imm = (InputMethodManager) view.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
         if (imm == null) {
             return;


### PR DESCRIPTION
Closes #1923 
This should hide the keyboard when closing the fragments: ManualAddSearchEngineSettingsFragment and AutocompleteAddFragment