### PR TITLE
Fix redundant '.let' call in AutocompleteListFragment #1946

### DIFF
--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteListFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteListFragment.kt
@@ -254,7 +254,7 @@ open class AutocompleteListFragment : Fragment() {
                     selectedDomains.remove(domain)
                 }
 
-                fragment.activity?.let { it.invalidateOptionsMenu() }
+                fragment.activity?.invalidateOptionsMenu()
             })
 
             handleView.visibility = if (isSelectionMode) View.GONE else View.VISIBLE


### PR DESCRIPTION
Fixes #1946 