### PR TITLE
Closes #1900: Kotlin: treat warnings as errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,9 +138,7 @@ kotlin {
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-    kotlinOptions {
         kotlinOptions.allWarningsAsErrors = true
-    }
 }
 
 jacocoAndroidUnitTestReport {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,6 @@ apply plugin: 'jacoco-android'
 apply plugin: 'pmd'
 apply plugin: 'checkstyle'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
-
 apply from: "$project.rootDir/tools/gradle/versionCode.gradle"
 
 android {
@@ -137,6 +135,12 @@ android {
 
 kotlin {
     experimental { coroutines 'enable' }
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        kotlinOptions.allWarningsAsErrors = true
+    }
 }
 
 jacocoAndroidUnitTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ buildscript {
 
 plugins {
     id "io.gitlab.arturbosch.detekt" version "1.0.0.RC5-6"
+    id "org.jetbrains.kotlin.kapt" version "1.2.0"
 }
 
 detekt {


### PR DESCRIPTION
Added flag to treat Kotlin errors as warnings. Changed the use of kotlin-kapt from apply to using the plugins block to avoid a builds failing due to sources output directory not being specified: https://github.com/mozilla-mobile/focus-android/issues/1900#issuecomment-349306400 Closes #1900
