### PR TITLE
Closes #1976, HttpUrlConnection now allowed to follow redirects

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
@@ -219,6 +219,7 @@ public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
         HttpURLConnection connection = null;
         try {
             connection = (HttpURLConnection) searchURL.openConnection();
+            connection.setInstanceFollowRedirects(true);
             connection.setConnectTimeout(SEARCH_QUERY_VALIDATION_TIMEOUT_MILLIS);
             connection.setReadTimeout(SEARCH_QUERY_VALIDATION_TIMEOUT_MILLIS);
 

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
@@ -223,8 +223,8 @@ public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
             connection.setConnectTimeout(SEARCH_QUERY_VALIDATION_TIMEOUT_MILLIS);
             connection.setReadTimeout(SEARCH_QUERY_VALIDATION_TIMEOUT_MILLIS);
 
-            // A non-error HTTP response is good enough as a sanity check, some search engines redirect to https.
-            return connection.getResponseCode() < 400;
+            // Now that redirects are followed, 300 is a better and stronger sanity check, checks for a non error and non redirect response
+            return connection.getResponseCode() < 300;
 
         } catch (final IOException e) {
             // Don't log exception to avoid leaking URL.

--- a/app/src/test/java/org/mozilla/focus/settings/SearchEngineValidationTest.kt
+++ b/app/src/test/java/org/mozilla/focus/settings/SearchEngineValidationTest.kt
@@ -24,9 +24,9 @@ class SearchEngineValidationTest {
     }
 
     @Test
-    fun `URL using HTTP redirect is valid`() = withMockWebServer(responseWithStatus(301)) {
-        // Currently we accept redirects as valid. We might want to follow the redirect (Issue #1976)
-        assertTrue(isValidSearchQueryURL(it.rootUrl()))
+    fun `URL using HTTP redirect is invalid`() = withMockWebServer(responseWithStatus(301)) {
+        // We now follow redirects(Issue #1976). This test now asserts false.
+        assertFalse(isValidSearchQueryURL(it.rootUrl()))
     }
 
     @Test


### PR DESCRIPTION
@pocmo pointed out that instead of accepting a redirect as successful, we could follow redirects.