### PR TITLE
Closes #1712 Downloads Do Not Save With Correct File Extension

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/DownloadUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/DownloadUtils.java
@@ -133,10 +133,10 @@ public class DownloadUtils {
 
     /**
      * Format as defined in RFC 2616 and RFC 5987
-     * Only the attachment type is supported.
+     * Both inline and attachment types are supported.
      */
     private static final Pattern CONTENT_DISPOSITION_PATTERN =
-            Pattern.compile("attachment\\s*;\\s*filename\\s*=\\s*" +
+            Pattern.compile("(inline|attachment)\\s*;\\s*filename\\s*=\\s*" +
                             "(\"((?:\\\\.|[^\"\\\\])*)\"|[^;]*)\\s*" +
                             "(?:;\\s*filename\\*\\s*=\\s*(utf-8|iso-8859-1)'[^']*'(\\S*))?",
                     Pattern.CASE_INSENSITIVE);
@@ -148,22 +148,22 @@ public class DownloadUtils {
 
             if (m.find()) {
                 // If escaped string is found, decode it using the given encoding.
-                String encodedFileName = m.group(4);
-                String encoding = m.group(3);
+                String encodedFileName = m.group(5);
+                String encoding = m.group(4);
 
                 if (encodedFileName != null) {
                     return decodeHeaderField(encodedFileName, encoding);
                 }
 
                 // Return quoted string if available and replace escaped characters.
-                String quotedFileName = m.group(2);
+                String quotedFileName = m.group(3);
 
                 if (quotedFileName != null) {
                     return quotedFileName.replaceAll("\\\\(.)", "$1");
                 }
 
                 // Otherwise try to extract the unquoted file name
-                return m.group(1);
+                return m.group(2);
             }
         } catch (IllegalStateException | UnsupportedEncodingException ex) {
             // This function is defined as returning null when it can't parse the header

--- a/app/src/test/java/org/mozilla/focus/utils/DownloadUtilsTest.java
+++ b/app/src/test/java/org/mozilla/focus/utils/DownloadUtilsTest.java
@@ -15,6 +15,8 @@ import static junit.framework.Assert.assertEquals;
 @RunWith(RobolectricTestRunner.class)
 public class DownloadUtilsTest {
 
+    private static final int CONTENT_DISPOSITION_TYPES = 2;
+
     private static void assertContentDisposition(String expected, String contentDisposition) {
         Download download = new Download(null, null, contentDisposition, null, 0, null);
         assertEquals(expected, DownloadUtils.guessFileName(download));
@@ -22,35 +24,47 @@ public class DownloadUtilsTest {
 
     @Test
     public void testGuessFileName_contentDisposition() {
-        // Default file name
+        String contentDisposition = "attachment";
+
+        // Default file name without content disposition
         assertContentDisposition("downloadfile.bin", "");
-        assertContentDisposition("downloadfile.bin", "attachment");
-        assertContentDisposition("downloadfile.bin", "attachment;");
-        assertContentDisposition("downloadfile.bin", "attachment; filename");
-        assertContentDisposition(".bin", "attachment; filename=");
-        assertContentDisposition(".bin", "attachment; filename=\"\"");
 
-        // Provided filename field
-        assertContentDisposition("filename.jpg", "attachment; filename=\"filename.jpg\"");
-        assertContentDisposition("file\"name.jpg", "attachment; filename=\"file\\\"name.jpg\"");
-        assertContentDisposition("file\\name.jpg", "attachment; filename=\"file\\\\name.jpg\"");
-        assertContentDisposition("file\\\"name.jpg", "attachment; filename=\"file\\\\\\\"name.jpg\"");
-        assertContentDisposition("filename.jpg", "attachment; filename=filename.jpg");
-        assertContentDisposition("filename.jpg", "attachment; filename=filename.jpg; foo");
-        assertContentDisposition("filename.jpg", "attachment; filename=\"filename.jpg\"; foo");
+        for (int i = 0; i < CONTENT_DISPOSITION_TYPES; i++) {
 
-        // UTF-8 encoded filename* field
-        assertContentDisposition("\uD83E\uDD8A + x.jpg",
-                "attachment; filename=\"_.jpg\"; filename*=utf-8'en'%F0%9F%A6%8A%20+%20x.jpg");
-        assertContentDisposition("filename 的副本.jpg",
-                "attachment;filename=\"_.jpg\";" +
-                "filename*=UTF-8''filename%20%E7%9A%84%E5%89%AF%E6%9C%AC.jpg");
-        assertContentDisposition("filename.jpg",
-                "attachment; filename=_.jpg; filename*=utf-8'en'filename.jpg");
+            if (i == CONTENT_DISPOSITION_TYPES - 1) {
+                contentDisposition = "inline";
+            }
 
-        // ISO-8859-1 encoded filename* field
-        assertContentDisposition("file' 'name.jpg",
-                "attachment; filename=\"_.jpg\"; filename*=iso-8859-1'en'file%27%20%27name.jpg");
+            //continuing with default filenames
+            assertContentDisposition("downloadfile.bin", contentDisposition);
+            assertContentDisposition("downloadfile.bin", contentDisposition + ";");
+            assertContentDisposition("downloadfile.bin", contentDisposition + "; filename");
+            assertContentDisposition(".bin", contentDisposition + "; filename=");
+            assertContentDisposition(".bin", contentDisposition + "; filename=\"\"");
+
+            // Provided filename field
+            assertContentDisposition("filename.jpg", contentDisposition + "; filename=\"filename.jpg\"");
+            assertContentDisposition("file\"name.jpg", contentDisposition + "; filename=\"file\\\"name.jpg\"");
+            assertContentDisposition("file\\name.jpg", contentDisposition + "; filename=\"file\\\\name.jpg\"");
+            assertContentDisposition("file\\\"name.jpg", contentDisposition + "; filename=\"file\\\\\\\"name.jpg\"");
+            assertContentDisposition("filename.jpg", contentDisposition + "; filename=filename.jpg");
+            assertContentDisposition("filename.jpg", contentDisposition + "; filename=filename.jpg; foo");
+            assertContentDisposition("filename.jpg", contentDisposition + "; filename=\"filename.jpg\"; foo");
+
+            // UTF-8 encoded filename* field
+            assertContentDisposition("\uD83E\uDD8A + x.jpg",
+                    contentDisposition + "; filename=\"_.jpg\"; filename*=utf-8'en'%F0%9F%A6%8A%20+%20x.jpg");
+            assertContentDisposition("filename 的副本.jpg",
+                    contentDisposition + ";filename=\"_.jpg\";" +
+                            "filename*=UTF-8''filename%20%E7%9A%84%E5%89%AF%E6%9C%AC.jpg");
+            assertContentDisposition("filename.jpg",
+                    contentDisposition + "; filename=_.jpg; filename*=utf-8'en'filename.jpg");
+
+            // ISO-8859-1 encoded filename* field
+            assertContentDisposition("file' 'name.jpg",
+                    contentDisposition + "; filename=\"_.jpg\"; filename*=iso-8859-1'en'file%27%20%27name.jpg");
+        }
+
     }
 
     private static void assertUrl(String expected, String url) {


### PR DESCRIPTION
Added inline as an option for the Content Disposition Matcher. Modified unit test to test for both inline and attachment
