### PR TITLE
Make some static fields final

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -81,7 +81,7 @@ import java.util.List;
 public class BrowserFragment extends WebFragment implements View.OnClickListener, DownloadDialogFragment.DownloadDialogListener {
     public static final String FRAGMENT_TAG = "browser";
 
-    private static int REQUEST_CODE_STORAGE_PERMISSION = 101;
+    private static final int REQUEST_CODE_STORAGE_PERMISSION = 101;
     private static final int ANIMATION_DURATION = 300;
 
     private static final String ARGUMENT_SESSION_UUID = "sessionUUID";

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.java
@@ -39,7 +39,7 @@ import java.net.URL;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class ManualAddSearchEngineSettingsFragment extends SettingsFragment {
-    private static String LOGTAG = "ManualAddSearchEngine";
+    private static final String LOGTAG = "ManualAddSearchEngine";
 
     // Set so the user doesn't have to wait *too* long. It's used twice: once for connecting and once for reading.
     private static final int SEARCH_QUERY_VALIDATION_TIMEOUT_MILLIS = 4000;

--- a/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/IntentUtils.java
@@ -21,8 +21,8 @@ import java.util.List;
 
 public class IntentUtils {
 
-    private static String MARKET_INTENT_URI_PACKAGE_PREFIX = "market://details?id=";
-    private static String EXTRA_BROWSER_FALLBACK_URL = "browser_fallback_url";
+    private static final String MARKET_INTENT_URI_PACKAGE_PREFIX = "market://details?id=";
+    private static final String EXTRA_BROWSER_FALLBACK_URL = "browser_fallback_url";
 
     /**
      * Find and open the appropriate app for a given Uri. If appropriate, let the user select between


### PR DESCRIPTION
Adding final prohibits modification and allows initialization of
primitive and String fields at compile time instead of runtime in
clinit:

https://developer.android.com/training/articles/perf-tips.html#UseFinal

Found via error-prone.