### PR TITLE
Unregister onSharedPreferencesChangeListener

### DIFF
--- a/app/src/gecko/java/org/mozilla/focus/web/WebViewProvider.java
+++ b/app/src/gecko/java/org/mozilla/focus/web/WebViewProvider.java
@@ -346,5 +346,11 @@ public class WebViewProvider {
         public void exitFullscreen() {
             geckoSession.exitFullScreen();
         }
+
+        @Override
+        public void onDetachedFromWindow() {
+            PreferenceManager.getDefaultSharedPreferences(getContext()).unregisterOnSharedPreferenceChangeListener(this);
+            super.onDetachedFromWindow();
+        }
     }
 }


### PR DESCRIPTION
Just noticed that I never unregistered the listener 