### PR TITLE
Update 'detekt'

### DIFF
--- a/app/src/main/java/org/mozilla/focus/animation/TransitionDrawableGroup.kt
+++ b/app/src/main/java/org/mozilla/focus/animation/TransitionDrawableGroup.kt
@@ -9,7 +9,7 @@ import android.graphics.drawable.TransitionDrawable
 /**
  * A class to allow [TransitionDrawable]'s animations to play together: similar to [android.animation.AnimatorSet].
  */
-class TransitionDrawableGroup(vararg private val transitionDrawables: TransitionDrawable) {
+class TransitionDrawableGroup(private vararg val transitionDrawables: TransitionDrawable) {
     fun startTransition(durationMillis: Int) {
         // In theory, there are no guarantees these will play together.
         // In practice, I haven't noticed any problems.

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ detekt {
         input = "$projectDir"
         config = "$projectDir/quality/detekt.yml"
         filters = ".*test.*,.*/resources/.*,.*/tmp/.*"
+        output = "$projectDir/app/build/reports/detekt"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,13 @@ plugins {
     // limitations of the gradle plugin. We've decided to stick with duplication for now since the
     // other methods involve using undocumented APIs
     // https://docs.gradle.org/current/userguide/plugins.html#plugins_dsl_limitations
-    id "io.gitlab.arturbosch.detekt" version "1.0.0.RC5-6"
+    id "io.gitlab.arturbosch.detekt" version "1.0.0.RC6-3"
     id "org.jetbrains.kotlin.kapt" version "1.2.0"
 }
 
 detekt {
     // The version number is duplicated, please refer to plugins block for more details
-    version = "1.0.0.RC5-6"
+    version = "1.0.0.RC6-3"
     profile("main") {
         input = "$projectDir"
         config = "$projectDir/quality/detekt.yml"


### PR DESCRIPTION
The latest version of `detekt` will generate an HTML report which will be helpful to understand what exactly `detekt` is complaining about when builds fail.