### PR TITLE
We need to wait until toast is gone, otherwise, trash button is covered

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/TypicalUseScenarioTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/TypicalUseScenarioTest.java
@@ -86,6 +86,7 @@ public class TypicalUseScenarioTest {
         TestHelper.floatingEraseButton.perform(click());
         TestHelper.erasedMsg.waitForExists(waitingTime);
         assertTrue(TestHelper.erasedMsg.exists());
+        TestHelper.erasedMsg.waitUntilGone(waitingTime);
 
         // Let's go to an actual URL which is https://
         TestHelper.inlineAutocompleteEditText.waitForExists(waitingTime);
@@ -106,6 +107,7 @@ public class TypicalUseScenarioTest {
         TestHelper.floatingEraseButton.perform(click());
         TestHelper.erasedMsg.waitForExists(waitingTime);
         assertTrue(TestHelper.erasedMsg.exists());
+        TestHelper.erasedMsg.waitUntilGone(waitingTime);
 
         // Let's go to an actual URL which is http://
         TestHelper.inlineAutocompleteEditText.waitForExists(waitingTime);


### PR DESCRIPTION
To address intermittent failures found on UI Test.