### PR TITLE
Fix UITest Failures in Firebase

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/OpenwithDialogTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/OpenwithDialogTest.java
@@ -61,7 +61,7 @@ public class OpenwithDialogTest {
                 .enabled(true));
         UiObject openWithTitle = TestHelper.mDevice.findObject(new UiSelector()
                 .className("android.widget.TextView")
-                .text("Open with…")
+                .text("Open in…")
                 .enabled(true));
         UiObject openWithList = TestHelper.mDevice.findObject(new UiSelector()
                 .resourceId("org.mozilla.focus.debug:id/apps")

--- a/app/src/androidTest/java/org/mozilla/focus/activity/TypicalUseScenarioTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/TypicalUseScenarioTest.java
@@ -15,7 +15,6 @@ import android.support.test.uiautomator.UiObjectNotFoundException;
 import android.support.test.uiautomator.UiSelector;
 
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,7 +26,6 @@ import static org.mozilla.focus.helpers.TestHelper.waitingTime;
 import static org.mozilla.focus.fragment.FirstrunFragment.FIRSTRUN_PREF;
 
 @RunWith(AndroidJUnit4.class)
-@Ignore("This one is failing frequently - Let's fix it: #2207")
 public class TypicalUseScenarioTest {
 
     @Rule
@@ -137,7 +135,7 @@ public class TypicalUseScenarioTest {
         blockSocialTrackerEntry.click();
 
         //Back to the webpage
-        TestHelper.navigateUp.click();
+        TestHelper.pressBackKey();
         assertTrue(TestHelper.webView.waitForExists(waitingTime));
         assertTrue (TestHelper.browserURLbar.getText().contains("http://www.example.com"));
         assertTrue (!TestHelper.lockIcon.exists());


### PR DESCRIPTION
Use back key instead of matching by description
Match new title text on Open In dialog