### PR TITLE
Pass session object to AverageLoadTimeObserver. (#2229)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -232,7 +232,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
         setBlockingEnabled(session.isBlockingEnabled());
 
-        session.getLoading().observe(this, new AverageLoadTimeObserver());
+        session.getLoading().observe(this, new AverageLoadTimeObserver(session));
 
         session.getLoading().observe(this, new NonNullObserver<Boolean>() {
             @Override

--- a/app/src/main/java/org/mozilla/focus/observer/AverageLoadTimeObserver.java
+++ b/app/src/main/java/org/mozilla/focus/observer/AverageLoadTimeObserver.java
@@ -1,9 +1,11 @@
 package org.mozilla.focus.observer;
 
 import android.os.SystemClock;
+import android.support.annotation.NonNull;
 import android.util.Log;
 
 import org.mozilla.focus.architecture.NonNullObserver;
+import org.mozilla.focus.session.Session;
 import org.mozilla.focus.session.SessionManager;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
 
@@ -12,6 +14,12 @@ public class AverageLoadTimeObserver extends NonNullObserver<Boolean> {
     private static final String LOG_TAG = "AverageLoadTimeObserver";
     private long startLoadTime = 0;
     private boolean loadStarted = false;
+
+    private Session session;
+
+    public AverageLoadTimeObserver(@NonNull Session session) {
+        this.session = session;
+    }
 
     @Override
     protected void onValueChanged(Boolean loading) {
@@ -24,8 +32,7 @@ public class AverageLoadTimeObserver extends NonNullObserver<Boolean> {
             }
         } else {
             if (loadStarted) {
-                Log.i(LOG_TAG, "Loaded page at " +
-                        SessionManager.getInstance().getCurrentSession().getUrl().getValue());
+                Log.i(LOG_TAG, "Loaded page at " + session.getUrl().getValue());
                 long endTime = SystemClock.elapsedRealtime();
                 Log.i(LOG_TAG, "zerdatime " + endTime +
                         " - page load stop");


### PR DESCRIPTION
When running UI tests it sometimes has happened that there was no "current session"
anymore at the time a page finished loading. In addition to that there can be
multiple concurrent sessions - so keeping track of the session this observer
observes should make this more robust.