### PR TITLE
Findbugs: Set "effort" to "min".

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -496,7 +496,7 @@ clean.doLast {
 findbugs {
     ignoreFailures = false
 
-    effort = "max"
+    effort = "min"
     // This selects what level of bugs to report: low means low priority issues will be reported
     // (in addition to medium+high), which corresponds to warning about everything.
     // TODO: boost this to low once low priority issues are fixed.


### PR DESCRIPTION
From the docs:
"Higher levels increase precision and find more bugs at the
expense of running time and memory consumption."

We have been running out of memory on taskcluster every now and
then. Let's try how it performs with effort set to "min".