### PR TITLE
Support for camera cutouts

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -34,7 +34,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
-import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.webkit.CookieManager;
 import android.widget.FrameLayout;

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -67,6 +67,7 @@ import org.mozilla.focus.utils.ColorUtils;
 import org.mozilla.focus.utils.DownloadUtils;
 import org.mozilla.focus.utils.DrawableUtils;
 import org.mozilla.focus.utils.Features;
+import org.mozilla.focus.utils.StatusBarUtils;
 import org.mozilla.focus.utils.UrlUtils;
 import org.mozilla.focus.web.Download;
 import org.mozilla.focus.web.IWebView;
@@ -206,11 +207,10 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
         urlBar = view.findViewById(R.id.urlbar);
         statusBar = view.findViewById(R.id.status_bar_background);
-        statusBar.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+        StatusBarUtils.getStatusBarHeight(statusBar, new StatusBarUtils.StatusBarHeightListener() {
             @Override
-            public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
-                v.getLayoutParams().height = insets.getSystemWindowInsetTop();
-                return insets;
+            public void onStatusBarHeightFetched(int statusBarHeight) {
+                statusBar.getLayoutParams().height = statusBarHeight;
             }
         });
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -34,6 +34,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.webkit.CookieManager;
 import android.widget.FrameLayout;
@@ -205,6 +206,13 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
         urlBar = view.findViewById(R.id.urlbar);
         statusBar = view.findViewById(R.id.status_bar_background);
+        statusBar.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+            @Override
+            public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
+                v.getLayoutParams().height = insets.getSystemWindowInsetTop();
+                return insets;
+            }
+        });
 
         urlView = (TextView) view.findViewById(R.id.display_url);
 

--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.java
@@ -23,6 +23,7 @@ import android.view.WindowInsets;
 import org.mozilla.focus.R;
 import org.mozilla.focus.firstrun.FirstrunPagerAdapter;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
+import org.mozilla.focus.utils.StatusBarUtils;
 
 public class FirstrunFragment extends Fragment implements View.OnClickListener {
     public static final String FRAGMENT_TAG = "firstrun";
@@ -56,11 +57,10 @@ public class FirstrunFragment extends Fragment implements View.OnClickListener {
         view.findViewById(R.id.skip).setOnClickListener(this);
 
         final View background = view.findViewById(R.id.background);
-        background.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+        StatusBarUtils.getStatusBarHeight(background, new StatusBarUtils.StatusBarHeightListener() {
             @Override
-            public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
-                v.setPadding(0, insets.getSystemWindowInsetTop(), 0, 0);
-                return insets;
+            public void onStatusBarHeightFetched(int statusBarHeight) {
+                background.setPadding(0, statusBarHeight, 0, 0);
             }
         });
 

--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.java
@@ -18,6 +18,7 @@ import android.transition.TransitionInflater;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowInsets;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.firstrun.FirstrunPagerAdapter;
@@ -55,6 +56,14 @@ public class FirstrunFragment extends Fragment implements View.OnClickListener {
         view.findViewById(R.id.skip).setOnClickListener(this);
 
         final View background = view.findViewById(R.id.background);
+        background.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+            @Override
+            public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
+                v.setPadding(0, insets.getSystemWindowInsetTop(), 0, 0);
+                return insets;
+            }
+        });
+
         final FirstrunPagerAdapter adapter = new FirstrunPagerAdapter(container.getContext(), this);
 
         viewPager = (ViewPager) view.findViewById(R.id.pager);

--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.java
@@ -18,7 +18,6 @@ import android.transition.TransitionInflater;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.WindowInsets;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.firstrun.FirstrunPagerAdapter;

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -11,7 +11,10 @@ import android.os.Bundle
 import android.text.SpannableString
 import android.text.TextUtils
 import android.text.style.StyleSpan
-import android.view.*
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import android.widget.FrameLayout
 import kotlinx.android.synthetic.main.fragment_urlinput.*
 import org.mozilla.focus.R
@@ -171,14 +174,16 @@ class UrlInputFragment :
 
         keyboardLinearLayout.setOnApplyWindowInsetsListener { v, insets ->
             if (v.layoutParams is ViewGroup.MarginLayoutParams) {
-                (v.layoutParams as ViewGroup.MarginLayoutParams).topMargin =
-                        (resources.getDimension(R.dimen.urlinput_height) + insets.systemWindowInsetTop).toInt();
+                val inputHeight = resources.getDimension(R.dimen.urlinput_height)
+                val marginParams = v.layoutParams as ViewGroup.MarginLayoutParams
+                marginParams.topMargin = (inputHeight + insets.systemWindowInsetTop).toInt()
             }
             insets
         }
 
         urlInputLayout.setOnApplyWindowInsetsListener { v, insets ->
-            v.layoutParams.height = (resources.getDimension(R.dimen.urlinput_height) + insets.systemWindowInsetTop).toInt();
+            val inputHeight = resources.getDimension(R.dimen.urlinput_height)
+            v.layoutParams.height = (inputHeight + insets.systemWindowInsetTop).toInt();
             insets;
         }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -183,8 +183,8 @@ class UrlInputFragment :
 
         urlInputLayout.setOnApplyWindowInsetsListener { v, insets ->
             val inputHeight = resources.getDimension(R.dimen.urlinput_height)
-            v.layoutParams.height = (inputHeight + insets.systemWindowInsetTop).toInt();
-            insets;
+            v.layoutParams.height = (inputHeight + insets.systemWindowInsetTop).toInt()
+            insets
         }
 
         session?.let {

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -27,7 +27,13 @@ import org.mozilla.focus.session.Session
 import org.mozilla.focus.session.SessionManager
 import org.mozilla.focus.session.Source
 import org.mozilla.focus.telemetry.TelemetryWrapper
-import org.mozilla.focus.utils.*
+import org.mozilla.focus.utils.Features
+import org.mozilla.focus.utils.Settings
+import org.mozilla.focus.utils.SupportUtils
+import org.mozilla.focus.utils.ThreadUtils
+import org.mozilla.focus.utils.UrlUtils
+import org.mozilla.focus.utils.ViewUtils
+import org.mozilla.focus.utils.StatusBarUtils
 import org.mozilla.focus.whatsnew.WhatsNew
 import org.mozilla.focus.widget.InlineAutocompleteEditText
 

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -11,10 +11,7 @@ import android.os.Bundle
 import android.text.SpannableString
 import android.text.TextUtils
 import android.text.style.StyleSpan
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import android.view.ViewTreeObserver
+import android.view.*
 import android.widget.FrameLayout
 import kotlinx.android.synthetic.main.fragment_urlinput.*
 import org.mozilla.focus.R
@@ -114,7 +111,8 @@ class UrlInputFragment :
     private val urlAutoCompleteFilter: UrlAutoCompleteFilter = UrlAutoCompleteFilter()
     private var displayedPopupMenu: HomeMenu? = null
 
-    @Volatile private var isAnimating: Boolean = false
+    @Volatile
+    private var isAnimating: Boolean = false
 
     private var session: Session? = null
 
@@ -170,6 +168,19 @@ class UrlInputFragment :
         }
 
         urlView.setOnCommitListener(this)
+
+        keyboardLinearLayout.setOnApplyWindowInsetsListener { v, insets ->
+            if (v.layoutParams is ViewGroup.MarginLayoutParams) {
+                (v.layoutParams as ViewGroup.MarginLayoutParams).topMargin =
+                        (resources.getDimension(R.dimen.urlinput_height) + insets.systemWindowInsetTop).toInt();
+            }
+            insets
+        }
+
+        urlInputLayout.setOnApplyWindowInsetsListener { v, insets ->
+            v.layoutParams.height = (resources.getDimension(R.dimen.urlinput_height) + insets.systemWindowInsetTop).toInt();
+            insets;
+        }
 
         session?.let {
             urlView.setText(if (it.isSearch && Features.SEARCH_TERMS_OR_URL) it.searchTerms else it.url.value)

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -27,12 +27,7 @@ import org.mozilla.focus.session.Session
 import org.mozilla.focus.session.SessionManager
 import org.mozilla.focus.session.Source
 import org.mozilla.focus.telemetry.TelemetryWrapper
-import org.mozilla.focus.utils.Features
-import org.mozilla.focus.utils.Settings
-import org.mozilla.focus.utils.SupportUtils
-import org.mozilla.focus.utils.ThreadUtils
-import org.mozilla.focus.utils.UrlUtils
-import org.mozilla.focus.utils.ViewUtils
+import org.mozilla.focus.utils.*
 import org.mozilla.focus.whatsnew.WhatsNew
 import org.mozilla.focus.widget.InlineAutocompleteEditText
 
@@ -172,20 +167,26 @@ class UrlInputFragment :
 
         urlView.setOnCommitListener(this)
 
-        keyboardLinearLayout.setOnApplyWindowInsetsListener { v, insets ->
-            if (v.layoutParams is ViewGroup.MarginLayoutParams) {
+        StatusBarUtils.getStatusBarHeight(keyboardLinearLayout, {
+            if (keyboardLinearLayout.layoutParams is ViewGroup.MarginLayoutParams) {
                 val inputHeight = resources.getDimension(R.dimen.urlinput_height)
-                val marginParams = v.layoutParams as ViewGroup.MarginLayoutParams
-                marginParams.topMargin = (inputHeight + insets.systemWindowInsetTop).toInt()
+                val marginParams = keyboardLinearLayout.layoutParams as ViewGroup.MarginLayoutParams
+                marginParams.topMargin = (inputHeight + it).toInt()
             }
-            insets
-        }
+        })
 
-        urlInputLayout.setOnApplyWindowInsetsListener { v, insets ->
+        StatusBarUtils.getStatusBarHeight(urlInputLayout, {
             val inputHeight = resources.getDimension(R.dimen.urlinput_height)
-            v.layoutParams.height = (inputHeight + insets.systemWindowInsetTop).toInt()
-            insets
-        }
+            urlInputLayout.layoutParams.height = (inputHeight + it).toInt()
+        })
+
+        StatusBarUtils.getStatusBarHeight(searchViewContainer, {
+            val inputHeight = resources.getDimension(R.dimen.urlinput_height)
+            if (searchViewContainer.layoutParams is ViewGroup.MarginLayoutParams) {
+                val marginParams = searchViewContainer.layoutParams as ViewGroup.MarginLayoutParams
+                marginParams.topMargin = (inputHeight + it).toInt()
+            }
+        })
 
         session?.let {
             urlView.setText(if (it.isSearch && Features.SEARCH_TERMS_OR_URL) it.searchTerms else it.url.value)

--- a/app/src/main/java/org/mozilla/focus/utils/StatusBarUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/StatusBarUtils.java
@@ -8,7 +8,7 @@ import android.view.WindowInsets;
  */
 
 public class StatusBarUtils {
-    public static int STATUS_BAR_SIZE = -1;
+    private static int STATUS_BAR_SIZE = -1;
 
     public interface StatusBarHeightListener {
         void onStatusBarHeightFetched(int statusBarHeight);

--- a/app/src/main/java/org/mozilla/focus/utils/StatusBarUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/StatusBarUtils.java
@@ -14,7 +14,7 @@ public class StatusBarUtils {
         void onStatusBarHeightFetched(int statusBarHeight);
     }
 
-    public static void getStatusBarHeight(View view, final StatusBarHeightListener listener) {
+    public static void getStatusBarHeight(final View view, final StatusBarHeightListener listener) {
         if (STATUS_BAR_SIZE > 0) {
             listener.onStatusBarHeightFetched(STATUS_BAR_SIZE);
         } else {
@@ -23,6 +23,7 @@ public class StatusBarUtils {
                 public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
                     STATUS_BAR_SIZE = insets.getSystemWindowInsetTop();
                     listener.onStatusBarHeightFetched(STATUS_BAR_SIZE);
+                    view.setOnApplyWindowInsetsListener(null);
                     return insets;
                 }
             });

--- a/app/src/main/java/org/mozilla/focus/utils/StatusBarUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/StatusBarUtils.java
@@ -1,0 +1,30 @@
+package org.mozilla.focus.utils;
+
+import android.view.View;
+import android.view.WindowInsets;
+
+/**
+ * Created by Fer on 08/03/2018.
+ */
+
+public class StatusBarUtils {
+    public static int STATUS_BAR_SIZE = -1;
+
+    public interface StatusBarHeightListener {
+        void onStatusBarHeightFetched(int statusBarHeight);
+    }
+
+    public static void getStatusBarHeight(View view, final StatusBarHeightListener listener) {
+        if (STATUS_BAR_SIZE > 0)
+            listener.onStatusBarHeightFetched(STATUS_BAR_SIZE);
+
+        view.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+            @Override
+            public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
+                STATUS_BAR_SIZE = insets.getSystemWindowInsetTop();
+                listener.onStatusBarHeightFetched(STATUS_BAR_SIZE);
+                return insets;
+            }
+        });
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/utils/StatusBarUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/StatusBarUtils.java
@@ -15,16 +15,17 @@ public class StatusBarUtils {
     }
 
     public static void getStatusBarHeight(View view, final StatusBarHeightListener listener) {
-        if (STATUS_BAR_SIZE > 0)
+        if (STATUS_BAR_SIZE > 0) {
             listener.onStatusBarHeightFetched(STATUS_BAR_SIZE);
-
-        view.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
-            @Override
-            public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
-                STATUS_BAR_SIZE = insets.getSystemWindowInsetTop();
-                listener.onStatusBarHeightFetched(STATUS_BAR_SIZE);
-                return insets;
-            }
-        });
+        } else {
+            view.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+                @Override
+                public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
+                    STATUS_BAR_SIZE = insets.getSystemWindowInsetTop();
+                    listener.onStatusBarHeightFetched(STATUS_BAR_SIZE);
+                    return insets;
+                }
+            });
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/utils/StatusBarUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/StatusBarUtils.java
@@ -1,11 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.utils;
 
 import android.view.View;
 import android.view.WindowInsets;
-
-/**
- * Created by Fer on 08/03/2018.
- */
 
 public class StatusBarUtils {
     private static int STATUS_BAR_SIZE = -1;

--- a/app/src/main/res/layout/fragment_urlinput.xml
+++ b/app/src/main/res/layout/fragment_urlinput.xml
@@ -40,7 +40,7 @@
 
     </org.mozilla.focus.widget.ResizableKeyboardLinearLayout>
 
-    <FrameLayout
+    <FrameLayout android:id="@+id/urlInputLayout"
         android:layout_width="match_parent"
         android:layout_height="81dp"
         android:orientation="horizontal"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -41,4 +41,6 @@
     <dimen name="preference_row_height">48dp</dimen>
 
     <dimen name="textinputlayout_spacing">8dp</dimen>
+
+    <dimen name="urlinput_height">57dp</dimen>
 </resources>


### PR DESCRIPTION
This PR fixes content overlapping with the status bar on devices with a camera cutout.

The fix consists of replacing the hardcoded 25dp values with the actual status bar height via the WindowInsets API.

Below you can find screenshots of before and after the change was made (taken from an Android P emulator thanks to P's notch simulation feature).

Before:
![focus_cameracutout_before_1](https://user-images.githubusercontent.com/4409856/37152824-e7127126-22da-11e8-97a5-eb489c563091.png)
![focus_cameracutout_before_2](https://user-images.githubusercontent.com/4409856/37152827-eabfd03e-22da-11e8-8cce-79f5c7dd0887.png)
![focus_cameracutout_before_3](https://user-images.githubusercontent.com/4409856/37152835-efc94790-22da-11e8-890e-9529e4be6f6a.png)
![focus_cameracutout_before_4](https://user-images.githubusercontent.com/4409856/37152843-f587109a-22da-11e8-9777-f422cc78a2a1.png)


After:
![focus_cameracuout_after_1](https://user-images.githubusercontent.com/4409856/37152707-8b92ba18-22da-11e8-8adf-bf92cbc9cff4.png)
![focus_cameracutout_after_2](https://user-images.githubusercontent.com/4409856/37152807-dba3cd4e-22da-11e8-9a57-a78b10a28f07.png)
![focus_cameracutout_after_3](https://user-images.githubusercontent.com/4409856/37152813-ded8528c-22da-11e8-8a36-582fd3b401ef.png)
![focus_cameracutout_after_4](https://user-images.githubusercontent.com/4409856/37152817-e0d35064-22da-11e8-8a8d-e829180b3871.png)

#2047 