### PR TITLE
Pause and resume WebView investigating #1216

### DIFF
--- a/app/src/webview/java/org/mozilla/focus/webview/SystemWebView.java
+++ b/app/src/webview/java/org/mozilla/focus/webview/SystemWebView.java
@@ -110,6 +110,18 @@ public class SystemWebView extends NestedWebView implements IWebView, SharedPref
     }
 
     @Override
+    public void onPause() {
+        super.onPause();
+        pauseTimers();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        resumeTimers();
+    }
+
+    @Override
     public void restoreWebViewState(Session session) {
         final Bundle stateData = session.getWebViewState();
 


### PR DESCRIPTION
Do you think this would help #1216 at all? I looked into it a bit.. Looks like a fairly common pain, there was one other solution I found here http://www.mcseven.me/2011/12/how-to-kill-an-android-webview/ that loads a static asset in onPause and saves the current URL.