### PR TITLE
make swipe faster / avoid long tap menu not appearing

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/DownloadTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/DownloadTest.java
@@ -138,7 +138,7 @@ public class DownloadTest {
         TestHelper.mDevice.openNotification();
 
         TestHelper.savedNotification.waitForExists(waitingTime);
-        TestHelper.savedNotification.swipeRight(600);
+        TestHelper.savedNotification.swipeRight(50);
         TestHelper.pressBackKey();
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ImageSelectTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ImageSelectTest.java
@@ -142,7 +142,7 @@ public class ImageSelectTest {
 
         // Find image and long tap it
         Assert.assertTrue(rabbitImage.exists());
-        rabbitImage.dragTo(rabbitImage, 5);
+        rabbitImage.dragTo(rabbitImage, 10);
         imageMenuTitle.waitForExists(waitingTime);
         Assert.assertTrue(imageMenuTitle.exists());
         Assert.assertEquals(imageMenuTitleText.getText(),
@@ -186,7 +186,7 @@ public class ImageSelectTest {
 
         // Find image and long tap it
         Assert.assertTrue(rabbitImage.exists());
-        rabbitImage.dragTo(rabbitImage, 5);
+        rabbitImage.dragTo(rabbitImage, 10);
         imageMenuTitle.waitForExists(waitingTime);
         Assert.assertTrue(shareMenu.exists());
         Assert.assertTrue(copyMenu.exists());
@@ -216,7 +216,7 @@ public class ImageSelectTest {
         // Find image and long tap it
         rabbitImage.waitForExists(waitingTime);
         Assert.assertTrue(rabbitImage.exists());
-        rabbitImage.dragTo(rabbitImage, 5);
+        rabbitImage.dragTo(rabbitImage, 10);
         imageMenuTitle.waitForExists(waitingTime);
         Assert.assertTrue(imageMenuTitle.exists());
         Assert.assertTrue(shareMenu.exists());

--- a/app/src/test/java/org/mozilla/focus/utils/SupportUtilsTest.java
+++ b/app/src/test/java/org/mozilla/focus/utils/SupportUtilsTest.java
@@ -34,7 +34,7 @@ public class SupportUtilsTest {
         final String testTopicStr = testTopic.topicStr;
 
         Locale.setDefault(Locale.GERMANY);
-        assertEquals("https://support.mozilla.org/1/mobile/" + versionName +"/Android/de-DE/" + testTopicStr,
+        assertEquals("https://support.mozilla.org/1/mobile/" + versionName + "/Android/de-DE/" + testTopicStr,
                 SupportUtils.getSumoURLForTopic(RuntimeEnvironment.application, testTopic));
 
         Locale.setDefault(Locale.CANADA_FRENCH);


### PR DESCRIPTION
extend the long tap time of image to avoid intermittent, and reduce the swipe time of notification element