### PR TITLE
Update GeckoView and add aarch64 product flavor 🔃

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -330,9 +330,9 @@ dependencies {
     // What I actually want to define here is geckoArmCompile and geckoX86Compile. But gradle doesn't
     // allow me to define dependencies for such a flavor combination. However as we are not building
     // WebView + (ARM / x86) flavor combinations this should be good enough for now.
-    armCompile "org.mozilla:geckoview-nightly-armeabi-v7a:60.0a1"
-    x86Compile "org.mozilla:geckoview-nightly-x86:60.0a1"
-    aarch64Compile "org.mozilla:geckoview-nightly-arm64-v8a:60.0a1"
+    armCompile "org.mozilla:geckoview-nightly-armeabi-v7a:61.0a1"
+    x86Compile "org.mozilla:geckoview-nightly-x86:61.0a1"
+    aarch64Compile "org.mozilla:geckoview-nightly-arm64-v8a:61.0a1"
 
     testCompile 'junit:junit:4.12'
     testCompile "org.robolectric:robolectric:3.7.1"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,6 +101,10 @@ android {
             dimension "abi"
         }
 
+        aarch64 {
+            dimension "abi"
+        }
+
         universal {
             dimension "abi"
         }
@@ -187,6 +191,11 @@ android {
             res.srcDir 'src/klarRelease/res'
         }
 
+        klarGeckoAarch64Release {
+            java.srcDir 'src/klarRelease/java'
+            res.srcDir 'src/klarRelease/res'
+        }
+
         focusGeckoArmRelease {
             java.srcDir 'src/focusRelease/java'
             manifest.srcFile 'src/focusRelease/AndroidManifest.xml'
@@ -194,6 +203,12 @@ android {
         }
 
         focusGeckoX86Release {
+            java.srcDir 'src/focusRelease/java'
+            manifest.srcFile 'src/focusRelease/AndroidManifest.xml'
+            res.srcDir 'src/focusRelease/res'
+        }
+
+        focusGeckoAarch64Release {
             java.srcDir 'src/focusRelease/java'
             manifest.srcFile 'src/focusRelease/AndroidManifest.xml'
             res.srcDir 'src/focusRelease/res'
@@ -209,11 +224,19 @@ android {
             res.srcDir 'src/focusBeta/res'
         }
 
+        focusGeckoAarch64Beta {
+            res.srcDir 'src/focusBeta/res'
+        }
+
         klarGeckoArmBeta {
             res.srcDir 'src/klarBeta/res'
         }
 
         klarGeckoX86Beta {
+            res.srcDir 'src/klarBeta/res'
+        }
+
+        klarGeckoAarch64Beta {
             res.srcDir 'src/klarBeta/res'
         }
 
@@ -227,11 +250,19 @@ android {
             res.srcDir 'src/focusDebug/res'
         }
 
+        focusGeckoAarch64Debug {
+            res.srcDir 'src/focusDebug/res'
+        }
+
         klarGeckoArmDebug {
             res.srcDir 'src/klarDebug/res'
         }
 
         klarGeckoX86Debug {
+            res.srcDir 'src/klarDebug/res'
+        }
+
+        klarGeckoAarch64Debug {
             res.srcDir 'src/klarDebug/res'
         }
     }
@@ -261,11 +292,15 @@ repositories {
         //   https://tools.taskcluster.net/index/gecko.v2.mozilla-central.nightly
 
         // ARM GeckoView builds
-        url "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.nightly.2018.03.07.latest.mobile.android-api-16-opt/artifacts/public/android/maven"
+        url "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.nightly.${geckoview_nightly_version}.latest.mobile.android-api-16-opt/artifacts/public/android/maven"
     }
     maven {
         // x86 GeckoView builds
-        url "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.nightly.2018.03.07.latest.mobile.android-x86-opt/artifacts/public/android/maven"
+        url "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.nightly.${geckoview_nightly_version}.latest.mobile.android-x86-opt/artifacts/public/android/maven"
+    }
+    maven {
+        // aarch64 builds
+        url "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.nightly.${geckoview_nightly_version}.latest.mobile.android-aarch64-opt/artifacts/public/android/maven"
     }
 }
 
@@ -297,6 +332,7 @@ dependencies {
     // WebView + (ARM / x86) flavor combinations this should be good enough for now.
     armCompile "org.mozilla:geckoview-nightly-armeabi-v7a:60.0a1"
     x86Compile "org.mozilla:geckoview-nightly-x86:60.0a1"
+    aarch64Compile "org.mozilla:geckoview-nightly-arm64-v8a:60.0a1"
 
     testCompile 'junit:junit:4.12'
     testCompile "org.robolectric:robolectric:3.7.1"
@@ -341,6 +377,8 @@ android.applicationVariants.all { variant ->
         def multiplier = 100000000
 
         if (variant.flavorName.contains("X86")) {
+            versionCode = versionCode + (3 * multiplier)
+        } else if (variant.flavorName.contains("Aarch64")) {
             versionCode = versionCode + (2 * multiplier)
         } else if (variant.flavorName.contains("Arm")) {
             versionCode = versionCode + (1 * multiplier)

--- a/app/src/gecko/java/org/mozilla/focus/web/WebViewProvider.java
+++ b/app/src/gecko/java/org/mozilla/focus/web/WebViewProvider.java
@@ -98,7 +98,7 @@ public class WebViewProvider {
 
         @Override
         public void destroy() {
-            geckoSession.closeWindow();
+            geckoSession.close();
         }
 
         @Override
@@ -191,7 +191,7 @@ public class WebViewProvider {
                 }
 
                 @Override
-                public void onContextMenu(GeckoSession session, int screenX, int screenY, String uri, String elementSrc) {
+                public void onContextMenu(GeckoSession session, int screenX, int screenY, String uri, @ElementType int elementType, String elementSrc) {
                     if (elementSrc != null && uri != null) {
                         callback.onLongPress(new HitTarget(true, uri, true, elementSrc));
                     } else if (elementSrc != null) {
@@ -266,9 +266,9 @@ public class WebViewProvider {
                 }
 
                 @Override
-                public boolean onLoadUri(GeckoSession session, String uri, GeckoSession.NavigationDelegate.TargetWindow where) {
+                public boolean onLoadRequest(GeckoSession session, String uri, @TargetWindow int target) {
                     // If this is trying to load in a new tab, just load it in the current one
-                    if (where == GeckoSession.NavigationDelegate.TargetWindow.NEW) {
+                    if (target == GeckoSession.NavigationDelegate.TARGET_WINDOW_NEW) {
                         geckoSession.loadUri(uri);
                         return true;
                     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.support_libraries_version = '27.0.2'
     ext.espresso_version = '3.0.1'
     ext.kotlin_version = '1.2.30'
-    ext.geckoview_nightly_version = '2018.03.07'
+    ext.geckoview_nightly_version = '2018.03.16'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     ext.support_libraries_version = '27.0.2'
     ext.espresso_version = '3.0.1'
     ext.kotlin_version = '1.2.30'
+    ext.geckoview_nightly_version = '2018.03.07'
 
     repositories {
         google()


### PR DESCRIPTION
This PR:
* Adds an aarch64 product flavor for testing purposes (According to the GV team this build might have performance/stability issues and might not ship initially)
* Update GeckoView to the latest version and update the code to use the changed API