### PR TITLE
Use new API for version code override

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,8 +114,13 @@ android {
 
     variantFilter { variant ->
         def flavors = variant.flavors*.name
-        // We only need a gecko debug and beta build for now.
         if (flavors.contains("gecko") && flavors.contains("focus")) {
+            // We only need Klar builds with gecko for now
+            setIgnore(true)
+        }
+
+        if (variant.buildType.name == "release" && flavors.contains("gecko")) {
+            // Do not build release versions including Gecko until we actually want to release something.
             setIgnore(true)
         }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -385,7 +385,9 @@ android.applicationVariants.all { variant ->
             versionCode = versionCode + (1 * multiplier)
         }
 
-        variant.mergedFlavor.versionCode = versionCode
+        variant.outputs.all { output ->
+            setVersionCodeOverride(versionCode)
+        }
     }
 
     println("----------------------------------------------")


### PR DESCRIPTION
Since updating the Android build plugin our version code override was failing silently (sigh). However there's a new API that we can use.