### PR TITLE
Fixes #2346 - Performs null checks onAnimationEnd

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -434,16 +434,16 @@ class UrlInputFragment :
                 .alpha((if (reverse) 0 else 1).toFloat())
                 .setListener(object : AnimatorListenerAdapter() {
                     override fun onAnimationStart(animation: Animator) {
-                        toolbarBackgroundView.visibility = View.VISIBLE
+                        toolbarBackgroundView?.visibility = View.VISIBLE
                     }
 
                     override fun onAnimationEnd(animation: Animator) {
                         if (reverse) {
-                            toolbarBackgroundView.visibility = View.GONE
+                            toolbarBackgroundView?.visibility = View.GONE
 
                             if (!isOverlay) {
-                                dismissView.visibility = View.GONE
-                                menuView.visibility = View.VISIBLE
+                                dismissView?.visibility = View.GONE
+                                menuView?.visibility = View.VISIBLE
                             }
                         }
                     }


### PR DESCRIPTION
Is there a better way to make sure any pending animations get dequeued when a fragment is getting cleaned up? This should fix the crash though.