### PR TITLE
Use primary Google engine for Focus

### DIFF
--- a/app/src/main/assets/search/search_configuration.json
+++ b/app/src/main/assets/search/search_configuration.json
@@ -455,7 +455,7 @@
     "wikipedia-hr"
   ],
   "en-US": [
-    "google-2018",
+    "google",
     "yahoo",
     "amazondotcom",
     "duckduckgo",


### PR DESCRIPTION
We're using the Android locale (en-US) to determine which engine to use and it doesn't work well, so we end up with a lot of searches using the wrong code.

So many that it makes sense to use the non US code for everyone.