### PR TITLE
For #2055 - Only show the whats new dot on major versions

### DIFF
--- a/app/src/main/java/org/mozilla/focus/whatsnew/WhatsNew.kt
+++ b/app/src/main/java/org/mozilla/focus/whatsnew/WhatsNew.kt
@@ -47,6 +47,7 @@ class WhatsNew {
             if (wasUpdatedRecently == null) {
                 wasUpdatedRecently = wasUpdatedRecentlyInner(context)
             }
+
             return wasUpdatedRecently!!
         }
 
@@ -83,7 +84,14 @@ class WhatsNew {
                 return false
             }
 
-            return !lastKnownAppVersionName.equals(context.appVersionName)
+            val getMajorVersion: (String?) -> Int = { version ->
+                version?.split(".")?.first()?.toInt() ?: 0
+            }
+
+            val lastMajorVersion = getMajorVersion(lastKnownAppVersionName)
+            val currentMajorVersion = getMajorVersion(context.appVersionName)
+
+            return currentMajorVersion > lastMajorVersion
         }
 
         private fun getLastKnownAppVersionName(context: Context): String? {

--- a/app/src/main/java/org/mozilla/focus/whatsnew/WhatsNewStorage.kt
+++ b/app/src/main/java/org/mozilla/focus/whatsnew/WhatsNewStorage.kt
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.whatsnew
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.preference.PreferenceManager
+import android.support.annotation.VisibleForTesting
+
+/**
+ * Interface to abstract where the cached version and session counter is stored
+ */
+interface WhatsNewStorage {
+    fun getVersion(): WhatsNewVersion?
+    fun setVersion(version: WhatsNewVersion)
+    fun getSessionCounter(): Int
+    fun setSessionCounter(sessionCount: Int)
+
+    companion object {
+        @VisibleForTesting
+        internal const val PREFERENCE_KEY_APP_NAME = "whatsnew-lastKnownAppVersionName"
+
+        @VisibleForTesting
+        internal const val PREFERENCE_KEY_SESSION_COUNTER = "whatsnew-updateSessionCounter"
+    }
+}
+
+class SharedPreferenceWhatsNewStorage(private val sharedPreference: SharedPreferences) : WhatsNewStorage {
+
+    constructor(context: Context): this(PreferenceManager.getDefaultSharedPreferences(context))
+
+    override fun getVersion(): WhatsNewVersion? {
+        return sharedPreference.getString(WhatsNewStorage.PREFERENCE_KEY_APP_NAME, null)?.let { WhatsNewVersion(it) }
+    }
+
+    override fun setVersion(version: WhatsNewVersion) {
+        sharedPreference.edit()
+                .putString(WhatsNewStorage.PREFERENCE_KEY_APP_NAME, version.version)
+                .apply()
+    }
+
+    override fun getSessionCounter(): Int {
+        return sharedPreference.getInt(WhatsNewStorage.PREFERENCE_KEY_SESSION_COUNTER, 0)
+    }
+
+    override fun setSessionCounter(sessionCount: Int) {
+        sharedPreference.edit()
+                .putInt(WhatsNewStorage.PREFERENCE_KEY_SESSION_COUNTER, sessionCount)
+                .apply()
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/whatsnew/WhatsNewVersion.kt
+++ b/app/src/main/java/org/mozilla/focus/whatsnew/WhatsNewVersion.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.whatsnew
+
+import android.content.Context
+import mozilla.components.ktx.android.content.appVersionName
+
+/**
+* Convenience class to deal with the application version number
+* I opted to keep it contained to the whatsnew package. We may
+* want to pull it
+*/
+open class WhatsNewVersion(internal open val version: String) {
+
+    override fun hashCode(): Int {
+        return version.hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other is WhatsNewVersion) {
+            return version == other.version
+        }
+
+        return false
+    }
+
+    val majorVersionNumber: Int
+        get() = version.split(".").first().toInt()
+}
+
+data class ContextWhatsNewVersion(private val context: Context) : WhatsNewVersion("") {
+    override val version: String
+        get() = context.appVersionName ?: ""
+}

--- a/app/src/test/java/org/mozilla/focus/whatsnew/WhatsNewStorageTest.kt
+++ b/app/src/test/java/org/mozilla/focus/whatsnew/WhatsNewStorageTest.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.whatsnew
+
+import android.preference.PreferenceManager
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class WhatsNewStorageTest {
+    @Before
+    fun setUp() {
+        // Reset all saved and cached values before running a test
+        PreferenceManager.getDefaultSharedPreferences(RuntimeEnvironment.application)
+            .edit()
+            .clear()
+            .apply()
+    }
+
+    @Test
+    fun testGettingAndSettingAVersion() {
+        val storage = SharedPreferenceWhatsNewStorage(RuntimeEnvironment.application)
+
+        val version = WhatsNewVersion("3.0")
+        storage.setVersion(version)
+
+        val storedVersion = storage.getVersion()
+        assertEquals(version, storedVersion)
+    }
+
+    @Test
+    fun testGettingAndSettingTheSessionCounter() {
+        val storage = SharedPreferenceWhatsNewStorage(RuntimeEnvironment.application)
+        val expected = 3
+
+        storage.setSessionCounter(expected)
+
+        val storedCounter = storage.getSessionCounter()
+        assertEquals(expected, storedCounter)
+    }
+}

--- a/app/src/test/java/org/mozilla/focus/whatsnew/WhatsNewTest.kt
+++ b/app/src/test/java/org/mozilla/focus/whatsnew/WhatsNewTest.kt
@@ -39,20 +39,37 @@ class WhatsNewTest {
     fun testWithUpdatedAppVersionName() {
         assertFalse(WhatsNew.shouldHighlightWhatsNew(RuntimeEnvironment.application))
 
-        PreferenceManager.getDefaultSharedPreferences(RuntimeEnvironment.application)
-                .edit()
-                .putString(WhatsNew.PREFERENCE_KEY_APP_NAME, "2.0")
-                .apply()
+        val storage = object : WhatsNewStorage {
+            private var version = WhatsNewVersion("2.0.0")
+            private var sessionCounter = 0
+
+            override fun getVersion(): WhatsNewVersion? {
+                return version
+            }
+
+            override fun getSessionCounter(): Int {
+                return sessionCounter
+            }
+
+            override fun setSessionCounter(sessionCount: Int) {
+                sessionCounter = sessionCount
+            }
+
+            override fun setVersion(version: WhatsNewVersion) {
+                this.version = version
+            }
+        }
 
         // Reset cached value
         WhatsNew.wasUpdatedRecently = null
+        val newVersion = WhatsNewVersion("3.0.0")
 
         // The app was updated recently
-        assertTrue(WhatsNew.shouldHighlightWhatsNew(RuntimeEnvironment.application))
+        assertTrue(WhatsNew.shouldHighlightWhatsNew(newVersion, storage))
 
         // shouldHighlightWhatsNew() will continue to return true as long as the process is alive
         for (i in 1..10) {
-            assertTrue(WhatsNew.shouldHighlightWhatsNew(RuntimeEnvironment.application))
+            assertTrue(WhatsNew.shouldHighlightWhatsNew(newVersion, storage))
         }
     }
 
@@ -62,7 +79,7 @@ class WhatsNewTest {
 
         PreferenceManager.getDefaultSharedPreferences(RuntimeEnvironment.application)
                 .edit()
-                .putString(WhatsNew.PREFERENCE_KEY_APP_NAME, "2.0")
+                .putString(WhatsNewStorage.PREFERENCE_KEY_APP_NAME, "2.0")
                 .apply()
 
         for (i in 1..3) {
@@ -82,7 +99,7 @@ class WhatsNewTest {
 
         PreferenceManager.getDefaultSharedPreferences(RuntimeEnvironment.application)
                 .edit()
-                .putString(WhatsNew.PREFERENCE_KEY_APP_NAME, "2.0")
+                .putString(WhatsNewStorage.PREFERENCE_KEY_APP_NAME, "2.0")
                 .apply()
 
         // Reset cached value

--- a/app/src/test/java/org/mozilla/focus/whatsnew/WhatsNewVersionTest.kt
+++ b/app/src/test/java/org/mozilla/focus/whatsnew/WhatsNewVersionTest.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.whatsnew
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WhatsNewVersionTest {
+    @Test
+    fun testMajorVersionNumber() {
+        val versionOne = WhatsNewVersion("1.2.0")
+        assertEquals(1, versionOne.majorVersionNumber)
+
+        val versionTwo = WhatsNewVersion("2.4.0")
+        assertNotEquals(1, versionTwo.majorVersionNumber)
+    }
+}


### PR DESCRIPTION
@ekager @pocmo I would love to add another test to test the negativity of a minor version update. But couldn't figure out how to stub `context.appVersionName`. Any ideas?