### PR TITLE
Ignore clicks on URL bar if session no longer exists Closes #2417

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -843,13 +843,15 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
                 break;
 
             case R.id.display_url:
-                final Fragment urlFragment = UrlInputFragment
-                        .createWithSession(session, urlView);
+                if (SessionManager.getInstance().hasSessionWithUUID(session.getUUID())) {
+                    final Fragment urlFragment = UrlInputFragment
+                            .createWithSession(session, urlView);
 
-                getActivity().getSupportFragmentManager()
-                        .beginTransaction()
-                        .add(R.id.container, urlFragment, UrlInputFragment.FRAGMENT_TAG)
-                        .commit();
+                    getActivity().getSupportFragmentManager()
+                            .beginTransaction()
+                            .add(R.id.container, urlFragment, UrlInputFragment.FRAGMENT_TAG)
+                            .commit();
+                }
                 break;
 
             case R.id.erase: {


### PR DESCRIPTION
Should be a simpler solution to just ignore the clicks if the session no longer exists (ie clear all sessions was called right before clicking on the URL bar)