### PR TITLE
Perhaps a 'Reset to Default' button is needed in Settings 

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -7,11 +7,15 @@ package org.mozilla.focus.settings;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.os.CountDownTimer;
 import android.preference.ListPreference;
 import android.preference.Preference;
+import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
+import android.widget.ListView;
+
 import org.mozilla.focus.R;
 import org.mozilla.focus.activity.SettingsActivity;
 import org.mozilla.focus.autocomplete.AutocompleteSettingsFragment;

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -90,6 +90,35 @@ public class SettingsFragment extends BaseSettingsFragment implements SharedPref
             TelemetryWrapper.openSearchSettingsEvent();
         } else if (preference.getKey().equals(resources.getString(R.string.pref_key_screen_autocomplete))) {
             navigateToFragment(new AutocompleteSettingsFragment());
+        } else if (preference.getKey().equals(resources.getString(R.string.pref_key_reset_default_browser))) {
+            // Reset browser settings to default
+            PreferenceManager.getDefaultSharedPreferences(getActivity().getApplicationContext())
+                    .edit()
+                    .clear()
+                    .apply();
+
+            // Reset locale to default - US
+            final LocaleManager localeManager = LocaleManager.getInstance();
+            localeManager.setSelectedLocale(getActivity(), String.valueOf(Locale.US));
+            localeManager.updateConfiguration(getActivity(), Locale.US);
+
+            // Update the language selection (in dialog)
+            final ListPreference languagePreference = (ListPreference) findPreference(getString(R.string.pref_key_locale));
+            languagePreference.setValue(String.valueOf(Locale.US));
+
+            // Scroll to selected item in ListView.
+            final ListView mListView = getActivity().findViewById(android.R.id.list);
+            mListView.smoothScrollToPosition(0);
+            if (mListView != null) mListView.setVerticalScrollBarEnabled(false);
+            // Half a second delay for better animation
+            new CountDownTimer(500, 1000) {
+                public void onTick(long millisUntilFinished) {}
+                public void onFinish() {
+                    // Manually notify SettingsActivity of browser settings reset
+                    if (mListView != null) mListView.setVerticalScrollBarEnabled(true);
+                    if (getActivity() != null) addPreferencesFromResource(R.xml.settings);
+                }
+            }.start();
         }
 
         return super.onPreferenceTreeClick(preferenceScreen, preference);

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -16,7 +16,8 @@
     <string name="pref_key_performance_block_images" translatable="false"><xliff:g id="preference_key">pref_performance_block_images</xliff:g></string>
 
     <string name="pref_key_default_browser" translatable="false"><xliff:g id="preference_key">pref_default_browser</xliff:g></string>
-
+    <string name="pref_key_reset_default_browser" translatable="false"><xliff:g id="preference_key">pref_reset_default_browser</xliff:g></string>
+    
     <string name="pref_key_telemetry" translatable="false"><xliff:g id="preference_key">pref_telemetry</xliff:g></string>
 
     <string name="pref_key_secure" translatable="false"><xliff:g id="preference_key">pref_secure</xliff:g></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -240,6 +240,12 @@
     <!-- %1$s will be replaced with the name of the app (e.g. Firefox Focus) -->
     <string name="preference_mozilla_telemetry_summary2">Mozilla strives to collect only what we need to provide and improve %1$s for everyone.</string>
 
+    <!-- Action header to reset the browser settings to default. --> 
+    <string name="preference_browser_default_settings">Reset</string>
+
+    <!-- Action summary for reset the browser settings. -->  
+    <string name="preference_browser_default_settings_summary">Reset browser settings to default</string>  
+
     <!-- In-app link (in settings) to Focus privacy notice. -->
     <string name="preference_privacy_notice">Privacy Notice</string>
 

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -110,7 +110,13 @@
             android:title="@string/preference_mozilla_telemetry2"
             android:persistent="false"
             android:summary="@string/preference_mozilla_telemetry_summary2" />
-
+       
+        <Preference
+            android:key="@string/pref_key_reset_default_browser"
+            android:title="@string/preference_browser_default_settings"
+            android:summary="@string/preference_browser_default_settings_summary"
+            android:defaultValue="false" />
+        
         <!-- AboutPreference performs some string substitutions, so that we can show "About <AppName>".
              We keep a plain "About" as the title here in xml as a fallback, but AboutPreference
              will use the substitution regardless of what is set here. -->


### PR DESCRIPTION
First of all this is not a bug fix, it is new feature that has been requested (#1848) 
I have added Reset (Reset browser settings to default) functionality to the settings menu. Now, once the "Reset" preference is clicked the browser shared preferences are cleared and the locale is set to US. Then the settings view gets refreshed with smooth animation. 
Here is a video showcasing the functionality:

<a href="https://imgflip.com/gif/28w6w4"><img src="https://i.imgflip.com/28w6w4.gif" title="made at imgflip.com"/></a>

I also wanted to localize/translate to the reset preference title and summary strings, but then i decided to get your feedback first to confirm that i am on the right track. Also i could have missed other preferences/data that must be cleared, so it would be nice if you could specify what else needs to be reset.  
