### PR TITLE
Fix search engine writer url format

### DIFF
--- a/app/src/main/java/org/mozilla/focus/search/SearchEngineWriter.kt
+++ b/app/src/main/java/org/mozilla/focus/search/SearchEngineWriter.kt
@@ -30,24 +30,23 @@ internal class SearchEngineWriter {
                 document.appendChild(rootElement)
 
                 val shortNameElement = document.createElement("ShortName")
-                shortNameElement.setTextContent(engineName)
+                shortNameElement.textContent = engineName
                 rootElement.appendChild(shortNameElement)
 
                 val imageElement = document.createElement("Image")
                 imageElement.setAttribute("width", "16")
                 imageElement.setAttribute("height", "16")
-                imageElement.setTextContent(BitmapUtils.getBase64EncodedDataUriFromBitmap(iconBitmap))
+                imageElement.textContent = BitmapUtils.getBase64EncodedDataUriFromBitmap(iconBitmap)
                 rootElement.appendChild(imageElement)
 
                 val descriptionElement = document.createElement("Description")
-                descriptionElement.setTextContent(engineName)
+                descriptionElement.textContent = engineName
                 rootElement.appendChild(descriptionElement)
 
                 val urlElement = document.createElement("Url")
                 urlElement.setAttribute("type", "text/html")
 
-                // Simple implementation that assumes "%s" terminator from UrlUtils.isValidSearchEngineQueryUrl
-                val templateSearchString = searchQuery.substring(0, searchQuery.length - 2) + "{searchTerms}"
+                val templateSearchString = searchQuery.replace("%s", "{searchTerms}")
                 urlElement.setAttribute("template", templateSearchString)
                 rootElement.appendChild(urlElement)
 

--- a/app/src/test/java/org/mozilla/focus/search/SearchEngineWriterTest.kt
+++ b/app/src/test/java/org/mozilla/focus/search/SearchEngineWriterTest.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.search
+
+import android.graphics.Bitmap
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.junit.Assert.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+class SearchEngineWriterTest {
+
+    @Test
+    fun buildSearchEngineXML() {
+        val endSearchTermXml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
+            "<OpenSearchDescription xmlns=\"http://a9.com/-/spec/opensearch/1.1/\">" +
+            "<ShortName>testEngine</ShortName>" +
+            "<Image height=\"16\" width=\"16\">" +
+            "data:image/png;base64,Qml0bWFwICgyIHggMikgY29tcHJlc3NlZCBhcyBQTkcgd2l0aCBxdWFsaXR5IDEwMA==\n" +
+            "</Image>" +
+            "<Description>testEngine</Description>" +
+            "<Url template=\"testEngine/?q={searchTerms}\" type=\"text/html\"/>" +
+            "</OpenSearchDescription>"
+
+        assertEquals(endSearchTermXml,
+            SearchEngineWriter.buildSearchEngineXML("testEngine", "testEngine/?q=%s", createBitmap()))
+
+        val middleSearchTermXml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
+            "<OpenSearchDescription xmlns=\"http://a9.com/-/spec/opensearch/1.1/\">" +
+            "<ShortName>testEngine</ShortName>" +
+            "<Image height=\"16\" width=\"16\">" +
+            "data:image/png;base64,Qml0bWFwICgyIHggMikgY29tcHJlc3NlZCBhcyBQTkcgd2l0aCBxdWFsaXR5IDEwMA==\n" +
+            "</Image>" +
+            "<Description>testEngine</Description>" +
+            "<Url template=\"testEngine/?q={searchTerms}/tests\" type=\"text/html\"/>" +
+            "</OpenSearchDescription>"
+
+        assertEquals(middleSearchTermXml,
+            SearchEngineWriter.buildSearchEngineXML("testEngine", "testEngine/?q=%s/tests", createBitmap()))
+    }
+
+    private fun createBitmap(): Bitmap {
+        val width = 2
+        val height = 2
+        return Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    }
+}


### PR DESCRIPTION
* The URL validation doesn't enforce `%s` placeholder anymore. The
writer now replaces `%s` by `{searchTers}` everywhere in the template.
* Unit test `SearchEngineWriter`

Closes #2487