### PR TITLE
Closes #2518 - transparent background to the security popup window

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -15,6 +15,7 @@ import android.content.IntentFilter;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.TransitionDrawable;
 import android.net.Uri;
@@ -1107,6 +1108,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
                     popupTint.setVisibility(View.GONE);
                 }
             });
+            securityPopup.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
             securityPopup.setAnimationStyle(android.R.style.Animation_Dialog);
             securityPopup.setTouchable(true);
             securityPopup.setFocusable(true);


### PR DESCRIPTION
FIxed - popup couldn't be dismissed on touch in devices where the background was passed as null therefore not intercepting any user events and preventing the popup to be dismissed.