### PR TITLE
Bug 1409091 - Add mandatory but unused ChainOfTrust artifacts

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -142,6 +142,14 @@ tasks:
           type: 'file'
           path: '/opt/focus-android/task-graph.json'
           expires: "{{ '1 year' | $fromNow }}"
+        'public/actions.json':
+          type: 'file'
+          path: '/opt/focus-android/actions.json'
+          expires: "{{ '1 year' | $fromNow }}"
+        'public/parameters.yml':
+          type: 'file'
+          path: '/opt/focus-android/parameters.yml'
+          expires: "{{ '1 year' | $fromNow }}"
     metadata:
       name: (Focus for Android) Decision task ({{ event.version }})
       description: Scheduling tasks for releasing Focus/Klar

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -141,7 +141,7 @@ tasks:
         'public/task-graph.json':
           type: 'file'
           path: '/opt/focus-android/task-graph.json'
-          expires: "{{ '1 week' | $fromNow }}"
+          expires: "{{ '1 year' | $fromNow }}"
     metadata:
       name: (Focus for Android) Decision task ({{ event.version }})
       description: Scheduling tasks for releasing Focus/Klar

--- a/tools/taskcluster/release.py
+++ b/tools/taskcluster/release.py
@@ -43,12 +43,12 @@ def generate_build_task(tag):
 			"public/focus.apk": {
 				"type": "file",
 				"path": "/opt/focus-android/app/build/outputs/apk/focusWebviewUniversal/release/app-focus-webview-universal-release-unsigned.apk",
-				"expires": taskcluster.stringDate(taskcluster.fromNow('1 month'))
+				"expires": taskcluster.stringDate(taskcluster.fromNow('1 year'))
 			},
             "public/klar.apk": {
 				"type": "file",
 				"path": "/opt/focus-android/app/build/outputs/apk/klarWebviewUniversal/release/app-klar-webview-universal-release-unsigned.apk",
-				"expires": taskcluster.stringDate(taskcluster.fromNow('1 month'))
+				"expires": taskcluster.stringDate(taskcluster.fromNow('1 year'))
 			}
 		},
         worker_type='gecko-focus',

--- a/tools/taskcluster/release.py
+++ b/tools/taskcluster/release.py
@@ -87,6 +87,17 @@ def generate_push_task(signing_task_id, track, commit):
         commit = commit
     )
 
+
+def populate_chain_of_trust_required_but_unused_files():
+    # Thoses files are needed to keep chainOfTrust happy. However, they have no need for Firefox
+    # Focus, at the moment. For more details, see:
+    # https://github.com/mozilla-releng/scriptworker/pull/209/files#r184180585
+
+    for file_names in ('actions.json', 'parameters.yml'):
+        with open(file_names, 'w') as f:
+            json.dump({}, f)    # Yaml is a super-set of JSON.
+
+
 def release(track, commit, tag):
     queue = taskcluster.Queue({ 'baseUrl': 'http://taskcluster/queue/v1' })
 
@@ -113,8 +124,11 @@ def release(track, commit, tag):
     print json.dumps(task_graph, indent=4, separators=(',', ': '))
 
     task_graph_path = "task-graph.json"
-    with open(task_graph_path, 'w') as token_file:
-        token_file.write(json.dumps(task_graph))
+    with open(task_graph_path, 'w') as f:
+        json.dump(task_graph, f)
+
+    populate_chain_of_trust_required_but_unused_files()
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
See https://github.com/mozilla-releng/scriptworker/pull/209/files#r184180585 for context. Once this PR is merged, we should also update the config of https://tools.taskcluster.net/hooks/project-mobile/focus-nightly. Could you handle it @pocmo ? 