### PR TITLE
Update custom URL hint. Fixes #2504

### DIFF
--- a/app/src/main/res/layout/fragment_autocomplete_add_domain.xml
+++ b/app/src/main/res/layout/fragment_autocomplete_add_domain.xml
@@ -32,7 +32,7 @@
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/preference_autocomplete_add_example"
+        android:text="@string/preference_autocomplete_add_example2"
         android:paddingStart="8dp"
         android:paddingEnd="8dp" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,6 +158,9 @@
     <string name="preference_autocomplete_add_hint">Paste or enter URL</string>
 
     <!-- Example how a custom domain autocomplete URL be added (e.g. without http://) -->
+    <string name="preference_autocomplete_add_example2">Example: mozilla.org</string>
+
+    <!-- To be removed once the new hint has been translated -->
     <string name="preference_autocomplete_add_example">Example: example.com</string>
 
     <!-- Content description (not visible, for screen readers etc.): A "handle" that allows the user to reorder custom autocomplete URLs -->


### PR DESCRIPTION
Fixes [#2504](https://github.com/mozilla-mobile/focus-android/issues/2504).

I have left the previous example string(preference_autocomplete_add_example) as the translations for the new string(preference_autocomplete_add_example2) have not been done yet. Once they are completed, the references of the old string resource can be replaced and the string removed.