### PR TITLE
Closes #2581: Upgrade to android-components 0.5.1

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -553,10 +553,8 @@ class UrlInputFragment :
         }
 
         view?.let {
-
-            autoCompleteProvider.autocomplete(searchText, { result, domain, source, size ->
-                view.onAutocomplete(AutocompleteResult(result, source, size, { domain }))
-            })
+            val result = autoCompleteProvider.autocomplete(searchText)
+            view.onAutocomplete(AutocompleteResult(result.text, result.source, result.size, { result.url }))
         }
 
         if (searchText.trim { it <= ' ' }.isEmpty()) {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext.geckoview_revision = '6276ec7ebbf33e3484997b189f20fc1511534187'
     ext.geckoview_nightly_version ='61.0.20180416100101'
     ext.spotbugs_version = '3.1.2'
-    ext.mozilla_components_version = '0.4'
+    ext.mozilla_components_version = '0.5.1'
 
     repositories {
         google()


### PR DESCRIPTION
The only required change is due to an API improvement we did for https://github.com/mozilla-mobile/android-components/pull/106