### PR TITLE
Show "Report Site Issue" for GeckoView builds only 🔃

### DIFF
--- a/app/src/main/java/org/mozilla/focus/menu/browser/BrowserMenuAdapter.java
+++ b/app/src/main/java/org/mozilla/focus/menu/browser/BrowserMenuAdapter.java
@@ -17,6 +17,7 @@ import android.view.ViewGroup;
 import org.mozilla.focus.R;
 import org.mozilla.focus.customtabs.CustomTabConfig;
 import org.mozilla.focus.fragment.BrowserFragment;
+import org.mozilla.focus.utils.AppConstants;
 import org.mozilla.focus.utils.Browsers;
 import org.mozilla.focus.utils.HardwareUtils;
 
@@ -92,7 +93,10 @@ public class BrowserMenuAdapter extends RecyclerView.Adapter<BrowserMenuViewHold
             items.add(new MenuItem(R.id.settings, resources.getString(R.string.menu_settings)));
         }
 
-        items.add(new MenuItem(R.id.report_site_issue, resources.getString(R.string.menu_report_site_issue)));
+        if (AppConstants.isGeckoBuild()) {
+            // "Report Site Issue" is available for builds using GeckoView only
+            items.add(new MenuItem(R.id.report_site_issue, resources.getString(R.string.menu_report_site_issue)));
+        }
 
         if (customTabConfig != null) {
             addCustomTabMenuItems(items, customTabConfig);


### PR DESCRIPTION
We only want to show the `Report Site Issue` menu item in builds using
GeckoView

Closes #2606