### PR TITLE
Fix localized contents shown as insecure

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
@@ -18,6 +18,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import mozilla.components.browser.search.SearchEngine;
+import org.mozilla.focus.browser.LocalizedContent;
 
 public class UrlUtils {
     public static String normalize(@NonNull String input) {
@@ -182,5 +183,10 @@ public class UrlUtils {
         }
 
         return url.substring(start);
+    }
+
+    public static boolean isLocalizedContent(@Nullable String url) {
+        return url != null &&
+            (url.equals(LocalizedContent.URL_ABOUT) || url.equals(LocalizedContent.URL_RIGHTS) || url.equals("about:blank"));
     }
 }

--- a/app/src/test/java/org/mozilla/focus/utils/UrlUtilsTest.java
+++ b/app/src/test/java/org/mozilla/focus/utils/UrlUtilsTest.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mozilla.focus.browser.LocalizedContent;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
@@ -159,5 +160,15 @@ public class UrlUtilsTest {
         assertEquals("mozilla.org", UrlUtils.stripCommonSubdomains("m.mozilla.org"));
         assertEquals("mozilla.org", UrlUtils.stripCommonSubdomains("mobile.mozilla.org"));
         assertEquals("random.mozilla.org", UrlUtils.stripCommonSubdomains("random.mozilla.org"));
+    }
+
+    @Test
+    public void isLocalizedContent() {
+        assertFalse(UrlUtils.isLocalizedContent(null));
+        assertFalse(UrlUtils.isLocalizedContent("mozilla.org"));
+        assertFalse(UrlUtils.isLocalizedContent("http://www.mozilla.org"));
+        assertTrue(UrlUtils.isLocalizedContent("about:blank"));
+        assertTrue(UrlUtils.isLocalizedContent(LocalizedContent.URL_ABOUT));
+        assertTrue(UrlUtils.isLocalizedContent(LocalizedContent.URL_RIGHTS));
     }
 }

--- a/app/src/webview/java/org/mozilla/focus/webview/FocusWebViewClient.java
+++ b/app/src/webview/java/org/mozilla/focus/webview/FocusWebViewClient.java
@@ -194,8 +194,11 @@ import org.mozilla.focus.web.IWebView;
         }
 
         if (callback != null) {
-            callback.onPageFinished(certificate != null);
-            callback.onSecurityChanged(certificate != null, null, (certificate != null) ? certificate.getIssuedBy().getOName() : null);
+            // The page is secure when the url is a localized content or when the certificate isn't null
+            final boolean isSecure = certificate != null || UrlUtils.isLocalizedContent(view.getUrl());
+
+            callback.onPageFinished(isSecure);
+            callback.onSecurityChanged(isSecure, null, (certificate != null) ? certificate.getIssuedBy().getOName() : null);
             // The URL which is supplied in onPageFinished() could be fake (see #301), but webview's
             // URL is always correct _except_ for error pages
             final String viewURL = view.getUrl();


### PR DESCRIPTION
Localized contents are local pages. As they aren't insecure, the lock
icon should be displayed.

Close: #2631 