### PR TITLE
Redesign URL bar (active/typing) Closes #2678

### DIFF
--- a/app/src/main/res/drawable/background_inactive.xml
+++ b/app/src/main/res/drawable/background_inactive.xml
@@ -5,7 +5,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
         android:angle="315"
+        android:startColor="@color/colorInactiveGradientStart"
         android:centerColor="@color/colorInactiveGradientCenter"
-        android:endColor="@color/colorInactiveGradientEnd"
-        android:startColor="@color/coloInactiveGradientStart" />
+        android:endColor="@color/colorInactiveGradientEnd" />
 </shape>

--- a/app/src/main/res/layout/fragment_urlinput.xml
+++ b/app/src/main/res/layout/fragment_urlinput.xml
@@ -64,8 +64,7 @@
             <View
                 android:id="@+id/urlInputBackgroundView"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@drawable/urlbar_background" />
+                android:layout_height="match_parent" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -101,7 +100,7 @@
                     android:id="@+id/clearView"
                     android:layout_width="40dp"
                     android:layout_height="40dp"
-                    android:src="@drawable/ic_clear"
+                    android:src="@drawable/ic_stop"
                     android:layout_marginTop="8dp"
                     android:layout_marginBottom="8dp"
                     android:layout_gravity="end"
@@ -150,13 +149,7 @@
             android:ellipsize="end"
             android:textSize="14sp"
             android:textColor="@color/searchHintTextColor"
-            android:background="?android:attr/selectableItemBackground" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="#33ffffff"
-            android:layout_gravity="bottom" />
+            android:background="@color/searchHintBackgroundColor" />
 
     </FrameLayout>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -16,9 +16,9 @@
     <color name="colorProgressGradientStart">#FF9400FF</color>
     <color name="colorProgressGradientEnd">#FFFF1AD9</color>
 
-    <color name="coloInactiveGradientStart">#ff453440</color>
-    <color name="colorInactiveGradientCenter">#ff433446</color>
-    <color name="colorInactiveGradientEnd">#ff3b3445</color>
+    <color name="colorInactiveGradientStart">#3e1e48</color>
+    <color name="colorInactiveGradientCenter">#331e4b</color>
+    <color name="colorInactiveGradientEnd">#331e4b</color>
 
     <color name="colorErase">@color/photonMagenta70</color>
     <color name="colorErasePressed">@color/photonMagenta80</color>
@@ -45,6 +45,7 @@
     <color name="snackbarActionText">@color/photonBlue50</color>
 
     <color name="searchHintTextColor">#ffffffff</color>
+    <color name="searchHintBackgroundColor">@color/photonInk80</color>
 
     <color name="onboarding_indicator_default">#7FFFFFFF</color>
     <color name="onboarding_indicator_selected">#FFFFFFFF</color>


### PR DESCRIPTION
Hello there!

This fixes #2678. Here's the screenshot after the change:

![screenshot_1528288060](https://user-images.githubusercontent.com/6861614/41038822-2268b5ca-69b5-11e8-8584-4d76e3b4a8b8.png)
