### PR TITLE
Redesign URL bar (active/inactive) Closes #2677 #2678

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -194,7 +194,6 @@ class UrlInputFragment :
             backgroundView?.setBackgroundResource(R.drawable.background_gradient)
 
             dismissView?.visibility = View.GONE
-            toolbarBackgroundView?.visibility = View.GONE
 
             menuView?.visibility = View.VISIBLE
             menuView?.setOnClickListener(this)
@@ -440,31 +439,21 @@ class UrlInputFragment :
         }
 
         if (!reverse) {
-            toolbarBackgroundView?.alpha = 0f
             clearView?.alpha = 0f
         }
 
         if (toolbarBackgroundView != null) {
-            // The darker background appears with an alpha animation
-            toolbarBackgroundView.animate()
-                .setDuration(ANIMATION_DURATION.toLong())
-                .alpha((if (reverse) 0 else 1).toFloat())
-                .setListener(object : AnimatorListenerAdapter() {
-                    override fun onAnimationStart(animation: Animator) {
-                        toolbarBackgroundView?.visibility = View.VISIBLE
-                    }
-
-                    override fun onAnimationEnd(animation: Animator) {
-                        if (reverse) {
-                            toolbarBackgroundView?.visibility = View.GONE
-
-                            if (!isOverlay) {
-                                dismissView?.visibility = View.GONE
-                                menuView?.visibility = View.VISIBLE
-                            }
-                        }
-                    }
-                })
+            if (reverse) {
+                toolbarBackgroundView.setBackgroundResource(R.drawable.background_inactive)
+                toolbarBottomBorder.visibility = View.VISIBLE
+                if (!isOverlay) {
+                    dismissView?.visibility = View.GONE
+                    menuView?.visibility = View.VISIBLE
+                }
+            } else {
+                toolbarBackgroundView.setBackgroundResource(R.drawable.background_active)
+                toolbarBottomBorder.visibility = View.GONE
+            }
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -444,7 +444,7 @@ class UrlInputFragment :
 
         if (toolbarBackgroundView != null) {
             if (reverse) {
-                toolbarBackgroundView.setBackgroundResource(R.drawable.background_inactive)
+                toolbarBackgroundView.setBackgroundResource(R.color.searchInActiveBackgroundColor)
                 toolbarBottomBorder.visibility = View.VISIBLE
                 if (!isOverlay) {
                     dismissView?.visibility = View.GONE

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -445,14 +445,12 @@ class UrlInputFragment :
         if (toolbarBackgroundView != null) {
             if (reverse) {
                 toolbarBackgroundView.setBackgroundResource(R.color.searchInActiveBackgroundColor)
-                toolbarBottomBorder.visibility = View.VISIBLE
                 if (!isOverlay) {
                     dismissView?.visibility = View.GONE
                     menuView?.visibility = View.VISIBLE
                 }
             } else {
                 toolbarBackgroundView.setBackgroundResource(R.drawable.background_active)
-                toolbarBottomBorder.visibility = View.GONE
             }
         }
     }

--- a/app/src/main/res/drawable/background_active.xml
+++ b/app/src/main/res/drawable/background_active.xml
@@ -5,7 +5,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
         android:angle="315"
-        android:startColor="@color/colorInactiveGradientStart"
-        android:centerColor="@color/colorInactiveGradientCenter"
-        android:endColor="@color/colorInactiveGradientEnd" />
+        android:startColor="@color/colorActiveGradientStart"
+        android:centerColor="@color/colorActiveGradientCenter"
+        android:endColor="@color/colorActiveGradientEnd" />
 </shape>

--- a/app/src/main/res/layout/fragment_urlinput.xml
+++ b/app/src/main/res/layout/fragment_urlinput.xml
@@ -57,7 +57,7 @@
             android:id="@+id/toolbarBottomBorder"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:alpha="0.30"
+            android:alpha="0.20"
             android:background="@color/photonGrey90"
             android:layout_gravity="bottom" />
 

--- a/app/src/main/res/layout/fragment_urlinput.xml
+++ b/app/src/main/res/layout/fragment_urlinput.xml
@@ -53,6 +53,14 @@
             android:layout_height="match_parent"
             android:background="@drawable/background_inactive" />
 
+        <View
+            android:id="@+id/toolbarBottomBorder"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:alpha="0.30"
+            android:background="@color/photonGrey90"
+            android:layout_gravity="bottom" />
+
         <FrameLayout
             android:id="@+id/urlInputContainerView"
             android:layout_width="match_parent"
@@ -64,8 +72,7 @@
             <View
                 android:id="@+id/urlInputBackgroundView"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@drawable/urlbar_background" />
+                android:layout_height="match_parent" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -101,7 +108,7 @@
                     android:id="@+id/clearView"
                     android:layout_width="40dp"
                     android:layout_height="40dp"
-                    android:src="@drawable/ic_clear"
+                    android:src="@drawable/ic_stop"
                     android:layout_marginTop="8dp"
                     android:layout_marginBottom="8dp"
                     android:layout_gravity="end"
@@ -150,13 +157,7 @@
             android:ellipsize="end"
             android:textSize="14sp"
             android:textColor="@color/searchHintTextColor"
-            android:background="?android:attr/selectableItemBackground" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="#33ffffff"
-            android:layout_gravity="bottom" />
+            android:background="@color/searchHintBackgroundColor" />
 
     </FrameLayout>
 

--- a/app/src/main/res/layout/fragment_urlinput.xml
+++ b/app/src/main/res/layout/fragment_urlinput.xml
@@ -51,7 +51,7 @@
             android:id="@+id/toolbarBackgroundView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="@drawable/background_inactive" />
+            android:background="@color/searchInActiveBackgroundColor" />
 
         <View
             android:id="@+id/toolbarBottomBorder"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,13 +17,13 @@
     <color name="colorProgressGradientStart">#FF9400FF</color>
     <color name="colorProgressGradientEnd">#FFFF1AD9</color>
 
+    <color name="colorInactiveGradientStart">#ff453440</color>
+    <color name="colorInactiveGradientCenter">#ff433446</color>
+    <color name="colorInactiveGradientEnd">#ff3b3445</color>
+
     <color name="colorLoadingGradientStart">#421c41</color>
     <color name="colorLoadingGradientCenter">#3e1c4d</color>
     <color name="colorLoadingGradientEnd">#271c44</color>
-
-    <color name="colorInactiveGradientStart">#7a1a41</color>
-    <color name="colorInactiveGradientCenter">#7a1a41</color>
-    <color name="colorInactiveGradientEnd">#701b5a</color>
 
     <color name="colorActiveGradientStart">#421c41</color>
     <color name="colorActiveGradientCenter">#3e1c4d</color>
@@ -55,6 +55,8 @@
 
     <color name="searchHintTextColor">#ffffffff</color>
     <color name="searchHintBackgroundColor">@color/photonInk80</color>
+
+    <color name="searchInActiveBackgroundColor">#4d202340</color>
 
     <color name="onboarding_indicator_default">#7FFFFFFF</color>
     <color name="onboarding_indicator_selected">#FFFFFFFF</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,9 +17,17 @@
     <color name="colorProgressGradientStart">#FF9400FF</color>
     <color name="colorProgressGradientEnd">#FFFF1AD9</color>
 
-    <color name="coloInactiveGradientStart">#421c41</color>
-    <color name="colorInactiveGradientCenter">#3e1c4d</color>
-    <color name="colorInactiveGradientEnd">#271c44</color>
+    <color name="colorLoadingGradientStart">#421c41</color>
+    <color name="colorLoadingGradientCenter">#3e1c4d</color>
+    <color name="colorLoadingGradientEnd">#271c44</color>
+
+    <color name="colorInactiveGradientStart">#7a1a41</color>
+    <color name="colorInactiveGradientCenter">#7a1a41</color>
+    <color name="colorInactiveGradientEnd">#701b5a</color>
+
+    <color name="colorActiveGradientStart">#3e1e48</color>
+    <color name="colorActiveGradientCenter">#331e4b</color>
+    <color name="colorActiveGradientEnd">#331e4b</color>
 
     <color name="colorErase">@color/photonMagenta70</color>
     <color name="colorErasePressed">@color/photonMagenta80</color>
@@ -46,6 +54,7 @@
     <color name="snackbarActionText">@color/photonBlue50</color>
 
     <color name="searchHintTextColor">#ffffffff</color>
+    <color name="searchHintBackgroundColor">@color/photonInk80</color>
 
     <color name="onboarding_indicator_default">#7FFFFFFF</color>
     <color name="onboarding_indicator_selected">#FFFFFFFF</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -25,9 +25,9 @@
     <color name="colorInactiveGradientCenter">#7a1a41</color>
     <color name="colorInactiveGradientEnd">#701b5a</color>
 
-    <color name="colorActiveGradientStart">#3e1e48</color>
-    <color name="colorActiveGradientCenter">#331e4b</color>
-    <color name="colorActiveGradientEnd">#331e4b</color>
+    <color name="colorActiveGradientStart">#421c41</color>
+    <color name="colorActiveGradientCenter">#3e1c4d</color>
+    <color name="colorActiveGradientEnd">#271c44</color>
 
     <color name="colorErase">@color/photonMagenta70</color>
     <color name="colorErasePressed">@color/photonMagenta80</color>


### PR DESCRIPTION
This fixes #2677 and #2678. I made a single PR because both the issues were related. 

I am not really sure if the colors are correct. And this is how it looks after the changes:

Inactive url bar (initial state)

![screenshot_152836300_7lxvx](https://user-images.githubusercontent.com/6861614/41090615-4eeee81e-6a62-11e8-9fcf-439713d28cd2.jpg)

Active url bar (typing state)

![screenshot_152828806_5llus](https://user-images.githubusercontent.com/6861614/41090636-573fa2a6-6a62-11e8-99ed-951f103dcdfd.jpg)
