### PR TITLE
Send GV label when reporting webcompat issue Closes #2837

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -1129,8 +1129,8 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
             case R.id.report_site_issue:
                 SessionManager.getInstance()
-                        .createSession(Source.MENU, SupportUtils.REPORT_SITE_ISSUE_URL
-                                .replace("%s", getUrl()));
+                        .createSession(Source.MENU,
+                                String.format(SupportUtils.REPORT_SITE_ISSUE_URL, getUrl()));
                 TelemetryWrapper.reportSiteIssueEvent();
                 break;
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -1128,7 +1128,9 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
                 break;
 
             case R.id.report_site_issue:
-                SessionManager.getInstance().createSession(Source.MENU, SupportUtils.REPORT_SITE_ISSUE_URL.concat(getUrl()));
+                SessionManager.getInstance()
+                        .createSession(Source.MENU, SupportUtils.REPORT_SITE_ISSUE_URL
+                                .replace("%s", getUrl()));
                 TelemetryWrapper.reportSiteIssueEvent();
                 break;
 

--- a/app/src/main/java/org/mozilla/focus/utils/SupportUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/SupportUtils.java
@@ -19,7 +19,7 @@ import java.util.Locale;
 public class SupportUtils {
     public static final String HELP_URL = "https://support.mozilla.org/kb/what-firefox-focus-android";
     public static final String DEFAULT_BROWSER_URL = "https://support.mozilla.org/kb/set-firefox-focus-default-browser-android";
-    public static final String REPORT_SITE_ISSUE_URL = "https://webcompat.com/issues/new?url=";
+    public static final String REPORT_SITE_ISSUE_URL = "https://webcompat.com/issues/new?url=%s&label=browser-focus-geckoview";
 
     public static final String PRIVACY_NOTICE_URL = "https://www.mozilla.org/privacy/firefox-focus/";
     public static final String PRIVACY_NOTICE_KLAR_URL = "https://www.mozilla.org/de/privacy/firefox-klar/";


### PR DESCRIPTION
Hey @miketaylr is this label added correctly at the end of the link? We only show the report site menu item for GeckoView builds now