### PR TITLE
Issue #2854: Allow searches including a domain name

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -15,6 +15,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
+import android.webkit.URLUtil
 import android.widget.FrameLayout
 import kotlinx.android.synthetic.main.fragment_urlinput.*
 import mozilla.components.browser.domains.DomainAutoCompleteProvider
@@ -482,7 +483,9 @@ class UrlInputFragment :
 
     private fun onCommit() {
         val input = urlView.autocompleteResult.formattedText.let {
-            if (it.isEmpty()) urlView?.text.toString() else it
+            if (it.isEmpty() || !URLUtil.isValidUrl(urlView?.text.toString())) {
+                urlView?.text.toString()
+            } else it
         }
 
         if (!input.trim { it <= ' ' }.isEmpty()) {


### PR DESCRIPTION
Closes #2854 
As we don't want to go to a domain when the query contains its address and other words, it should be sufficient if we just check if the query is a URL
