### PR TITLE
Update issue template: use Android/Focus naming

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -18,7 +18,7 @@
 
 ### Device information
 
-* Fire TV device: ?
-* Firefox version: ?
+* Android device: ?
+* Focus version: ?
 
 -->


### PR DESCRIPTION
It was using Fire TV naming.