### PR TITLE
Fixes #2904 - Coverage builds submit telemetry

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
+++ b/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
@@ -16,16 +16,16 @@ public final class AppConstants {
 
     private AppConstants() {}
 
-    public static boolean isDevBuild() {
-        return BUILD_TYPE_DEBUG.equals(BuildConfig.BUILD_TYPE);
-    }
-
     public static boolean isKlarBuild() {
         return PRODUCT_FLAVOR_KLAR.equals(BuildConfig.FLAVOR_product);
     }
 
     public static boolean isReleaseBuild() {
         return BUILD_TYPE_RELEASE.equals(BuildConfig.BUILD_TYPE);
+    }
+
+    public static boolean isDevBuild() {
+        return !isReleaseBuild();
     }
 
     public static boolean isGeckoBuild() {


### PR DESCRIPTION
This patch changes the logic of `isDevBuild` from explicitely comparing the build type to `debug` to simply assuming that it is a dev build if it is not a release build. This will then cover all types, including `coverage`.