### PR TITLE
Fixes issue #2930 - When First Run is dismissed, URL bar appears in purple typing state

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -6,12 +6,10 @@ package org.mozilla.focus.fragment
 
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
-import android.content.Context
 import android.graphics.Typeface
 import android.graphics.drawable.TransitionDrawable
 import android.os.Bundle
 import android.support.v4.content.ContextCompat
-import android.support.v4.content.res.ResourcesCompat
 import android.text.SpannableString
 import android.text.TextUtils
 import android.text.style.StyleSpan

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -6,9 +6,12 @@ package org.mozilla.focus.fragment
 
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
+import android.content.Context
 import android.graphics.Typeface
 import android.graphics.drawable.TransitionDrawable
 import android.os.Bundle
+import android.support.v4.content.ContextCompat
+import android.support.v4.content.res.ResourcesCompat
 import android.text.SpannableString
 import android.text.TextUtils
 import android.text.style.StyleSpan
@@ -246,6 +249,8 @@ class UrlInputFragment :
             if (!Settings.getInstance(it).shouldShowFirstrun()) {
                 // Only show keyboard if we are not displaying the first run tour on top.
                 showKeyboard()
+
+                toolbarBackgroundView.setBackground(ContextCompat.getDrawable(context!!, R.drawable.animated_background_url))
             }
         }
     }


### PR DESCRIPTION
**Earlier:**

After dismissing First Run, URL Bar appeared in purple typing state.

**Now:**

After dismissing First Run, URL Bar will appear in normal active (pink) state, as expected.