### PR TITLE
It Fixes "ADD" button is spelled A-D-D When Accessibility mode is ON.

### DIFF
--- a/app/src/main/res/layout/add_to_homescreen.xml
+++ b/app/src/main/res/layout/add_to_homescreen.xml
@@ -72,6 +72,7 @@
             android:textAllCaps="true"
             android:textColor="@color/dialogAccent"
             android:textSize="14sp"
+            android:contentDescription="@string/dialog_addtohomescreen_action_add"
             android:fontFamily="@string/font_roboto_medium" />
     </LinearLayout>
 


### PR DESCRIPTION
It Fixes "ADD" button is spelled A-D-D When Accessibility mode is ON.

Android device:
Moto C Plus (Android 7.0)

Closes #2945  