### PR TITLE
Apply IME flag NoPersonalizedLearning to find in page input.

### DIFF
--- a/app/src/main/res/layout/find_in_page.xml
+++ b/app/src/main/res/layout/find_in_page.xml
@@ -22,6 +22,7 @@
         android:gravity="center_vertical"
         android:hint="@string/find_in_page_input"
         android:inputType="textNoSuggestions"
+        android:imeOptions="flagNoPersonalizedLearning"
         android:lines="1"
         android:maxLines="1"
         android:textCursorDrawable="@drawable/cursor"


### PR DESCRIPTION
Fixes #2995.

Tested locally.

(As an aside, the build instructions in the README seem out of date, got <samp>Task 'assembleFocusWebviewArmDebug' not found in project ':app'.</samp> Changing to `app:assembleFocusArmDebug` seemed to work.)