### PR TITLE
Closes #2784: Accessibility - Erase Button

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -43,6 +43,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityManager;
 import android.view.inputmethod.EditorInfo;
 import android.webkit.CookieManager;
 import android.webkit.URLUtil;
@@ -925,6 +927,21 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
 
     public void erase() {
         final IWebView webView = getWebView();
+        final Context context = getContext();
+
+        // Notify the user their session has been erased if Talk Back is enabled:
+        if (context != null) {
+            final AccessibilityManager manager = (AccessibilityManager) context
+                    .getSystemService(Context.ACCESSIBILITY_SERVICE);
+            if (manager != null && manager.isEnabled()) {
+                AccessibilityEvent event = AccessibilityEvent.obtain();
+                event.setEventType(AccessibilityEvent.TYPE_ANNOUNCEMENT);
+                event.setClassName(getClass().getName());
+                event.setPackageName(getContext().getPackageName());
+                event.getText().add(getString(R.string.feedback_erase));
+            }
+        }
+
         if (webView != null) {
             webView.cleanup();
         }

--- a/app/src/main/java/org/mozilla/focus/widget/FloatingEraseButton.java
+++ b/app/src/main/java/org/mozilla/focus/widget/FloatingEraseButton.java
@@ -9,6 +9,7 @@ import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.FloatingActionButton;
 import android.util.AttributeSet;
 import android.view.View;
+import android.view.accessibility.AccessibilityManager;
 import android.view.animation.AnimationUtils;
 
 import org.mozilla.focus.R;
@@ -31,11 +32,17 @@ public class FloatingEraseButton extends FloatingActionButton {
     public void updateSessionsCount(int tabCount) {
         final CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) getLayoutParams();
         final FloatingActionButtonBehavior behavior = (FloatingActionButtonBehavior) params.getBehavior();
+        AccessibilityManager accessibilityManager = (AccessibilityManager) getContext().getSystemService(Context.ACCESSIBILITY_SERVICE);
 
         keepHidden = tabCount != 1;
 
         if (behavior != null) {
-            behavior.setEnabled(!keepHidden);
+            if (accessibilityManager != null && accessibilityManager.isTouchExplorationEnabled()) {
+                // Always display erase button if Talk Back is enabled
+                behavior.setEnabled(false);
+            } else {
+                behavior.setEnabled(!keepHidden);
+            }
         }
 
         if (keepHidden) {


### PR DESCRIPTION
* Erase button now visible at all times if Talk Back is enabled (scrolling doesn't hide it)
* "Your browsing history has been erased" now spoken after the erase button is pressed.