### PR TITLE
Closes #3049: Biometric crashes & bug fixes

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -10,6 +10,7 @@ import android.arch.lifecycle.ViewModelProviders;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
@@ -20,6 +21,7 @@ import android.view.WindowManager;
 
 import org.mozilla.focus.R;
 import org.mozilla.focus.architecture.NonNullObserver;
+import org.mozilla.focus.biometrics.Biometrics;
 import org.mozilla.focus.fragment.BrowserFragment;
 import org.mozilla.focus.fragment.FirstrunFragment;
 import org.mozilla.focus.fragment.UrlInputFragment;
@@ -148,6 +150,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity {
         super.onResume();
 
         TelemetryWrapper.startSession();
+        checkBiometricStillValid();
 
         if (Settings.getInstance(this).shouldUseSecureMode()) {
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
@@ -308,5 +311,15 @@ public class MainActivity extends LocaleAwareAppCompatActivity {
         }
 
         super.onBackPressed();
+    }
+
+    // Handles the edge case of a user removing all enrolled prints while auth was enabled
+    private void checkBiometricStillValid() {
+        // Disable biometrics if the user is no longer eligible due to un-enrolling fingerprints:
+        if (!Biometrics.INSTANCE.hasFingerprintHardware(this)) {
+            PreferenceManager.getDefaultSharedPreferences(this)
+                    .edit().putBoolean(getString(R.string.pref_key_biometric),
+                    false).apply();
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationDialogFragment.kt
@@ -16,10 +16,10 @@ import android.support.v7.app.AppCompatDialogFragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import kotlinx.android.synthetic.main.biometric_prompt_dialog_content.new_session_button
-import kotlinx.android.synthetic.main.biometric_prompt_dialog_content.biometric_error_text
-import kotlinx.android.synthetic.main.biometric_prompt_dialog_content.fingerprint_icon
-import kotlinx.android.synthetic.main.biometric_prompt_dialog_content.description
+import kotlinx.android.synthetic.main.biometric_prompt_dialog_content.view.fingerprintIcon
+import kotlinx.android.synthetic.main.biometric_prompt_dialog_content.view.newSessionButton
+import kotlinx.android.synthetic.main.biometric_prompt_dialog_content.view.description
+import kotlinx.android.synthetic.main.biometric_prompt_dialog_content.biometricErrorText
 import org.mozilla.focus.R
 
 @RequiresApi(api = Build.VERSION_CODES.M)
@@ -60,15 +60,15 @@ class BiometricAuthenticationDialogFragment : AppCompatDialogFragment(), Lifecyc
             )
         )
 
-        description.setText(R.string.biometric_auth_description)
+        v.description.setText(R.string.biometric_auth_description)
 
-        new_session_button.setText(R.string.biometric_auth_new_session)
-        new_session_button.setOnClickListener {
+        v.newSessionButton.setText(R.string.biometric_auth_new_session)
+        v.newSessionButton.setOnClickListener {
             newSessionButtonClicked()
             dismiss()
         }
 
-        fingerprint_icon.setImageResource(R.drawable.ic_fingerprint)
+        v.fingerprintIcon.setImageResource(R.drawable.ic_fingerprint)
         return v
     }
 
@@ -90,10 +90,10 @@ class BiometricAuthenticationDialogFragment : AppCompatDialogFragment(), Lifecyc
 
     fun displayError(errorText: String) {
         // Display the error text
-        biometric_error_text.text = errorText
-        biometric_error_text.setTextColor(
+        biometricErrorText.text = errorText
+        biometricErrorText.setTextColor(
             ContextCompat.getColor(
-                biometric_error_text.context,
+                biometricErrorText.context,
                 R.color.photonRed50
             )
         )
@@ -112,7 +112,7 @@ class BiometricAuthenticationDialogFragment : AppCompatDialogFragment(), Lifecyc
     }
 
     private fun resetErrorText() {
-        biometric_error_text.text = ""
+        biometricErrorText.text = ""
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationHandler.kt
+++ b/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationHandler.kt
@@ -81,7 +81,6 @@ class BiometricAuthenticationHandler(private val context: Context) :
 
     // Create the prompt and begin listening
     private fun startListening(cryptoObject: FingerprintManagerCompat.CryptoObject) {
-        if (!Biometrics.hasFingerprintHardware(context)) return
         if (biometricFragment == null) {
             biometricFragment = BiometricAuthenticationDialogFragment()
         }
@@ -127,7 +126,7 @@ class BiometricAuthenticationHandler(private val context: Context) :
 
     @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
     fun onPause() {
-        needsAuth = true
+        needsAuth = true && Biometrics.hasFingerprintHardware(context)
         stopListening()
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -67,6 +67,7 @@ import org.mozilla.focus.architecture.NonNullObserver;
 import org.mozilla.focus.autocomplete.AutocompleteQuickAddPopup;
 import org.mozilla.focus.biometrics.BiometricAuthenticationDialogFragment;
 import org.mozilla.focus.biometrics.BiometricAuthenticationHandler;
+import org.mozilla.focus.biometrics.Biometrics;
 import org.mozilla.focus.broadcastreceiver.DownloadBroadcastReceiver;
 import org.mozilla.focus.customtabs.CustomTabConfig;
 import org.mozilla.focus.findinpage.FindInPageCoordinator;
@@ -197,7 +198,8 @@ public class BrowserFragment extends WebFragment implements LifecycleObserver, V
         super.onCreate(savedInstanceState);
         ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
 
-        if (biometricController == null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (biometricController == null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                Biometrics.INSTANCE.hasFingerprintHardware(getContext())) {
             biometricController = new BiometricAuthenticationHandler(getContext());
         }
 
@@ -248,7 +250,9 @@ public class BrowserFragment extends WebFragment implements LifecycleObserver, V
     public void onPause() {
         super.onPause();
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Settings.getInstance(getContext()).shouldUseBiometrics()) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                Settings.getInstance(getContext()).shouldUseBiometrics() &&
+                Biometrics.INSTANCE.hasFingerprintHardware(getContext())) {
             biometricController.stopListening();
             getView().setAlpha(0);
         }
@@ -894,7 +898,9 @@ public class BrowserFragment extends WebFragment implements LifecycleObserver, V
             }
         });
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Settings.getInstance(getContext()).shouldUseBiometrics()) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                Settings.getInstance(getContext()).shouldUseBiometrics() &&
+                Biometrics.INSTANCE.hasFingerprintHardware(getContext())) {
             displayBiometricPromptIfNeeded();
         } else {
             getView().setAlpha(1);

--- a/app/src/main/java/org/mozilla/focus/settings/PrivacySecuritySettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/PrivacySecuritySettingsFragment.kt
@@ -7,8 +7,12 @@ package org.mozilla.focus.settings
 import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
+import android.preference.Preference
+import android.preference.PreferenceCategory
 import android.preference.SwitchPreference
 import org.mozilla.focus.R
+import org.mozilla.focus.R.string.pref_key_biometric
+import org.mozilla.focus.R.string.preference_category_switching_apps
 import org.mozilla.focus.biometrics.Biometrics
 import org.mozilla.focus.telemetry.TelemetryWrapper
 
@@ -21,7 +25,11 @@ class PrivacySecuritySettingsFragment : BaseSettingsFragment(),
 
         // Remove the biometric toggle if the software or hardware do not support it
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M || !Biometrics.hasFingerprintHardware(context)) {
-            preferenceScreen.removePreference(findPreference(getString(R.string.pref_key_biometric)))
+            val biometricPreference = findPreference(getString(pref_key_biometric)) as Preference
+            val switchingAppsCategory = findPreference(getString(
+                preference_category_switching_apps)) as PreferenceCategory
+
+            switchingAppsCategory.removePreference(biometricPreference)
         }
 
         updateStealthToggleAvailability()

--- a/app/src/main/res/layout/biometric_prompt_dialog_content.xml
+++ b/app/src/main/res/layout/biometric_prompt_dialog_content.xml
@@ -26,7 +26,7 @@
         android:gravity="center">
 
         <ImageView
-            android:id="@+id/fingerprint_icon"
+            android:id="@+id/fingerprintIcon"
             android:contentDescription="@string/biometric_auth_image_description"
             android:layout_width="@dimen/fingerprint_icon_size"
             android:layout_height="@dimen/fingerprint_icon_size" />
@@ -34,7 +34,7 @@
     </LinearLayout>
 
     <TextView
-        android:id="@+id/biometric_error_text"
+        android:id="@+id/biometricErrorText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
@@ -45,7 +45,7 @@
         tools:text=""/>
 
     <Button
-        android:id="@+id/new_session_button"
+        android:id="@+id/newSessionButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"

--- a/app/src/main/res/xml/privacy_security_settings.xml
+++ b/app/src/main/res/xml/privacy_security_settings.xml
@@ -67,7 +67,8 @@
             android:title="@string/preference_privacy_category_cookies" />
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/preference_category_switching_apps">
+    <PreferenceCategory android:title="@string/preference_category_switching_apps"
+        android:key="@string/preference_category_switching_apps">
         <SwitchPreference
             android:defaultValue="false"
             android:key="@string/pref_key_biometric"


### PR DESCRIPTION
This PR fixes a crash caused by an edge case of un-enrolling all fingerprints with fingerprint hardware available.

It also fixes a few other bugs such as the settings option not disappearing when fingerprint authentication is not available.