### PR TITLE
 SessionManager: fix testShareIntentWithTextViaNewIntent test 

### DIFF
--- a/app/src/test/java/org/mozilla/focus/session/SessionManagerTest.java
+++ b/app/src/test/java/org/mozilla/focus/session/SessionManagerTest.java
@@ -176,6 +176,7 @@ public class SessionManagerTest {
         assertTrue(sessionManager.hasSession());
     }
 
+    @Test
     public void testShareIntentWithTextViaNewIntent() {
         final SessionManager sessionManager = SessionManager.getInstance();
 

--- a/app/src/test/java/org/mozilla/focus/session/SessionManagerTest.java
+++ b/app/src/test/java/org/mozilla/focus/session/SessionManagerTest.java
@@ -188,10 +188,11 @@ public class SessionManagerTest {
         assertNotNull(sessions);
         assertEquals(1, sessions.size());
 
+        final String SEARCH_QUERY = "https://www.google.com/search?q=Hello%20World%20Focus&ie=utf-8&oe=utf-8&client=firefox-b";
         final Session session = sessions.get(0);
         assertTrue(session.isSearch());
         assertEquals("Hello World Focus", session.getSearchTerms());
-        assertEquals(TEST_URL, session.getUrl().getValue());
+        assertEquals(SEARCH_QUERY, session.getUrl().getValue());
         assertFalse(session.isCustomTab());
         assertNull(session.getCustomTabConfig());
 


### PR DESCRIPTION
When searching using "Hello World Focus", the SessionMager will never return the github link of focus-android. Hence replace it with the actual Google query since the default search engine is Google.

Also annotate testShareIntentWithTextViaNewIntent with @test 
Closes #2078 
