### PR TITLE
Re-adds task to commit to the google play store

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -138,6 +138,7 @@ tasks:
           && python tools/taskcluster/release.py \
             --tag {{ event.version }} \
             --track alpha \
+            --commit \
             --output /opt/focus-android/app/build/outputs/apk \
             --apk focusWebviewUniversal/release/app-focus-webview-universal-release-unsigned.apk \
             --apk klarWebviewUniversal/release/app-klar-webview-universal-release-unsigned.apk


### PR DESCRIPTION
We pulled this out of the last RC to make sure the build had the correct versionCode before pushing to the play store. Just re-adding it 👍 