### PR TITLE
Fixes #3081: Multiple request desktop site buttons

### DIFF
--- a/app/src/main/java/org/mozilla/focus/menu/browser/BrowserMenuAdapter.kt
+++ b/app/src/main/java/org/mozilla/focus/menu/browser/BrowserMenuAdapter.kt
@@ -143,7 +143,6 @@ class BrowserMenuAdapter(
         }
 
         if (AppConstants.isGeckoBuild) {
-            items.add(MenuItem.RequestDesktopCheck)
             // "Report Site Issue" is available for builds using GeckoView only
             items.add(
                 MenuItem.Default(


### PR DESCRIPTION
Browser menu will no longer display two request desktop sites when running GeckoView.