### PR TITLE
Fixes #3069: Tracking protection re-enable fails

### DIFF
--- a/app/src/main/java/org/mozilla/focus/web/ClassicWebViewProvider.java
+++ b/app/src/main/java/org/mozilla/focus/web/ClassicWebViewProvider.java
@@ -128,6 +128,10 @@ public class ClassicWebViewProvider implements IWebViewProvider {
 
     @Override
     public void applyAppSettings(@NotNull Context context, @NotNull WebSettings webSettings, @NotNull SystemWebView systemWebView) {
+
+        // Clear the cache so trackers previously loaded are removed
+        systemWebView.clearCache(true);
+
         // We could consider calling setLoadsImagesAutomatically() here too (This will block images not loaded over the network too)
         webSettings.setBlockNetworkImage(Settings.getInstance(context).shouldBlockImages());
         webSettings.setJavaScriptEnabled(!Settings.getInstance(context).shouldBlockJavaScript());


### PR DESCRIPTION
Re-enabling tracking protection from the menu item now properly blocks all previously cached trackers.