### PR TITLE
Fixes #3046: Frozen URL bar

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -240,6 +240,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity {
 
         transaction
                 .replace(R.id.container, UrlInputFragment.createWithoutSession(), UrlInputFragment.FRAGMENT_TAG)
+                .addToBackStack("browserFragment")
                 .commit();
     }
 
@@ -294,8 +295,19 @@ public class MainActivity extends LocaleAwareAppCompatActivity {
 
         final UrlInputFragment urlInputFragment = (UrlInputFragment) fragmentManager.findFragmentByTag(UrlInputFragment.FRAGMENT_TAG);
         if (urlInputFragment != null &&
-                urlInputFragment.isVisible() &&
-                urlInputFragment.onBackPressed()) {
+                urlInputFragment.isVisible()) {
+
+            if (!urlInputFragment.onBackPressed()) {
+                /* URL input fragment failed to handle the back press. This means the user has a
+                previous browsing session on the stack that we don't want to display, so go pop
+                the stack, then go home */
+
+                Intent homeIntent = new Intent(Intent.ACTION_MAIN);
+                homeIntent.addCategory(Intent.CATEGORY_HOME);
+                homeIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivity(homeIntent);
+            }
+
             // The URL input fragment has handled the back press. It does its own animations so
             // we do not try to remove it from outside.
             return;


### PR DESCRIPTION
I am unable to produce the frozen URL bug after this patch. However, I want to confirm there are no security concerns with keeping the previous fragment on the backStack. There may be a cleaner solution that exists, but after several hours of working on it, this was the only one I could figure out. If this solution is insufficient perhaps someone else should try a crack at it, as I'm unsure what else to try.