### PR TITLE
For #3075 - Adds telemetry for search suggestions

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -170,7 +170,8 @@ class UrlInputFragment :
                 .commit()
 
         searchSuggestionsViewModel.selectedSearchSuggestion.observe(this, Observer {
-            onSearch(it)
+            val isSuggestion = searchSuggestionsViewModel.searchQuery.value != it
+            onSearch(it, isSuggestion)
         })
     }
 
@@ -612,13 +613,13 @@ class UrlInputFragment :
         return Triple(isUrl, url, searchTerms)
     }
 
-    private fun onSearch(query: String?) {
+    private fun onSearch(query: String?, isSuggestion: Boolean = false) {
         val searchTerms = query ?: urlView?.originalText
         val searchUrl = UrlUtils.createSearchUrl(context, searchTerms)
 
         openUrl(searchUrl, searchTerms)
 
-        TelemetryWrapper.searchSelectEvent()
+        TelemetryWrapper.searchSelectEvent(isSuggestion)
     }
 
     private fun openUrl(url: String, searchTerms: String?) {

--- a/app/src/main/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsPreferences.kt
+++ b/app/src/main/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsPreferences.kt
@@ -9,6 +9,7 @@ import android.preference.PreferenceManager
 import org.mozilla.focus.R
 import mozilla.components.browser.search.SearchEngine
 import org.mozilla.focus.Components
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.Settings
 
 class SearchSuggestionsPreferences(private val context: Context) {
@@ -29,6 +30,8 @@ class SearchSuggestionsPreferences(private val context: Context) {
                 .putBoolean(TOGGLED_SUGGESTIONS_PREF, true)
                 .putBoolean(context.resources.getString(R.string.pref_key_show_search_suggestions), true)
                 .apply()
+
+        TelemetryWrapper.respondToSearchSuggestionPrompt(true)
     }
 
     fun disableSearchSuggestions() {
@@ -36,6 +39,8 @@ class SearchSuggestionsPreferences(private val context: Context) {
                 .putBoolean(TOGGLED_SUGGESTIONS_PREF, true)
                 .putBoolean(context.resources.getString(R.string.pref_key_show_search_suggestions), false)
                 .apply()
+
+        TelemetryWrapper.respondToSearchSuggestionPrompt(false)
     }
 
     fun dismissNoSuggestionsMessage() {

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -130,6 +130,7 @@ object TelemetryWrapper {
         val REMOVE_SEARCH_ENGINES = "remove_search_engines"
         val GECKO_ENGINE = "gecko_engine"
         val TIP = "tip"
+        val SEARCH_SUGGESTION_PROMPT = "search_suggestion_prompt"
     }
 
     private object Value {
@@ -178,6 +179,7 @@ object TelemetryWrapper {
         val SOURCE = "source"
         val SUCCESS = "success"
         val ERROR_CODE = "error_code"
+        val SEARCH_SUGGESTION = "search_suggestion"
     }
 
     enum class BrowserContextMenuValue {
@@ -250,7 +252,8 @@ object TelemetryWrapper {
                             resources.getString(R.string.pref_key_autocomplete_preinstalled),
                             resources.getString(R.string.pref_key_autocomplete_custom),
                             resources.getString(R.string.pref_key_remote_debugging),
-                            resources.getString(R.string.pref_key_homescreen_tips))
+                            resources.getString(R.string.pref_key_homescreen_tips),
+                            resources.getString(R.string.pref_key_show_search_suggestions))
                     .setSettingsProvider(TelemetrySettingsProvider(context))
                     .setCollectionEnabled(telemetryEnabled)
                     .setUploadEnabled(telemetryEnabled)
@@ -452,10 +455,13 @@ object TelemetryWrapper {
     }
 
     @JvmStatic
-    fun searchSelectEvent() {
+    fun searchSelectEvent(isSearchSuggestion: Boolean) {
         val telemetry = TelemetryHolder.get()
 
-        TelemetryEvent.create(Category.ACTION, Method.TYPE_SELECT_QUERY, Object.SEARCH_BAR).queue()
+        TelemetryEvent
+                .create(Category.ACTION, Method.TYPE_SELECT_QUERY, Object.SEARCH_BAR)
+                .extra(Extra.SEARCH_SUGGESTION, "$isSearchSuggestion")
+                .queue()
 
         val searchEngineIdentifier = getDefaultSearchEngineIdentifierForTelemetry(telemetry.configuration.context)
 
@@ -830,6 +836,13 @@ object TelemetryWrapper {
     @JvmStatic
     fun reportSiteIssueEvent() {
         TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.MENU, Value.REPORT_ISSUE).queue()
+    }
+
+    @JvmStatic
+    fun respondToSearchSuggestionPrompt(enable: Boolean) {
+        TelemetryEvent
+                .create(Category.ACTION, Method.CLICK, Object.SEARCH_SUGGESTION_PROMPT, "$enable")
+                .queue()
     }
 
     @JvmStatic


### PR DESCRIPTION
| Event                                  | category | method                | object     | value  | extras.    |
|----------------------------------------|----------|-----------------------|------------|--------|------------|
| URL entered*                            | action   | type_url              | search_bar |        | `search_suggestion: true/false` |
| Enable Search Suggestion from prompt                            | action   | click              | search_suggestion_prompt |    true/false    |  |

* Modified existing event to include the `search_suggestion` extra.

# Request for data collection review form

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

1) **What questions will you answer with this data?**

* Are users enabling search suggestions
* Are users searching using provided search suggestions

2) **Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?**

* Having this data will allow us to better prioritize supporting suggestions on new search engines, or existing search engines that add suggestion support.

3) **What alternative methods did you consider to answer these questions? Why were they not sufficient?**

* Outside of the number of user reviews asking for this feature, we don't know the extent to how much users will use search suggestions. Telemetry seems like the best option for this.

4) **Can current instrumentation answer these questions?**

* Without new telemetry there will be no conclusive evidence to answer the questions

5) **List all proposed measurements and indicate the category of data collection for each measurement, using the Firefox [data c](https://wiki.mozilla.org/Firefox/Data_Collection)[ollection ](https://wiki.mozilla.org/Firefox/Data_Collection)[categories](https://wiki.mozilla.org/Firefox/Data_Collection) on the found on the Mozilla wiki.**

* All data is Category 2.

6) **How long will this data be collected?**

* @mmccorks will permanently monitor this data.

7) **What populations will you measure?**

* All release, beta, and nightly users with telemetry enabled.

8) **Please provide a general description of how you will analyze this data.**

* Re-dash queries + dashboards

9) **Where do you intend to share the results of your analysis?**

* Only on re-dash and with mobile teams.