### PR TITLE
fix "Add to home screen" force close on fresh installation

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -696,6 +696,6 @@ class UrlInputFragment :
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        if (key == getString(pref_key_homescreen_tips)) { updateTipsLabel() }
+        if (key == context?.getString(pref_key_homescreen_tips)) { updateTipsLabel() }
     }
 }


### PR DESCRIPTION
When trying to invoke getString() inside onSharedPreferenceChanged(), the Fragment is not attached to a context as shown by the error log
    java.lang.IllegalStateException: Fragment UrlInputFragment{2bbadca} not attached to a context.

using conext explicitly to invoke getString() resolves this