### PR TITLE
Fixes #3118 - Uses dp to size search engine icon in search suggestions

### DIFF
--- a/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsFragment.kt
@@ -91,7 +91,10 @@ class SearchSuggestionsFragment : Fragment() {
                 BitmapDrawable(resources, it)
             } ?: resources.getDrawable(R.drawable.ic_search, null)
 
-            searchView.setCompoundDrawablesWithIntrinsicBounds(icon, null, null, null)
+            val size = resources.getDimension(R.dimen.preference_icon_drawable_size).toInt()
+            icon.setBounds(0, 0, size, size)
+
+            searchView.setCompoundDrawables(icon, null, null, null)
         })
     }
 


### PR DESCRIPTION
<img width="599" alt="image" src="https://user-images.githubusercontent.com/1250545/44058017-a71bcd08-9f01-11e8-8efd-718d8113594c.png">
