### PR TITLE
Fix multi-architecture versionCode numbering

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -242,19 +242,16 @@ android.applicationVariants.all { variant ->
         // The Google Play Store does not allow multiple APKs for the same app that all have the
         // same version code. Therefore we need to have different version codes for our ARM and x86
         // builds.
-        // Our generated version code has a length of 8 (See tools/gradle/versionCode.gradle).
-        // We will prefix our ARM builds with 1 and our x86 builds with 2. Our x86 builds need a
-        // higher version code to avoid installing ARM builds on an x86 device with ARM
-        // compatibility mode.
-        def multiplier = 100000000
+
+        // Our generated version code now has a length of 9 (See tools/gradle/versionCode.gradle).
+        // Our x86 builds need a higher version code to avoid installing ARM builds on an x86 device
+        // with ARM compatibility mode.
 
         if (variant.flavorName.contains("X86")) {
-            versionCode = versionCode + (3 * multiplier)
+            versionCode = versionCode + 2
         } else if (variant.flavorName.contains("Aarch64")) {
-            versionCode = versionCode + (2 * multiplier)
-        } else if (variant.flavorName.contains("Arm")) {
-            versionCode = versionCode + (1 * multiplier)
-        }
+            versionCode = versionCode + 1
+        } else // variant.flavorName.contains("Arm")) use generated version code
 
         variant.outputs.all { output ->
             setVersionCodeOverride(versionCode)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -251,7 +251,7 @@ android.applicationVariants.all { variant ->
             versionCode = versionCode + 2
         } else if (variant.flavorName.contains("Aarch64")) {
             versionCode = versionCode + 1
-        } else // variant.flavorName.contains("Arm")) use generated version code
+        }// else variant.flavorName.contains("Arm")) use generated version code
 
         variant.outputs.all { output ->
             setVersionCodeOverride(versionCode)

--- a/tools/gradle/versionCode.gradle
+++ b/tools/gradle/versionCode.gradle
@@ -22,6 +22,7 @@ import java.text.SimpleDateFormat
 // system.
 
 ext {
+    def base = "3"
     def today = new Date()
 
     // We use the current year (double digit) and substract 16. We first released Focus in
@@ -37,7 +38,7 @@ ext {
     // minute.
     def time = new SimpleDateFormat("HHmm").format(today)
 
-    generatedVersionCode = (year + day + time) as int
+    generatedVersionCode = (base + year + day + time) as int
 
     println("Generated versionCode: $generatedVersionCode")
     println()


### PR DESCRIPTION
GeckoView builds appended a prefix for the versionCode of 1, 2, or 3. This meant ARM and ARM64 builds could not be deployed to Google Play as the build number would decrease. This fix should start version numbering with the latest '3' prefix and numbers that only go upwards.