### PR TITLE
Fixes #1897 Restore search engines after deleting and changing locale

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/InstalledSearchEnginesSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/InstalledSearchEnginesSettingsFragment.kt
@@ -21,6 +21,7 @@ class InstalledSearchEnginesSettingsFragment : BaseSettingsFragment() {
 
     companion object {
         fun newInstance() = InstalledSearchEnginesSettingsFragment()
+        var languageChanged: Boolean = false
     }
 
     override fun onResume() {
@@ -30,7 +31,10 @@ class InstalledSearchEnginesSettingsFragment : BaseSettingsFragment() {
             updateIcon(R.drawable.ic_back)
         }
 
-        refetchSearchEngines()
+        if (languageChanged)
+            restoreSearchEngines()
+        else
+            refetchSearchEngines()
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -53,13 +57,17 @@ class InstalledSearchEnginesSettingsFragment : BaseSettingsFragment() {
                 true
             }
             R.id.menu_restore_default_engines -> {
-                CustomSearchEngineStore.restoreDefaultSearchEngines(activity!!)
-                refetchSearchEngines()
-                TelemetryWrapper.menuRestoreEnginesEvent()
+                restoreSearchEngines()
                 true
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    private fun restoreSearchEngines() {
+        CustomSearchEngineStore.restoreDefaultSearchEngines(activity!!)
+        refetchSearchEngines()
+        TelemetryWrapper.menuRestoreEnginesEvent()
     }
 
     override fun onPreferenceTreeClick(preference: Preference): Boolean {

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.java
@@ -87,6 +87,9 @@ public class SettingsFragment extends BaseSettingsFragment implements SharedPref
             // fragment gets replaced at the end of this method anyways.
             localeUpdated = true;
 
+            //Set langChanged from InstalledSearchEngines to true
+            InstalledSearchEnginesSettingsFragment.Companion.setLanguageChanged(true);
+
             final ListPreference languagePreference = (ListPreference) findPreference(getString(R.string.pref_key_locale));
             final String value = languagePreference.getValue();
 


### PR DESCRIPTION
-Added a boolean languageChanged to InstalledSearchEnginesSettingsFragment that is modified on SettingsFragment when locale is changed
-When languageChanged is true, a restoreDefaultSearchEngines is triggered