### PR TITLE
add tip screenshot for 7.0 

### DIFF
--- a/Screengrabfile
+++ b/Screengrabfile
@@ -10,21 +10,20 @@
 app_package_name 'org.mozilla.focus.debug'
 use_tests_in_packages ['org.mozilla.focus.screenshots']
 
-app_apk_path 'app/build/outputs/apk/focusX86/debug/app-focus-x86-debug.apk'
-tests_apk_path 'app/build/outputs/apk/androidTest/focusX86/debug/app-focus-x86-debug-androidTest.apk'
+app_apk_path 'app/build/outputs/apk/focusArm/debug/app-focus-arm-debug.apk'
+tests_apk_path 'app/build/outputs/apk/androidTest/focusArm/debug/app-focus-arm-debug-androidTest.apk'
 
-# 67 locales
-locales ['af','am','an','anp','ar', 'ast', 'az', 'bg', 'bn-BD', 'bn-IN', 'bs','ca',
+locales ['af','am','an','anp','ar', 'ast', 'ay', 'az', 'bg', 'bn-BD', 'bn-IN', 'bs','ca',
          'cak','cs', 'cy', 'da','de', 'dsb', 'el', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX',
-         'eu','fa', 'fi','fr', 'fy-NL','ga-IE', 'gu-IN','he', 'hi-IN','hr', 'hsb', 'hu',
-         'hy-AM', 'ia','id', 'it', 'ixl', 'ja', 'ka', 'kab', 'kk', 'ko', 'kw', 'lo', 'lt',
-         'lv','meh','mix', 'ms', 'my','nb-NO', 'ne-NP', 'nl', 'nn-NO','oc', 'pai', 'pl',
-         'pt-BR', 'ro', 'ru', 'sk', 'sl', 'sq', 'sr', 'sv-SE', 'ta', 'te', 'th', 'tr','trs',
-         'tsz', 'tt', 'uk', 'ur', 'vi','wo','zam','zh-CN', 'zh-TW','en-CA']
+         'eu','fa', 'fi','fr', 'fy-NL','ga-IE', 'gl','gu-IN','he', 'hi-IN','hr', 'hsb', 'hu',
+         'hy-AM', 'ia','id', 'it', 'ixl', 'ja', 'jv', 'ka', 'kab', 'kk', 'ko', 'kw', 'lo', 'lt',
+         'meh','mix', 'mr', 'ms', 'my','nb-NO', 'ne-NP', 'nl', 'nn-NO','oc', 'pa-IN', 'pai', 'pl',
+         'ppl', 'pt-BR', 'quc', 'quy', 'ro', 'ru', 'sk', 'sl', 'sq', 'sr', 'su', 'sv-SE', 'ta', 
+         'te', 'th', 'tr','trs', 'tsz', 'tt', 'uk', 'ur', 'vi','wo','zam','zh-CN', 'zh-TW','en-CA']
 
 # Clear all previous screenshots locally. Technically not needed in automation.
 # But it's easier to debug this on a local device if there are no old screenshots
 # hanging around.
 clear_previous_screenshots true
-
+reinstall_app true
 exit_on_test_failure false

--- a/app/src/androidTest/java/org/mozilla/focus/screenshots/FirstRunScreenshots.java
+++ b/app/src/androidTest/java/org/mozilla/focus/screenshots/FirstRunScreenshots.java
@@ -4,6 +4,7 @@
 
 package org.mozilla.focus.screenshots;
 
+import android.os.SystemClock;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.test.uiautomator.UiObjectNotFoundException;
@@ -22,6 +23,10 @@ import org.mozilla.focus.utils.AppConstants;
 import tools.fastlane.screengrab.Screengrab;
 import tools.fastlane.screengrab.locale.LocaleTestRule;
 
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static junit.framework.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
@@ -42,13 +47,13 @@ public class FirstRunScreenshots extends ScreenshotTest {
     public static final LocaleTestRule localeTestRule = new LocaleTestRule();
 
     @Test
-    public void takeScreenshotsOfFirstrun() throws UiObjectNotFoundException {
-        Screengrab.screenshot("Ignore_FirstRun");
-        assertTrue(device.findObject(new UiSelector()
-                .text(getString(R.string.firstrun_defaultbrowser_title))
-                .enabled(true)
-        ).waitForExists(waitingTime));
+    public void takeScreenshotsOfFirstrun() throws UiObjectNotFoundException, InterruptedException {
+        onView(withText(R.string.firstrun_defaultbrowser_title))
+                .check(matches(isDisplayed()));
+
         device.waitForIdle();
+        SystemClock.sleep(5000);
+
         Screengrab.screenshot("Onboarding_1_View");
         TestHelper.nextBtn.click();
 

--- a/app/src/androidTest/java/org/mozilla/focus/screenshots/HomeScreenScreenshots.java
+++ b/app/src/androidTest/java/org/mozilla/focus/screenshots/HomeScreenScreenshots.java
@@ -4,6 +4,7 @@
 
 package org.mozilla.focus.screenshots;
 
+import android.os.SystemClock;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.ClassRule;
@@ -17,6 +18,8 @@ import tools.fastlane.screengrab.locale.LocaleTestRule;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.pressImeActionButton;
+import static android.support.test.espresso.action.ViewActions.replaceText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.hasFocus;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -29,13 +32,26 @@ public class HomeScreenScreenshots extends ScreenshotTest {
     @ClassRule
     public static final LocaleTestRule localeTestRule = new LocaleTestRule();
 
+    private enum TipTypes {
+        TIP_CREATETP (1),
+        TIP_CREATEHS (2),
+        TIP_CREATEDEFAULTBROWSER (3),
+        TIP_AC_URL (4),
+        TIP_NEWTAB (5),
+        TIP_REQDESKTOP (6);
+        private int value;
+
+        TipTypes(int value) {
+            this.value = value;
+        }
+    }
+
     @Test
     public void takeScreenshotOfHomeScreen() {
-        Screengrab.screenshot("Ignore");
         onView(withId(R.id.urlView))
                 .check(matches(isDisplayed()))
                 .check(matches(hasFocus()));
-
+        SystemClock.sleep(5000);
         Screengrab.screenshot("Home_View");
     }
 
@@ -47,5 +63,19 @@ public class HomeScreenScreenshots extends ScreenshotTest {
                 .check(matches(isDisplayed()));
 
         Screengrab.screenshot("MainViewMenu");
+    }
+
+    @Test
+    public void takeScreenshotOfTips() {
+        for (TipTypes tip: TipTypes.values()) {
+            onView(withId(R.id.urlView))
+                    .check(matches(isDisplayed()))
+                    .check(matches(hasFocus()))
+                    .perform(click(), replaceText("l10n:tip:" + tip.value), pressImeActionButton());
+
+            onView(withId(R.id.homeViewTipsLabel))
+                    .check(matches(isDisplayed()));
+            Screengrab.screenshot("MainViewTip_" + tip.name());
+        }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/screenshots/SettingsScreenshots.java
+++ b/app/src/androidTest/java/org/mozilla/focus/screenshots/SettingsScreenshots.java
@@ -5,6 +5,7 @@
 package org.mozilla.focus.screenshots;
 
 import android.content.Context;
+import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.Espresso;
@@ -31,14 +32,12 @@ import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static android.support.test.espresso.action.ViewActions.replaceText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.isEnabled;
 import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.core.AllOf.allOf;
 import static org.mozilla.focus.fragment.FirstrunFragment.FIRSTRUN_PREF;
 import static org.mozilla.focus.helpers.EspressoHelper.assertToolbarMatchesText;
 import static org.mozilla.focus.helpers.EspressoHelper.childAtPosition;
@@ -72,6 +71,7 @@ public class SettingsScreenshots extends ScreenshotTest {
 
     @Test
     public void takeScreenShotsOfSettings() throws Exception {
+        SystemClock.sleep(5000);
         openSettings();
 
         Screengrab.screenshot("Settings_View_Top");
@@ -151,8 +151,9 @@ public class SettingsScreenshots extends ScreenshotTest {
         onView(withText(getString(R.string.preference_autocomplete_custom_summary)))
                 .perform(click());
         /* Add custom URL */
-        onView(allOf(withId(R.id.list),
-                childAtPosition(withId(android.R.id.list_container), 0))).perform(actionOnItemAtPosition(4, click()));
+        onView(childAtPosition(withId(R.id.recycler_view), 4)).perform(click());
+
+        //        onView(childAtPosition(withId(R.id.recycler_view), 0)).perform(actionOnItemAtPosition(4, click()));
 
         final String addCustomURLAction = getString(R.string.preference_autocomplete_action_add);
         onView(withText(addCustomURLAction))
@@ -166,15 +167,14 @@ public class SettingsScreenshots extends ScreenshotTest {
         Screengrab.screenshot("Autocomplete_Add_Custom_URL_Dialog");
         onView(withId(R.id.save))
                 .perform(click());
-        device.waitForIdle();
-        Screengrab.screenshot("Autocomplete_Add_Custom_URL_Error_Popup");
+       Screengrab.screenshot("Autocomplete_Add_Custom_URL_Error_Popup");
 
         onView(withId(R.id.domainView))
                 .perform(replaceText("screenshot.com"), closeSoftKeyboard());
         onView(withId(R.id.save))
                 .perform(click());
+        SystemClock.sleep(500);
         Screengrab.screenshot("Autocomplete_Add_Custom_URL_Saved_Popup");
-        device.waitForIdle();
         onView(withText(addCustomURLAction))
                 .check(matches(isDisplayed()));
 
@@ -201,13 +201,6 @@ public class SettingsScreenshots extends ScreenshotTest {
         Espresso.pressBack();
         Espresso.pressBack();
 
-        /*
-        assertTrue(TestHelper.settingsHeading.waitForExists(waitingTime));
-        UiScrollable settingsView = new UiScrollable(new UiSelector().scrollable(true));
-        settingsView.scrollToEnd(4);
-        Screengrab.screenshot("Settings_View_Bottom");
-        */
-
         // "Mozilla" submenu
         onView(withText(R.string.preference_category_mozilla))
                 .perform(click());
@@ -220,16 +213,12 @@ public class SettingsScreenshots extends ScreenshotTest {
                 .check(matches(isDisplayed()))
                 .perform(click());
 
-        onView(withId(R.id.display_url))
-                .check(matches(isDisplayed()))
-                .check(matches(withText("focus:about")));
-
+        onView(withText(R.string.menu_about))
+                .check(matches(isDisplayed()));
         Screengrab.screenshot("About_Page");
 
         // leave about page, tap menu and go to settings again
-        openSettings();
-        onView(withText(R.string.preference_category_mozilla))
-                .perform(click());
+        device.pressBack();
 
         // "Your rights" screen
         final String yourRightsLabel = getString(R.string.menu_rights);
@@ -238,21 +227,19 @@ public class SettingsScreenshots extends ScreenshotTest {
                 .check(matches(isDisplayed()))
                 .perform(click());
 
-        onView(withId(R.id.display_url))
-                .check(matches(isDisplayed()))
-                .check(matches(withText("focus:rights")));
-
+        onView(withText(R.string.your_rights))
+                .check(matches(isDisplayed()));
         Screengrab.screenshot("YourRights_Page");
-
+        device.pressBack();
+        device.pressBack();
 
         // "Privacy & Security" submenu
-        openSettings();
         onView(withText(R.string.preference_privacy_and_security_header))
                 .perform(click());
         Screengrab.screenshot("Privacy_Security_Submenu_top");
         UiScrollable settingsView = new UiScrollable(new UiSelector().scrollable(true));
         if (settingsView.exists()) {        // On tablet, this will not be found
-            settingsView.scrollToEnd(4);
+            settingsView.scrollToEnd(5);
             Screengrab.screenshot("Privacy_Security_Submenu_bottom");
         }
     }


### PR DESCRIPTION
Update l10n screenshot code to:
add the search suggestion help balloon
add the main screen tip
use sleep() instead of taking dummy screenshots (hopefully we can replace this with idlingresource definition soon)
