### PR TITLE
Fixes #3059 - Accept license for latest sdk / build tools

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -26,7 +26,7 @@ tasks:
     payload:
       maxRunTime: 7200
       deadline: "{{ '2 hours' | $fromNow }}"
-      image: 'mozillamobile/focus-android'
+      image: 'mozillamobile/focus-android:1.0'
       command:
         - /bin/bash
         - '--login'
@@ -36,7 +36,6 @@ tasks:
           && git config advice.detachedHead false
           && git checkout {{event.head.sha}}
           && echo "--" > .adjust_token
-          && tools/taskcluster/accept-license.sh
           && python tools/l10n/check_locales.py
           && ./gradlew --no-daemon clean assembleFocusX86Debug assembleKlarX86Nightly assembleRelease detektCheck ktlint lintFocusX86Debug lintKlarX86Nightly pmd checkstyle spotbugs testFocusX86DebugUnitTest testKlarX86NightlyUnitTest
       artifacts:
@@ -79,7 +78,7 @@ tasks:
     payload:
       maxRunTime: 7200
       deadline: "{{ '2 hours' | $fromNow }}"
-      image: 'mozillamobile/focus-android'
+      image: 'mozillamobile/focus-android:1.0'
       command:
         - /bin/bash
         - '--login'
@@ -127,7 +126,7 @@ tasks:
       maxRunTime: 7200
       deadline: "{{ '2 hours' | $fromNow }}"
       expires: "{{ '1 year' | $fromNow }}"
-      image: 'mozillamobile/focus-android'
+      image: 'mozillamobile/focus-android:1.0'
       command:
         - /bin/bash
         - '--login'

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN cd /opt && rm -f android-sdk.tgz
 
 ENV ANDROID_SDK_HOME /opt/android-sdk-linux
 ENV ANDROID_HOME /opt/android-sdk-linux
-ENV PATH ${PATH}:${ANDROID_SDK_HOME}/tools:${ANDROID_SDK_HOME}/platform-tools:/opt/tools:${ANDROID_SDK_HOME}/build-tools/27.0.3
+ENV PATH ${PATH}:${ANDROID_SDK_HOME}/tools:${ANDROID_SDK_HOME}/platform-tools:/opt/tools:${ANDROID_SDK_HOME}/build-tools/28.0.2
 
 # Platform tools
 RUN echo y | android update sdk --no-ui --all --filter platform-tools | grep 'package installed'
@@ -46,10 +46,12 @@ RUN echo y | android update sdk --no-ui --all --filter platform-tools | grep 'pa
 # Android 8.0 / SDK 26
 RUN echo y | android update sdk --no-ui --all --filter android-26 | grep 'package installed'
 RUN echo y | android update sdk --no-ui --all --filter android-27 | grep 'package installed'
+RUN echo y | android update sdk --no-ui --all --filter android-28 | grep 'package installed'
 
 # Build tools 26.0.1
 RUN echo y | android update sdk --no-ui --all --filter build-tools-26.0.1 | grep 'package installed'
 RUN echo y | android update sdk --no-ui --all --filter build-tools-27.0.3 | grep 'package installed'
+RUN echo y | android update sdk --no-ui --all --filter build-tools-28.0.2 | grep 'package installed'
 
 # Extras
 RUN echo y | android update sdk --no-ui --all --filter extra-android-m2repository | grep 'package installed'
@@ -91,7 +93,7 @@ RUN git clone https://github.com/mozilla-mobile/focus-android.git
 
 # Build project and run gradle tasks once to pull all dependencies
 WORKDIR /opt/focus-android
-RUN ./gradlew --no-daemon assemble testFocusWebviewDebugUnitTest lint pmd checkstyle spotbugs detektCheck ktlint
+RUN ./gradlew --no-daemon assemble testFocusX86DebugUnitTest lint pmd checkstyle spotbugs detektCheck ktlint
 
 # -- Post setup -------------------------------------------------------------------------
 

--- a/tools/taskcluster/lib/tasks.py
+++ b/tools/taskcluster/lib/tasks.py
@@ -43,7 +43,7 @@ class TaskBuilder(object):
             "payload": {
                 "features": features,
                 "maxRunTime": 7200,
-                "image": "mozillamobile/focus-android",
+                "image": "mozillamobile/focus-android:1.0",
                 "command": [
                     "/bin/bash",
                     "--login",

--- a/tools/taskcluster/schedule-master-build.py
+++ b/tools/taskcluster/schedule-master-build.py
@@ -154,7 +154,7 @@ def generate_task(name, description, command, dependencies = [], artifacts = {},
 	            "taskclusterProxy": True
 	        },
 	        "maxRunTime": 7200,
-	        "image": "mozillamobile/focus-android",
+	        "image": "mozillamobile/focus-android:1.0",
 	        "command": [
 	            "/bin/bash",
 	            "--login",

--- a/tools/taskcluster/schedule-screenshots.py
+++ b/tools/taskcluster/schedule-screenshots.py
@@ -48,7 +48,7 @@ def generate_screenshot_task(locales):
 	            "taskclusterProxy": True
 	        },
 	        "maxRunTime": 7200,
-	        "image": "mozillamobile/focus-android",
+	        "image": "mozillamobile/focus-android:1.0",
 	        "command": [
 	            "/bin/bash",
 	            "--login",


### PR DESCRIPTION
Trying a docker build failed spotbugs, but I think that may be due to a different issue?

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:spotbugs'.
> Failed to run Gradle SpotBugs Worker
   > Process 'Gradle SpotBugs Worker 2' finished with non-zero exit value 137

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 19m 38s
```