### PR TITLE
Fixes  #3263: Tip telemetry needs updated

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -167,6 +167,7 @@ object TelemetryWrapper {
         val ADD_TO_HOMESCREEN_TIP = "add_to_homescreen_tip"
         val AUTOCOMPLETE_URL_TIP = "autocomplete_url_tip"
         val OPEN_IN_NEW_TAB_TIP = "open_in_new_tab_tip"
+        val DISABLE_TIPS_TIP = "disable_tips_tip"
     }
 
     private object Extra {
@@ -849,6 +850,7 @@ object TelemetryWrapper {
             R.string.tip_disable_tracking_protection -> Value.DISABLE_TRACKING_PROTECTION_TIP
             R.string.tip_set_default_browser -> Value.DEFAULT_BROWSER_TIP
             R.string.tip_autocomplete_url -> Value.AUTOCOMPLETE_URL_TIP
+            R.string.tip_disable_tips -> Value.DISABLE_TIPS_TIP
             else -> {
                 // Unknown tip, fail silently rather than crashing.
                 return
@@ -862,11 +864,8 @@ object TelemetryWrapper {
     fun pressTipEvent(tipId: Int) {
 
         val telemetryValue = when (tipId) {
-            R.string.tip_open_in_new_tab -> Value.OPEN_IN_NEW_TAB_TIP
-            R.string.tip_add_to_homescreen -> Value.ADD_TO_HOMESCREEN_TIP
-            R.string.tip_disable_tracking_protection -> Value.DISABLE_TRACKING_PROTECTION_TIP
             R.string.tip_set_default_browser -> Value.DEFAULT_BROWSER_TIP
-            R.string.tip_autocomplete_url -> Value.AUTOCOMPLETE_URL_TIP
+            R.string.tip_disable_tips -> Value.DISABLE_TIPS_TIP
             else -> {
                 // Unknown tip, fail silently rather than crashing.
                 return

--- a/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
+++ b/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
@@ -16,8 +16,6 @@ import org.mozilla.focus.R.string.tip_open_in_new_tab
 import org.mozilla.focus.R.string.tip_request_desktop
 import org.mozilla.focus.R.string.tip_set_default_browser
 import org.mozilla.focus.locale.LocaleAwareAppCompatActivity
-import org.mozilla.focus.session.SessionManager
-import org.mozilla.focus.session.Source
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.Settings
 import org.mozilla.focus.utils.SupportUtils
@@ -87,19 +85,12 @@ class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val d
         fun createOpenInNewTabTip(context: Context): Tip {
             val id = tip_open_in_new_tab
             val name = context.resources.getString(id)
-            val newTabURL =
-                    "https://support.mozilla.org/en-US/kb/open-new-tab-firefox-focus-android"
 
             val shouldDisplayOpenInNewTab = {
                 !Settings.getInstance(context).hasOpenedInNewTab()
             }
 
-            val deepLinkOpenInNewTab = {
-                SessionManager.getInstance().createSession(Source.MENU, newTabURL)
-                TelemetryWrapper.pressTipEvent(id)
-            }
-
-            return Tip(id, name, shouldDisplayOpenInNewTab, deepLinkOpenInNewTab)
+            return Tip(id, name, shouldDisplayOpenInNewTab)
         }
 
         fun createRequestDesktopTip(context: Context): Tip {


### PR DESCRIPTION
Telemetry for tips is now as follows:

**Events**

| Event                                    | category | method     | object | value  |
|------------------------------------------|----------|------------|--------|--------|
| Disable tips tip displayed | action   | show | tip | disable_tips_tip    |        |
| Disable tips tip tapped | action   | click | tip | disable_tips_tip    |        |

See #3080 for data review.