### PR TITLE
Closes #3263: Tip telemetry needs updated

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -167,6 +167,7 @@ object TelemetryWrapper {
         val ADD_TO_HOMESCREEN_TIP = "add_to_homescreen_tip"
         val AUTOCOMPLETE_URL_TIP = "autocomplete_url_tip"
         val OPEN_IN_NEW_TAB_TIP = "open_in_new_tab_tip"
+        val DISABLE_TIPS_TIP = "disable_tips_tip"
     }
 
     private object Extra {
@@ -849,6 +850,7 @@ object TelemetryWrapper {
             R.string.tip_disable_tracking_protection -> Value.DISABLE_TRACKING_PROTECTION_TIP
             R.string.tip_set_default_browser -> Value.DEFAULT_BROWSER_TIP
             R.string.tip_autocomplete_url -> Value.AUTOCOMPLETE_URL_TIP
+            R.string.tip_disable_tips -> Value.DISABLE_TIPS_TIP
             else -> {
                 // Unknown tip, fail silently rather than crashing.
                 return
@@ -864,9 +866,9 @@ object TelemetryWrapper {
         val telemetryValue = when (tipId) {
             R.string.tip_open_in_new_tab -> Value.OPEN_IN_NEW_TAB_TIP
             R.string.tip_add_to_homescreen -> Value.ADD_TO_HOMESCREEN_TIP
-            R.string.tip_disable_tracking_protection -> Value.DISABLE_TRACKING_PROTECTION_TIP
             R.string.tip_set_default_browser -> Value.DEFAULT_BROWSER_TIP
             R.string.tip_autocomplete_url -> Value.AUTOCOMPLETE_URL_TIP
+            R.string.tip_disable_tips -> Value.DISABLE_TIPS_TIP
             else -> {
                 // Unknown tip, fail silently rather than crashing.
                 return


### PR DESCRIPTION
**Events**

| Event                                    | category | method     | object | value  |
|------------------------------------------|----------|------------|--------|--------|
| Disable tips tip displayed | action   | show | tip | disable_tips_tip    |        |
| Disable tips tip tapped | action   | click | tip | disable_tips_tip    |        |

Also removed the following event:

| Event                                    | category | method     | object | value  |
|------------------------------------------|----------|------------|--------|--------|
| Disable tracking protection tip clicked | action   | click | tip | disable_tracking_protection_tip    |        |

See #3080 for data review.