### PR TITLE
No issue: Redundant keyboard opening removed

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.java
@@ -147,7 +147,6 @@ public class FirstrunFragment extends Fragment implements View.OnClickListener {
         final UrlInputFragment inputFragment = (UrlInputFragment) fragmentManager.findFragmentByTag(UrlInputFragment.FRAGMENT_TAG);
         if (inputFragment != null) {
             fragmentManager.beginTransaction().attach(inputFragment).commit();
-            inputFragment.showKeyboard();
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -338,12 +338,7 @@ class UrlInputFragment :
     override fun onStart() {
         super.onStart()
 
-        context?.let {
-            if (!Settings.getInstance(it).shouldShowFirstrun()) {
-                // Only show keyboard if we are not displaying the first run tour on top.
-                showKeyboard()
-            }
-        }
+        showKeyboard()
     }
 
     override fun onStop() {


### PR DESCRIPTION
`UrlInputFragment.onStart()` already calls `showKeyboard()`, `FirstrunFragment.finishFirstrn()`'s call is redundant, am I missing something?
Also, I didn't create an issue, but can if you feel it necessary.

All Robolectric test run OK. Device tests: 31/42 tests failed and 1 was not run, but they don't seem relevant to this PR. Should I share the logs?