### PR TITLE
Fixes #2930: After FirstrunFragment create new UrlInputFragment

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -1339,6 +1339,7 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
         private const val REQUEST_CODE_ADD_TO_HOMESCREEN_DIALOG = 301
         private const val REQUEST_CODE_BIOMETRIC_PROMPT = 302
 
+        @JvmStatic
         fun createForSession(session: Session): BrowserFragment {
             val arguments = Bundle()
             arguments.putString(ARGUMENT_SESSION_UUID, session.uuid)


### PR DESCRIPTION
When starting `FirstrunFragment` destroy old `UrlInputFragment` and when exiting `FirstrunFragment` create new sessionless UrlInputFragment.

Fixes #2930.