### PR TITLE
Closes #3310 & Closes #3312: Tip fixes

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -216,7 +216,7 @@ class UrlInputFragment :
         // Only make the second line clickable if applicable
         val linkStartIndex =
                 if (tipText.contains("\n")) tipText.indexOf("\n") + 2
-                else tipText.length
+                else 0
 
         keyboardLinearLayout.homeViewTipsLabel.movementMethod = LinkMovementMethod()
         homeViewTipsLabel.setText(tipText, TextView.BufferType.SPANNABLE)

--- a/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
+++ b/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
@@ -23,6 +23,7 @@ import org.mozilla.focus.utils.Settings
 import org.mozilla.focus.utils.SupportUtils
 import org.mozilla.focus.utils.homeScreenTipsExperimentDescriptor
 import org.mozilla.focus.utils.isInExperiment
+import org.mozilla.focus.utils.Browsers
 import java.util.Random
 
 class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val deepLink: (() -> Unit)? = null) {
@@ -65,7 +66,7 @@ class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val d
             val name = context.resources.getString(id, appName)
 
             val shouldDisplayDefaultBrowser = {
-                !Settings.getInstance(context).isDefaultBrowser()
+                !Browsers(context, Browsers.TRADITIONAL_BROWSER_URL).isDefaultBrowser(context)
             }
 
             val deepLinkDefaultBrowser = {
@@ -197,14 +198,12 @@ object TipManager {
         }
 
         // Always show the disable tip if it's ready to be displayed
-        listOfTips
-                .firstOrNull { it.id == tip_disable_tips }
-                ?.let {
-                    if (it.shouldDisplay()) {
-                        listOfTips.remove(it)
-                        return it
-                    }
-                }
+        for (tip in listOfTips) {
+            if (tip.id == tip_disable_tips && tip.shouldDisplay()) {
+                listOfTips.remove(tip)
+                return tip
+            }
+        }
 
         var tip = listOfTips[getRandomTipIndex()]
 


### PR DESCRIPTION
* Changed spannable text to start at 0 if there is no break line (assuming the tip has a deep link) #3310
* Changed how default browser is detected (checking the actual Android settings rather than the preference as they may not always be in sync) #3312 
* Fixed disable tips tip not displaying (no issue related to this one)