### PR TITLE
Clear confusion with "focus:test" GV toggle 

### DIFF
--- a/app/src/debug/java/org/mozilla/focus/web/Config.kt
+++ b/app/src/debug/java/org/mozilla/focus/web/Config.kt
@@ -7,5 +7,5 @@ package org.mozilla.focus.web
 object Config {
     const val DEFAULT_NEW_RENDERER = false
     const val EXPERIMENT_DESCRIPTOR_GECKOVIEW_ENGINE = "use-gecko"
-    const val EXPERIMENT_DESCIPTOR_HOME_SCREEN_TIPS = "use-homescreen-tips"
+    const val EXPERIMENT_DESCRIPTOR_HOME_SCREEN_TIPS = "use-homescreen-tips"
 }

--- a/app/src/focusRelease/java/org/mozilla/focus/web/Config.kt
+++ b/app/src/focusRelease/java/org/mozilla/focus/web/Config.kt
@@ -7,5 +7,5 @@ package org.mozilla.focus.web
 object Config {
     const val DEFAULT_NEW_RENDERER = false
     const val EXPERIMENT_DESCRIPTOR_GECKOVIEW_ENGINE = "use-gecko"
-    const val EXPERIMENT_DESCIPTOR_HOME_SCREEN_TIPS = "use-homescreen-tips"
+    const val EXPERIMENT_DESCRIPTOR_HOME_SCREEN_TIPS = "use-homescreen-tips"
 }

--- a/app/src/klarRelease/java/org/mozilla/focus/web/Config.kt
+++ b/app/src/klarRelease/java/org/mozilla/focus/web/Config.kt
@@ -7,5 +7,5 @@ package org.mozilla.focus.web
 object Config {
     const val DEFAULT_NEW_RENDERER = false
     const val EXPERIMENT_DESCRIPTOR_GECKOVIEW_ENGINE = "use-gecko"
-    const val EXPERIMENT_DESCIPTOR_HOME_SCREEN_TIPS = "use-homescreen-tips"
+    const val EXPERIMENT_DESCRIPTOR_HOME_SCREEN_TIPS = "use-homescreen-tips"
 }

--- a/app/src/main/java/org/mozilla/focus/utils/Experiments.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Experiments.kt
@@ -15,7 +15,7 @@ const val EXPERIMENTS_BUCKET_NAME = "main"
 const val EXPERIMENTS_COLLECTION_NAME = "focus-experiments"
 
 val geckoEngineExperimentDescriptor = ExperimentDescriptor(Config.EXPERIMENT_DESCRIPTOR_GECKOVIEW_ENGINE)
-val homeScreenTipsExperimentDescriptor = ExperimentDescriptor(Config.EXPERIMENT_DESCIPTOR_HOME_SCREEN_TIPS)
+val homeScreenTipsExperimentDescriptor = ExperimentDescriptor(Config.EXPERIMENT_DESCRIPTOR_HOME_SCREEN_TIPS)
 
 val Context.app: FocusApplication
     get() = applicationContext as FocusApplication

--- a/app/src/nightly/java/org/mozilla/focus/web/Config.kt
+++ b/app/src/nightly/java/org/mozilla/focus/web/Config.kt
@@ -7,5 +7,5 @@ package org.mozilla.focus.web
 object Config {
     const val DEFAULT_NEW_RENDERER = true
     const val EXPERIMENT_DESCRIPTOR_GECKOVIEW_ENGINE = "use-gecko-nightly"
-    const val EXPERIMENT_DESCIPTOR_HOME_SCREEN_TIPS = "use-homescreen-tips-nightly"
+    const val EXPERIMENT_DESCRIPTOR_HOME_SCREEN_TIPS = "use-homescreen-tips-nightly"
 }


### PR DESCRIPTION
Resolves issues where the toggle value reflects the engine value on the next restart and the developer/QA is confused. It wasn't clear to users that there is a difference between the current engine and the current setting. Now the toggle will show the current engine instead. Also, fix a spelling error.