### PR TITLE
Record experiment names instead of IDs

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -24,7 +24,7 @@ import org.mozilla.focus.search.CustomSearchEngineStore
 import org.mozilla.focus.session.SessionManager
 import org.mozilla.focus.utils.AppConstants
 import org.mozilla.focus.utils.Settings
-import org.mozilla.focus.utils.activeExperimentIds
+import org.mozilla.focus.utils.activeExperimentNames
 import org.mozilla.telemetry.Telemetry
 import org.mozilla.telemetry.TelemetryHolder
 import org.mozilla.telemetry.config.TelemetryConfiguration
@@ -817,7 +817,7 @@ object TelemetryWrapper {
 
     @JvmStatic
     fun recordActiveExperiments(context: Context) {
-        TelemetryHolder.get().recordActiveExperiments(context.activeExperimentIds)
+        TelemetryHolder.get().recordActiveExperiments(context.activeExperimentNames)
     }
 
     @JvmStatic

--- a/app/src/main/java/org/mozilla/focus/utils/Experiments.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Experiments.kt
@@ -23,5 +23,5 @@ val Context.app: FocusApplication
 fun Context.isInExperiment(descriptor: ExperimentDescriptor): Boolean =
         app.fretboard.isInExperiment(this, descriptor)
 
-val Context.activeExperimentIds: List<String>
-    get() = app.fretboard.getActiveExperiments(this).map { it.id }
+val Context.activeExperimentNames: List<String>
+    get() = app.fretboard.getActiveExperiments(this).map { it.name }


### PR DESCRIPTION
As mentioned in #3327, we record Fretboard experiment IDs when it would be easier for our data folks to have experiment names.