### PR TITLE
Closes #3306 Can't switch build to using GeckoView on some devices

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.geckoview_revision = '31683bdf39d7bcacf8d9bf265fc2365024473fbe'
     ext.geckoview_version = '62.0.20180831225236' // GeckoView 62 RelBranch from 2018.08.31
     ext.spotbugs_version = '3.1.2'
-    ext.mozilla_components_version = '0.21'
+    ext.mozilla_components_version = '0.22'
 
     repositories {
         google()


### PR DESCRIPTION
This is a workaround for the race condition that makes it tricky to change rendering engines quickly. I made a PR to android-components to offer blocking calls in Fretboard so this type of race condition won't happen in future. Closes #3306.