### PR TITLE
Don't automatically open new tabs Closes #3300

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/AccessSettingsTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/AccessSettingsTest.java
@@ -21,7 +21,6 @@ import org.junit.runner.RunWith;
 import org.mozilla.focus.helpers.TestHelper;
 import org.mozilla.focus.utils.AppConstants;
 
-import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 import static org.mozilla.focus.fragment.FirstrunFragment.FIRSTRUN_PREF;
 import static org.mozilla.focus.helpers.EspressoHelper.openSettings;
@@ -68,8 +67,8 @@ public class AccessSettingsTest {
     @Test
     public void AccessSettingsTest() throws UiObjectNotFoundException {
 
-        UiObject languageHeading = TestHelper.mDevice.findObject(new UiSelector()
-                .text("Language")
+        UiObject generalHeading = TestHelper.mDevice.findObject(new UiSelector()
+                .text("General")
                 .resourceId("android:id/title"));
 
         UiObject privacyHeading = TestHelper.mDevice.findObject(new UiSelector()
@@ -80,13 +79,6 @@ public class AccessSettingsTest {
                 .text("Search")
                 .resourceId("android:id/title"));
 
-        UiObject defaultHeading = TestHelper.mDevice.findObject(new UiSelector()
-                .textContains("default browser")
-                .resourceId("android:id/title"));
-
-        UiObject defaultSwitch = TestHelper.mDevice.findObject(new UiSelector()
-                .resourceId(TestHelper.getAppName() + ":id/switch_widget"));
-
         UiObject mozHeading = TestHelper.mDevice.findObject(new UiSelector()
                 .text("Mozilla")
                 .resourceId("android:id/title"));
@@ -94,14 +86,12 @@ public class AccessSettingsTest {
         /* Go to Settings */
         TestHelper.inlineAutocompleteEditText.waitForExists(waitingTime);
         openSettings();
-        languageHeading.waitForExists(waitingTime);
+        generalHeading.waitForExists(waitingTime);
 
         /* Check the first element and other headings are present */
-        assertTrue(languageHeading.exists());
+        assertTrue(generalHeading.exists());
         assertTrue(searchHeading.exists());
         assertTrue(privacyHeading.exists());
-        assertTrue(defaultHeading.exists());
-        assertFalse(defaultSwitch.isChecked());
         assertTrue(mozHeading.exists());
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SwitchLocaleTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SwitchLocaleTest.java
@@ -111,17 +111,22 @@ public class SwitchLocaleTest {
             .enabled(true));
     private UiObject languageHeading = TestHelper.settingsMenu.getChild(new UiSelector()
             .className("android.widget.LinearLayout")
-            .instance(0));
+            .instance(4));
     private UiObject englishHeading = TestHelper.mDevice.findObject(new UiSelector()
             .className("android.widget.TextView")
             .text("Language"));
     private UiObject frenchHeading = TestHelper.mDevice.findObject(new UiSelector()
             .className("android.widget.TextView")
-            .text("Paramètres"));
+            .text("Langue"));
+    private UiObject englishGeneralHeading = TestHelper.mDevice.findObject(new UiSelector()
+            .text("General")
+            .resourceId("android:id/title"));
+    private UiObject frenchGeneralHeading = TestHelper.mDevice.findObject(new UiSelector()
+            .text("Général")
+            .resourceId("android:id/title"));
 
     @Test
     public void EnglishSystemLocaleTest() throws UiObjectNotFoundException {
-
         UiObject frenchMenuItem = TestHelper.mDevice.findObject(new UiSelector()
                 .className("android.widget.TextView")
                 .text("Français"));
@@ -136,6 +141,11 @@ public class SwitchLocaleTest {
         TestHelper.inlineAutocompleteEditText.waitForExists(waitingTime);
 
         openSettings();
+
+        // Open General Settings
+        englishGeneralHeading.waitForExists(waitingTime);
+        englishGeneralHeading.click();
+
         languageHeading.waitForExists(waitingTime);
 
         /* system locale is in English, check it is now set to system locale */
@@ -155,6 +165,8 @@ public class SwitchLocaleTest {
 
         /* Exit to main and see the UI is in French as well */
         TestHelper.pressBackKey();
+        TestHelper.pressBackKey();
+
         UiObject frenchTitle = TestHelper.mDevice.findObject(new UiSelector()
                 .className("android.widget.TextView")
                 .text("Navigation privée automatique.\nNaviguez. Effacez. Recommencez."));
@@ -166,7 +178,11 @@ public class SwitchLocaleTest {
         Assert.assertEquals(TestHelper.HelpItem.getText(), "Aide");
         TestHelper.settingsMenuItem.click();
 
-        /* re-enter settings, change it back to system locale, verify the locale is changed */
+        /* re-enter settings and general settings, change it back to system locale, verify the locale is changed */
+        frenchGeneralHeading.waitForExists(waitingTime);
+        frenchGeneralHeading.click();
+        languageHeading.waitForExists(waitingTime);
+
         languageHeading.click();
         Assert.assertTrue(frenchLocaleinEn.isChecked());
         appViews.scrollToBeginning(10);
@@ -175,7 +191,11 @@ public class SwitchLocaleTest {
         languageHeading.waitForExists(waitingTime);
         Assert.assertTrue(englishHeading.exists());
         Assert.assertTrue(englishMenuItem.exists());
+
+        // Exit Settings
         TestHelper.pressBackKey();
+        TestHelper.pressBackKey();
+
         UiObject englishTitle = TestHelper.mDevice.findObject(new UiSelector()
                 .className("android.widget.TextView")
                 .text("Automatic private browsing.\nBrowse. Erase. Repeat."));
@@ -203,6 +223,9 @@ public class SwitchLocaleTest {
         TestHelper.inlineAutocompleteEditText.waitForExists(waitingTime);
 
         openSettings();
+        frenchGeneralHeading.waitForExists(waitingTime);
+        frenchGeneralHeading.click();
+
         languageHeading.waitForExists(waitingTime);
 
         /* system locale is in French, check it is now set to system locale */

--- a/app/src/androidTest/java/org/mozilla/focus/screenshots/SettingsScreenshots.java
+++ b/app/src/androidTest/java/org/mozilla/focus/screenshots/SettingsScreenshots.java
@@ -19,6 +19,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mozilla.focus.R;
+import org.mozilla.focus.helpers.TestHelper;
 
 import java.util.Collections;
 
@@ -76,6 +77,13 @@ public class SettingsScreenshots extends ScreenshotTest {
 
         Screengrab.screenshot("Settings_View_Top");
 
+        /* General Settings */
+        UiObject generalHeading = TestHelper.mDevice.findObject(new UiSelector()
+                .text("General")
+                .resourceId("android:id/title"));
+        generalHeading.waitForExists(waitingTime);
+        generalHeading.click();
+
         /* Language List (First page only */
         onView(withText(R.string.preference_language))
                 .perform(click());
@@ -91,6 +99,8 @@ public class SettingsScreenshots extends ScreenshotTest {
         CancelBtn.click();
         onView(withText(R.string.preference_language))
                 .check(matches(isDisplayed()));
+
+        Espresso.pressBack();
 
         /* Search Engine List */
         onView(withText(R.string.preference_category_search))

--- a/app/src/main/java/org/mozilla/focus/session/SessionManager.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionManager.java
@@ -4,18 +4,14 @@
 
 package org.mozilla.focus.session;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-import android.support.design.widget.Snackbar;
 import android.text.TextUtils;
-import android.view.View;
 
-import org.mozilla.focus.R;
 import org.mozilla.focus.architecture.NonNullLiveData;
 import org.mozilla.focus.architecture.NonNullMutableLiveData;
 import org.mozilla.focus.customtabs.CustomTabConfig;
@@ -23,7 +19,6 @@ import org.mozilla.focus.shortcut.HomeScreen;
 import org.mozilla.focus.utils.AppConstants;
 import org.mozilla.focus.utils.Settings;
 import org.mozilla.focus.utils.UrlUtils;
-import org.mozilla.focus.utils.ViewUtils;
 import org.mozilla.focus.web.GeckoWebViewProvider;
 import org.mozilla.geckoview.GeckoSession;
 

--- a/app/src/main/java/org/mozilla/focus/session/SessionManager.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionManager.java
@@ -4,20 +4,26 @@
 
 package org.mozilla.focus.session;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.support.design.widget.Snackbar;
 import android.text.TextUtils;
+import android.view.View;
 
+import org.mozilla.focus.R;
 import org.mozilla.focus.architecture.NonNullLiveData;
 import org.mozilla.focus.architecture.NonNullMutableLiveData;
 import org.mozilla.focus.customtabs.CustomTabConfig;
 import org.mozilla.focus.shortcut.HomeScreen;
 import org.mozilla.focus.utils.AppConstants;
+import org.mozilla.focus.utils.Settings;
 import org.mozilla.focus.utils.UrlUtils;
+import org.mozilla.focus.utils.ViewUtils;
 import org.mozilla.focus.web.GeckoWebViewProvider;
 import org.mozilla.geckoview.GeckoSession;
 
@@ -239,6 +245,12 @@ public class SessionManager {
         return customTabSessions;
     }
 
+    public Session createNewTabSession(@NonNull Source source, @NonNull String url, Context context) {
+        final Session session = new Session(source, url);
+        addNewTabSession(session, context);
+        return session;
+    }
+
     public void createSession(@NonNull Source source, @NonNull String url) {
         final Session session = new Session(source, url);
         addSession(session);
@@ -280,6 +292,16 @@ public class SessionManager {
 
             this.sessions.setValue(Collections.unmodifiableList(sessions));
         }
+    }
+
+    private void addNewTabSession(final Session session, Context context) {
+        if (currentSessionUUID == null || Settings.getInstance(context).shouldOpenNewTabs()) {
+            currentSessionUUID = session.getUUID();
+        }
+
+        final List<Session> sessions = new ArrayList<>(this.sessions.getValue());
+        sessions.add(session);
+        this.sessions.setValue(Collections.unmodifiableList(sessions));
     }
 
     public void selectSession(Session session) {

--- a/app/src/main/java/org/mozilla/focus/settings/GeneralSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/GeneralSettingsFragment.kt
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.settings
+
+import android.content.SharedPreferences
+import android.os.Bundle
+import android.support.v7.preference.ListPreference
+import android.text.TextUtils
+import org.mozilla.focus.R
+import org.mozilla.focus.activity.SettingsActivity
+import org.mozilla.focus.locale.LocaleManager
+import org.mozilla.focus.locale.Locales
+import org.mozilla.focus.telemetry.TelemetryWrapper
+import org.mozilla.focus.widget.DefaultBrowserPreference
+import java.util.Locale
+
+class GeneralSettingsFragment : BaseSettingsFragment(),
+    SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private var localeUpdated: Boolean = false
+
+    override fun onCreatePreferences(p0: Bundle?, p1: String?) {
+        addPreferencesFromResource(R.xml.general_settings)
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        val preference =
+            findPreference(getString(R.string.pref_key_default_browser)) as DefaultBrowserPreference
+        preference.update()
+
+        preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
+
+        // Update title and icons when returning to fragments.
+        val updater = activity as BaseSettingsFragment.ActionBarUpdater
+        updater.updateTitle(R.string.preference_category_general)
+        updater.updateIcon(R.drawable.ic_back)
+    }
+
+    override fun onPause() {
+        preferenceManager.sharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
+        super.onPause()
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+        TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
+
+        if (!localeUpdated && key == getString(R.string.pref_key_locale)) {
+            // Updating the locale leads to onSharedPreferenceChanged being triggered again in some
+            // cases. To avoid an infinite loop we won't update the preference a second time. This
+            // fragment gets replaced at the end of this method anyways.
+            localeUpdated = true
+
+            //Set langChanged from InstalledSearchEngines to true
+            InstalledSearchEnginesSettingsFragment.languageChanged = true
+
+            val languagePreference =
+                findPreference(getString(R.string.pref_key_locale)) as ListPreference
+            val value = languagePreference.value
+
+            val localeManager = LocaleManager.getInstance()
+
+            val locale: Locale?
+            if (TextUtils.isEmpty(value)) {
+                localeManager.resetToSystemLocale(activity)
+                locale = localeManager.getCurrentLocale(activity)
+            } else {
+                locale = Locales.parseLocaleCode(value)
+                localeManager.setSelectedLocale(activity, value)
+            }
+            localeManager.updateConfiguration(activity, locale)
+
+            // Manually notify SettingsActivity of locale changes (in most other cases activities
+            // will detect changes in onActivityResult(), but that doesn't apply to SettingsActivity).
+            activity!!.onConfigurationChanged(activity!!.resources.configuration)
+
+            // And ensure that the calling LocaleAware*Activity knows that the locale changed:
+            activity!!.setResult(SettingsActivity.ACTIVITY_RESULT_LOCALE_CHANGED)
+
+            // The easiest way to ensure we update the language is by replacing the entire fragment
+            // We have to pop the main Settings Fragment as well and then navigate here
+            fragmentManager!!.popBackStack()
+            fragmentManager!!.beginTransaction()
+                .replace(R.id.container, SettingsFragment.newInstance()).commit()
+            navigateToFragment(GeneralSettingsFragment.newInstance())
+        }
+    }
+
+    companion object {
+
+        fun newInstance(): GeneralSettingsFragment {
+            return GeneralSettingsFragment()
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.kt
@@ -7,19 +7,10 @@ package org.mozilla.focus.settings
 
 import android.content.SharedPreferences
 import android.os.Bundle
-import android.support.v7.preference.ListPreference
-import android.text.TextUtils
 import org.mozilla.focus.R
-import org.mozilla.focus.activity.SettingsActivity
-import org.mozilla.focus.locale.LocaleManager
-import org.mozilla.focus.locale.Locales
 import org.mozilla.focus.telemetry.TelemetryWrapper
-import org.mozilla.focus.widget.DefaultBrowserPreference
-import java.util.Locale
 
 class SettingsFragment : BaseSettingsFragment(), SharedPreferences.OnSharedPreferenceChangeListener {
-
-    private var localeUpdated: Boolean = false
 
     override fun onCreatePreferences(bundle: Bundle?, s: String?) {
         addPreferencesFromResource(R.xml.settings)
@@ -31,9 +22,6 @@ class SettingsFragment : BaseSettingsFragment(), SharedPreferences.OnSharedPrefe
         super.onResume()
 
         preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
-
-        val preference = findPreference(getString(R.string.pref_key_default_browser)) as DefaultBrowserPreference
-        preference.update()
 
         // Update title and icons when returning to fragments.
         val updater = activity as BaseSettingsFragment.ActionBarUpdater?
@@ -51,6 +39,8 @@ class SettingsFragment : BaseSettingsFragment(), SharedPreferences.OnSharedPrefe
 
         when {
             preference.key == resources.getString(R.string
+                .pref_key_general_screen) -> navigateToFragment(GeneralSettingsFragment())
+            preference.key == resources.getString(R.string
                     .pref_key_privacy_security_screen) -> navigateToFragment(PrivacySecuritySettingsFragment())
             preference.key == resources.getString(R.string
                     .pref_key_search_screen) -> navigateToFragment(SearchSettingsFragment())
@@ -65,43 +55,6 @@ class SettingsFragment : BaseSettingsFragment(), SharedPreferences.OnSharedPrefe
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
         TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
-
-        if (!localeUpdated && key == getString(R.string.pref_key_locale)) {
-            // Updating the locale leads to onSharedPreferenceChanged being triggered again in some
-            // cases. To avoid an infinite loop we won't update the preference a second time. This
-            // fragment gets replaced at the end of this method anyways.
-            localeUpdated = true
-
-            //Set langChanged from InstalledSearchEngines to true
-            InstalledSearchEnginesSettingsFragment.languageChanged = true
-
-            val languagePreference = findPreference(getString(R.string.pref_key_locale)) as ListPreference
-            val value = languagePreference.value
-
-            val localeManager = LocaleManager.getInstance()
-
-            val locale: Locale?
-            if (TextUtils.isEmpty(value)) {
-                localeManager.resetToSystemLocale(activity)
-                locale = localeManager.getCurrentLocale(activity)
-            } else {
-                locale = Locales.parseLocaleCode(value)
-                localeManager.setSelectedLocale(activity, value)
-            }
-            localeManager.updateConfiguration(activity, locale)
-
-            // Manually notify SettingsActivity of locale changes (in most other cases activities
-            // will detect changes in onActivityResult(), but that doesn't apply to SettingsActivity).
-            activity!!.onConfigurationChanged(activity!!.resources.configuration)
-
-            // And ensure that the calling LocaleAware*Activity knows that the locale changed:
-            activity!!.setResult(SettingsActivity.ACTIVITY_RESULT_LOCALE_CHANGED)
-
-            // The easiest way to ensure we update the language is by replacing the entire fragment:
-            fragmentManager!!.beginTransaction()
-                    .replace(R.id.container, SettingsFragment.newInstance())
-                    .commit()
-        }
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -240,6 +240,7 @@ object TelemetryWrapper {
                             resources.getString(R.string.pref_key_autocomplete_custom),
                             resources.getString(R.string.pref_key_remote_debugging),
                             resources.getString(R.string.pref_key_homescreen_tips),
+                            resources.getString(R.string.pref_key_open_new_tab),
                             resources.getString(R.string.pref_key_show_search_suggestions))
                     .setSettingsProvider(TelemetrySettingsProvider(context))
                     .setCollectionEnabled(telemetryEnabled)

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -91,6 +91,9 @@ class Settings private constructor(context: Context) {
     fun shouldUseBiometrics(): Boolean =
             preferences.getBoolean(getPreferenceKey(R.string.pref_key_biometric), false)
 
+    fun shouldOpenNewTabs(): Boolean =
+        preferences.getBoolean(getPreferenceKey(R.string.pref_key_open_new_tab), false)
+
     fun shouldUseSecureMode(): Boolean =
             preferences.getBoolean(getPreferenceKey(R.string.pref_key_secure), false)
 

--- a/app/src/main/java/org/mozilla/focus/utils/ViewUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/ViewUtils.java
@@ -152,6 +152,17 @@ public class ViewUtils {
         }, delayMillis);
     }
 
+    public static Snackbar getBrandedSnackbar(View view, @StringRes int resId) {
+        final Context context = view.getContext();
+        final Snackbar snackbar = Snackbar.make(view, resId, Snackbar.LENGTH_LONG);
+        final View snackbarView = snackbar.getView();
+        snackbarView.setBackgroundColor(ContextCompat.getColor(context, R.color.snackbarBackground));
+        final TextView snackbarTextView = snackbarView.findViewById(android.support.design.R.id.snackbar_text);
+        snackbarTextView.setTextColor(ContextCompat.getColor(context, R.color.snackbarTextColor));
+        snackbar.setActionTextColor(ContextCompat.getColor(context, R.color.snackbarActionText));
+        return snackbar;
+    }
+
     public static boolean isRTL(View view) {
         return ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL;
     }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -37,6 +37,8 @@
 
     <string name="pref_key_privacy_security_screen" translatable="false"><xliff:g id="preference_key">pref_screen_privacy_security</xliff:g></string>
     <string name="pref_key_advanced_screen" translatable="false"><xliff:g id="preference_key">pref_advanced_screen</xliff:g></string>
+    <string name="pref_key_general_screen" translatable="false"><xliff:g id="preference_key">pref_general_screen</xliff:g></string>
+
     <string name="pref_key_mozilla_screen" translatable="false"><xliff:g id="preference_key">pref_screen_mozilla</xliff:g></string>
     <string name="pref_key_search_screen" translatable="false"><xliff:g id="preference_key">pref_screen_search</xliff:g></string>
     <string name="pref_key_remote_debugging" translatable="false"><xliff:g id="preference_key">pref_remote_debugging</xliff:g></string>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -50,4 +50,7 @@
         <xliff:g id="preference_key">use_homescreen_tips</xliff:g>
     </string>
 
+    <string name="pref_key_open_new_tab" translatable="false">
+        <xliff:g id="preference_key">pref_open_new_tab</xliff:g>
+    </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,6 +137,9 @@
     <!-- Preference category for General Settings -->
     <string name="preference_category_general">General</string>
 
+    <!-- Preference summary for General Settings category; the three things users can find in this category -->
+    <string name="preference_general_summary">Default browser, tabs, language</string>
+
     <!-- Preference category for settings about sending usage data -->
     <string name="preference_category_data_collection_use">Data Collection &amp; Use</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -730,5 +730,5 @@ be temporary, and you can try again later.</li>
     <string name="open_new_tab_snackbar">Switch</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
-    <string name="preference_open_new_tab">When you open link in a new tab, switch to it immediately</string>
+    <string name="preference_open_new_tab">When you open a link in a new tab, switch to it immediately</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -721,4 +721,11 @@ be temporary, and you can try again later.</li>
     <!-- Tip displayed on home view explaining how to add a custom autocomplete URL
         Argument 1 is the app name (Firefox Focus/Firefox Klar/etc). -->
     <string name="tip_disable_tips">Turn off tips on the %1$s start screen</string>
+
+    <!-- Displayed in a snackbar when a user opens a new tab, gives action to switch to the newly opened tab -->
+    <string name="new_tab_opened_snackbar">New tab opened</string>
+    <string name="open_new_tab_snackbar">Switch</string>
+
+    <!-- Preference for switching to a new tab immediately after opening -->
+    <string name="preference_open_new_tab">When you open link in a new tab, switch to it immediately</string>
 </resources>

--- a/app/src/main/res/xml/general_settings.xml
+++ b/app/src/main/res/xml/general_settings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<android.support.v7.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <org.mozilla.focus.widget.DefaultBrowserPreference
+        android:key="@string/pref_key_default_browser"
+        android:layout="@layout/focus_preference_no_icon"
+        android:title="@string/preference_default_browser2" />
+
+    <SwitchPreference
+        android:key="@string/pref_key_open_new_tab"
+        android:layout="@layout/focus_preference_no_icon"
+        android:title="@string/preference_open_new_tab" />
+
+    <!-- Empty default: we use an empty string to indicate "system default" language being selected -->
+    <!--suppress AndroidDomInspection -->
+    <org.mozilla.focus.widget.LocaleListPreference
+        android:defaultValue=""
+        android:key="@string/pref_key_locale"
+        android:layout="@layout/focus_preference_no_icon"
+        android:title="@string/preference_language" />
+
+</android.support.v7.preference.PreferenceScreen>

--- a/app/src/main/res/xml/mozilla_settings.xml
+++ b/app/src/main/res/xml/mozilla_settings.xml
@@ -12,6 +12,11 @@
         android:layout="@layout/focus_preference_no_icon"
         android:title="@string/preference_homescreen_tips" />
 
+    <SwitchPreference
+        android:key="@string/pref_key_open_new_tab"
+        android:layout="@layout/focus_preference_no_icon"
+        android:title="@string/preference_open_new_tab" />
+
     <org.mozilla.focus.widget.AboutPreference
         android:key="@string/pref_key_about"
         android:layout="@layout/focus_preference_new_tab"

--- a/app/src/main/res/xml/mozilla_settings.xml
+++ b/app/src/main/res/xml/mozilla_settings.xml
@@ -12,11 +12,6 @@
         android:layout="@layout/focus_preference_no_icon"
         android:title="@string/preference_homescreen_tips" />
 
-    <SwitchPreference
-        android:key="@string/pref_key_open_new_tab"
-        android:layout="@layout/focus_preference_no_icon"
-        android:title="@string/preference_open_new_tab" />
-
     <org.mozilla.focus.widget.AboutPreference
         android:key="@string/pref_key_about"
         android:layout="@layout/focus_preference_new_tab"

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -2,14 +2,13 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <android.support.v7.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Empty default: we use an empty string to indicate "system default" language being selected -->
-    <!--suppress AndroidDomInspection -->
-    <org.mozilla.focus.widget.LocaleListPreference
-        android:icon="@drawable/ic_language"
-        android:defaultValue=""
-        android:key="@string/pref_key_locale"
+
+    <android.support.v7.preference.Preference
+        android:icon="@drawable/ic_settings"
+        android:key="@string/pref_key_general_screen"
         android:layout="@layout/focus_preference"
-        android:title="@string/preference_language" />
+        android:summary="@string/preference_general_summary"
+        android:title="@string/preference_category_general" />
 
     <android.support.v7.preference.Preference
         android:icon="@drawable/ic_lock"
@@ -30,11 +29,6 @@
         android:layout="@layout/focus_preference"
         android:summary="@string/preference_advanced_summary"
         android:title="@string/preference_category_advanced" />
-
-    <org.mozilla.focus.widget.DefaultBrowserPreference
-        android:key="@string/pref_key_default_browser"
-        android:layout="@layout/focus_preference"
-        android:title="@string/preference_default_browser2" />
 
     <org.mozilla.focus.widget.MozillaPreference
         android:icon="@drawable/ic_mozilla"


### PR DESCRIPTION
@brampitoyo I think this is almost done. 

The Setting:
![screenshot_20180906-153448](https://user-images.githubusercontent.com/25442310/45188738-954b3e00-b1ea-11e8-9a14-09f3216c8d48.png)

The Snackbar:
![screenshot_20180909-122929](https://user-images.githubusercontent.com/25442310/45268038-29581800-b42c-11e8-8c17-94567bc3200b.png)

I had a few questions about the Setting:
1. There are 0 other checkboxes in settings and it looked a bit strange so I made it a switch, but I can change it if you want. 
2. Should there be a title + summary for the setting, or just "When you open link in a new tab, switch to it immediately". Currently it's just that String. 
3. I assumed that this setting would go in Mozilla Settings because it's not privacy/search related, was that correct? 

I can send you a build to test it out if you like, let me know! I'm assuming this is going into the next release, so no rush