### PR TITLE
 Fixes #2002: Check search engine name against default engine list 

### DIFF
--- a/app/src/main/java/org/mozilla/focus/search/CustomSearchEngineStore.kt
+++ b/app/src/main/java/org/mozilla/focus/search/CustomSearchEngineStore.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.util.Log
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.SearchEngineParser
+import org.mozilla.focus.Components
 import org.mozilla.focus.shortcut.IconGenerator
 import org.xmlpull.v1.XmlPullParserException
 import java.io.IOException
@@ -17,7 +18,9 @@ object CustomSearchEngineStore {
         val sharedPreferences = context.getSharedPreferences(PREF_FILE_SEARCH_ENGINES,
                 Context.MODE_PRIVATE)
 
-        return !sharedPreferences.contains(engineName)
+        val defaultEngines = Components.searchEngineManager.getSearchEngines(context)
+
+        return !sharedPreferences.contains(engineName) && !defaultEngines.any { it.name == engineName }
     }
 
     fun restoreDefaultSearchEngines(context: Context) {

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
@@ -220,7 +220,7 @@ class ManualAddSearchEngineSettingsFragment : BaseSettingsFragment() {
             return isValidSearchQuery
         }
 
-        override fun onPostExecute(isValidSearchQuery: Boolean?) {
+        override fun onPostExecute(isValidSearchQuery: Boolean) {
             super.onPostExecute(isValidSearchQuery)
             if (isCancelled) {
                 Log.d(LOGTAG, "ValidateSearchEngineAsyncTask has been cancelled")
@@ -234,7 +234,7 @@ class ManualAddSearchEngineSettingsFragment : BaseSettingsFragment() {
                 return
             }
 
-            if (isValidSearchQuery == true) {
+            if (isValidSearchQuery) {
                 CustomSearchEngineStore.addSearchEngine(that.activity!!, engineName, query)
                 Snackbar.make(that.view!!, R.string.search_add_confirmation, Snackbar.LENGTH_SHORT).show()
                 Settings.getInstance(that.activity!!).setDefaultSearchEngineByName(engineName)

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
@@ -206,12 +206,12 @@ class ManualAddSearchEngineSettingsFragment : BaseSettingsFragment() {
 
     private class ValidateSearchEngineAsyncTask
         constructor (
-            that: ManualAddSearchEngineSettingsFragment,
+            fragment: ManualAddSearchEngineSettingsFragment,
             private val engineName: String,
             private val query: String
         ) : AsyncTask<Void, Void, Boolean>() {
 
-        private val thatWeakReference: WeakReference<ManualAddSearchEngineSettingsFragment> = WeakReference(that)
+        private val fragmentWeakReference = WeakReference(fragment)
 
         override fun doInBackground(vararg p0: Void?): Boolean {
             val isValidSearchQuery = isValidSearchQueryURL(query)
@@ -227,25 +227,25 @@ class ManualAddSearchEngineSettingsFragment : BaseSettingsFragment() {
                 return
             }
 
-            val that = thatWeakReference.get()
-            if (that == null) {
+            val fragment = fragmentWeakReference.get()
+            if (fragment == null) {
                 Log.d(LOGTAG, "Fragment or menu item no longer exists when search query " +
                         "validation async task returned.")
                 return
             }
 
             if (isValidSearchQuery) {
-                CustomSearchEngineStore.addSearchEngine(that.activity!!, engineName, query)
-                Snackbar.make(that.view!!, R.string.search_add_confirmation, Snackbar.LENGTH_SHORT).show()
-                Settings.getInstance(that.activity!!).setDefaultSearchEngineByName(engineName)
-                that.fragmentManager!!.popBackStack()
+                CustomSearchEngineStore.addSearchEngine(fragment.activity!!, engineName, query)
+                Snackbar.make(fragment.view!!, R.string.search_add_confirmation, Snackbar.LENGTH_SHORT).show()
+                Settings.getInstance(fragment.activity!!).setDefaultSearchEngineByName(engineName)
+                fragment.fragmentManager!!.popBackStack()
             } else {
-                showServerError(that)
+                showServerError(fragment)
             }
 
-            that.setUiIsValidatingAsync(false, that.menuItemForActiveAsyncTask)
-            that.activeAsyncTask = null
-            that.menuItemForActiveAsyncTask = null
+            fragment.setUiIsValidatingAsync(false, fragment.menuItemForActiveAsyncTask)
+            fragment.activeAsyncTask = null
+            fragment.menuItemForActiveAsyncTask = null
         }
 
         private fun showServerError(that: ManualAddSearchEngineSettingsFragment) {


### PR DESCRIPTION
Fixes #2002
And:
* ValidateSearchEngineAsyncTask.onPostExecute() nullable paramenter is now non null
* "that" -> "fragment" in ValidateSearchEngineAsyncTask 