### PR TITLE
Fixes #2989: Remove show badge notification channel

### DIFF
--- a/app/src/main/java/org/mozilla/focus/session/SessionNotificationService.kt
+++ b/app/src/main/java/org/mozilla/focus/session/SessionNotificationService.kt
@@ -129,7 +129,7 @@ class SessionNotificationService : Service() {
         channel.description = notificationChannelDescription
         channel.enableLights(false)
         channel.enableVibration(false)
-        channel.setShowBadge(true)
+        channel.setShowBadge(false)
 
         notificationManager.createNotificationChannel(channel)
     }


### PR DESCRIPTION
This is a shot in the dark, I cannot test if this works, because [it seems to be broken on emulators](https://stackoverflow.com/a/44528600/3124150) and I don't have an Android O phone to test on.
I am posting this PR because, even if this patch doesn't work, it might help lead to the correct solution.

Fixes #2989