### PR TITLE
Fixes #2943: Missing "button" text on more options home screen

### DIFF
--- a/app/src/main/res/layout/fragment_urlinput.xml
+++ b/app/src/main/res/layout/fragment_urlinput.xml
@@ -123,7 +123,7 @@
                     android:layout_width="40dp"
                     android:layout_height="40dp"
                     android:background="?android:attr/selectableItemBackgroundBorderless"
-                    android:contentDescription="@string/content_description_menu"
+                    android:contentDescription="@string/indicator_content_description_menu"
                     android:visibility="gone" />
 
             </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -369,6 +369,10 @@
     <!-- Content description (not visible, for screen readers etc.): "Three dot" menu button. -->
     <string name="content_description_menu">More options</string>
 
+    <!-- Content description (not visible, for screen readers etc.): "Three dot" menu button used
+    on home screen-->
+    <string name="indicator_content_description_menu">More options button</string>
+
     <!-- Content description (not visible, for screen readers etc.): Navigate forward (browsing history) -->
     <string name="content_description_forward">Navigate forward</string>
 


### PR DESCRIPTION
We have to use a different content description for this button because it's using our custom "IndicatorMenu" class which is not technically a button. Because of this, TalkBack doesn't know to automatically say "button" after saying the content description.