### PR TITLE
Fixes #815: Add open in app in WebContextMenu

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/screenshots/BrowserScreenScreenshots.java
+++ b/app/src/androidTest/java/org/mozilla/focus/screenshots/BrowserScreenScreenshots.java
@@ -240,6 +240,11 @@ public class BrowserScreenScreenshots extends ScreenshotTest {
 
         //Open a new tab
         openNewTabTitle.click();
+        TestHelper.mDevice.wait(Until.findObject(
+                By.res(TestHelper.getAppName(), "snackbar_text")), 5000);
+        Screengrab.screenshot("New_Tab_Popup");
+        TestHelper.mDevice.wait(Until.gone(
+                By.res(TestHelper.getAppName(), "snackbar_text")), 5000);
 
         assertTrue(multiTabBtn.waitForExists(waitingTime));
         multiTabBtn.click();
@@ -248,7 +253,8 @@ public class BrowserScreenScreenshots extends ScreenshotTest {
 
         eraseHistoryBtn.click();
 
-        device.wait(Until.findObject(By.res(TestHelper.getAppName(), "snackbar_text")), waitingTime);
+        device.wait(Until.findObject(
+                By.res(TestHelper.getAppName(), "snackbar_text")), waitingTime);
 
         Screengrab.screenshot("YourBrowsingHistoryHasBeenErased");
     }

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -534,7 +534,7 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
             override fun onRequestDesktopStateChanged(shouldRequestDesktop: Boolean) {}
 
             override fun onLongPress(hitTarget: IWebView.HitTarget) {
-                WebContextMenu.show(activity!!, this, hitTarget)
+                WebContextMenu.show(activity!!, fragmentManager!!, this, hitTarget)
             }
 
             override fun onEnterFullScreen(callback: IWebView.FullscreenCallback, view: View?) {

--- a/app/src/main/res/menu/menu_browser_context.xml
+++ b/app/src/main/res/menu/menu_browser_context.xml
@@ -4,6 +4,9 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
+        android:id="@+id/menu_open_with_app"
+        android:title="@string/contextmenu_open_in_app" />
+    <item
         android:id="@+id/menu_new_tab"
         android:title="@string/contextmenu_open_in_new_tab" />
     <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -487,6 +487,8 @@ be temporary, and you can try again later.</li>
     <string name="error_generic_message">We can’t load this page for some reason.</string>
 
     <!-- Label used in the contextmenu shown when long-pressing on a link -->
+    <string name="contextmenu_open_in_app">Open with app</string>
+    <!-- Label used in the contextmenu shown when long-pressing on a link -->
     <string name="contextmenu_link_share">Share link</string>
     <!-- Label used in the contextmenu shown when long-pressing on a link -->
     <string name="contextmenu_link_copy">Copy link address</string>


### PR DESCRIPTION
Fixes #815 

@colintheshots
I'm having problems with the argument count of `WebContextMenu.setupMenuForHitTarget()` 7 out a maximum 5. I feel the correct solution is to make `WebContextMenu` not an object, because the other two solutions are:
* to convert arguments to fields (possibly ending up with a memory leak) or
* passing objects with more than one parameter and separating them inside the function (adding unnecessary clutter).

But I feel that converting `WebContextMenu` to a class overextends the scope of this PR. What should I do? 