### PR TITLE
No issue: disable codecov patch checks.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,10 @@ coverage:
        if_not_found: success
     patch:
       default:
-        enabled: yes
+        # Patch ensures X percent of added lines are covered by unit tests.
+        # However, we don't require unit tests for each commit so it doesn't
+        # make sense to enable patch checks.
+        enabled: no
         threshold: 0.1
         if_not_found: success
     changes:


### PR DESCRIPTION
Status checks always fail because of this:

![image](https://user-images.githubusercontent.com/759372/45834329-abadcb00-bcbb-11e8-9bce-8adf702db19d.png)

So I think it'd be a good thing to do. We're doing this on TV too.

I want to have a separate discussion about the best way to improve our test culture (assuming there are problems with it) so I don't think this will have an impact.