### PR TITLE
Fix type error in locale lookup

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/LocaleListPreference.java
+++ b/app/src/main/java/org/mozilla/focus/widget/LocaleListPreference.java
@@ -202,8 +202,8 @@ public class LocaleListPreference extends ListPreference {
 
             if (languageCodeToNameMap.containsKey(locale.getLanguage())) {
                 displayName = languageCodeToNameMap.get(locale.getLanguage());
-            } else if (localeToNameMap.containsKey(locale)) {
-                displayName = localeToNameMap.get(locale);
+            } else if (localeToNameMap.containsKey(locale.getCountry())) {
+                displayName = localeToNameMap.get(locale.getCountry());
             } else {
                 displayName = locale.getDisplayName(locale);
             }


### PR DESCRIPTION
Found via error-prone.  Follows on to
mozilla-mobile/focus-android#3230.