### PR TITLE
String import 20180926-121015

### DIFF
--- a/app/src/main/res/values-ace/strings.xml
+++ b/app/src/main/res/values-ace/strings.xml
@@ -36,8 +36,13 @@
   <string name="preference_category_general">Awam</string>
   <string name="preference_category_data_collection_use">Peusapat Data &amp; Ngui</string>
   <string name="preference_category_search">Mita</string>
+  <string name="preference_show_search_suggestions">Peuleumah saran mita</string>
+  <string name="preference_search_engine_default">Teutap</string>
   <string name="preference_state_on">Udép</string>
   <string name="preference_state_off">Maté</string>
+  <string name="preference_subitem_autocomplete">Peuleungkap URL keudroe</string>
+  <string name="preference_switch_autocomplete">Peuleungkap keudroe</string>
+  <string name="preference_category_autocomplete_preinstalled">Dapeuta URL Teutap</string>
   <string name="preference_autocomplete_learn_more">Meurunoë lom</string>
   <string name="preference_mozilla_telemetry_summary">Meurunoë lom</string>
   <string name="download_dialog_action_cancel">Bateuë</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -77,7 +77,7 @@
   <string name="preference_privacy_block_content_summary2">Włączenie może spowodować nieoczekiwane zachowanie niektórych stron</string>
   <string name="preference_privacy_category_cookies">Blokowanie ciasteczek</string>
   <string name="preference_privacy_should_block_cookies_no_option">Nie</string>
-  <string name="preference_privacy_should_block_cookies_third_party_only_option">Blokowanie tylko ciasteczek witryn zewnętrznych podmiotów</string>
+  <string name="preference_privacy_should_block_cookies_third_party_only_option">Blokowanie tylko ciasteczek zewnętrznych witryn</string>
   <string name="preference_privacy_should_block_cookies_yes_option">Tak</string>
   <string name="preference_security_biometric">Odblokowywanie aplikacji odciskiem palca</string>
   <string name="preference_security_biometric_summary">Można odblokować %1$s za pomocą odcisku palca, jeśli w aplikacji jest już otwarty adres. Tryb ukryty będzie włączony.</string>


### PR DESCRIPTION

Automated import 20180926-121015

Log:
```
     [mkdir] app/src/main/res/values-zh-TW
   [created] app/src/main/res/values-zh-TW/strings.xml
     [mkdir] app/src/main/res/values-pa-IN
   [created] app/src/main/res/values-pa-IN/strings.xml
 [unchanged] app/src/main/res/values-gl/strings.xml
     [mkdir] app/src/main/res/values-ne-NP
   [created] app/src/main/res/values-ne-NP/strings.xml
 [unchanged] app/src/main/res/values-lo/strings.xml
 [unchanged] app/src/main/res/values-tt/strings.xml
 [unchanged] app/src/main/res/values-tr/strings.xml
 [unchanged] app/src/main/res/values-lt/strings.xml
 [unchanged] app/src/main/res/values-tsz/strings.xml
 [unchanged] app/src/main/res/values-th/strings.xml
 [unchanged] app/src/main/res/values-te/strings.xml
 [unchanged] app/src/main/res/values-ta/strings.xml
     [mkdir] app/src/main/res/values-bn-IN
   [created] app/src/main/res/values-bn-IN/strings.xml
 [unchanged] app/src/main/res/values-de/strings.xml
 [unchanged] app/src/main/res/values-da/strings.xml
     [mkdir] app/src/main/res/values-pt-BR
   [created] app/src/main/res/values-pt-BR/strings.xml
     [mkdir] app/src/main/res/values-nb-NO
   [created] app/src/main/res/values-nb-NO/strings.xml
     [mkdir] app/src/main/res/values-gu-IN
   [created] app/src/main/res/values-gu-IN/strings.xml
     [mkdir] app/src/main/res/values-ga-IE
   [created] app/src/main/res/values-ga-IE/strings.xml
     [mkdir] app/src/main/res/values-es-CL
   [created] app/src/main/res/values-es-CL/strings.xml
 [unchanged] app/src/main/res/values-trs/strings.xml
 [unchanged] app/src/main/res/values-el/strings.xml
 [unchanged] app/src/main/res/values-eo/strings.xml
 [unchanged] app/src/main/res/values-eu/strings.xml
     [mkdir] app/src/main/res/values-sv-SE
   [created] app/src/main/res/values-sv-SE/strings.xml
 [unchanged] app/src/main/res/values-ru/strings.xml
 [unchanged] app/src/main/res/values-wo/strings.xml
 [unchanged] app/src/main/res/values-ro/strings.xml
 [unchanged] app/src/main/res/values-dsb/strings.xml
 [unchanged] app/src/main/res/values-hsb/strings.xml
 [unchanged] app/src/main/res/values-bg/strings.xml
 [unchanged] app/src/main/res/values-uk/strings.xml
 [unchanged] app/src/main/res/values-ast/strings.xml
 [unchanged] app/src/main/res/values-quy/strings.xml
 [unchanged] app/src/main/res/values-jv/strings.xml
 [unchanged] app/src/main/res/values-bo/strings.xml
 [unchanged] app/src/main/res/values-meh/strings.xml
 [unchanged] app/src/main/res/values-quc/strings.xml
 [unchanged] app/src/main/res/values-bs/strings.xml
 [unchanged] app/src/main/res/values-ja/strings.xml
   [updated] app/src/main/res/values-ace/strings.xml
     [mkdir] app/src/main/res/values-es-AR
   [created] app/src/main/res/values-es-AR/strings.xml
 [unchanged] app/src/main/res/values-oc/strings.xml
     [mkdir] app/src/main/res/values-nn-NO
   [created] app/src/main/res/values-nn-NO/strings.xml
     [mkdir] app/src/main/res/values-fy-NL
   [created] app/src/main/res/values-fy-NL/strings.xml
 [unchanged] app/src/main/res/values-yua/strings.xml
             - "error_hostLookup_message" contains invalid XHTML (Opening and ending tag mismatch: strong line 3 and li, line 4, column 48 (line 4)); Falling back to loose parser.
 [unchanged] app/src/main/res/values-zam/strings.xml
 [unchanged] app/src/main/res/values-ca/strings.xml
 [unchanged] app/src/main/res/values-ppl/strings.xml
 [unchanged] app/src/main/res/values-cy/strings.xml
 [unchanged] app/src/main/res/values-cs/strings.xml
     [mkdir] app/src/main/res/values-en-CA
   [created] app/src/main/res/values-en-CA/strings.xml
 [unchanged] app/src/main/res/values-ixl/strings.xml
     [mkdir] app/src/main/res/values-hi-IN
   [created] app/src/main/res/values-hi-IN/strings.xml
   [updated] app/src/main/res/values-pl/strings.xml
 [unchanged] app/src/main/res/values-hr/strings.xml
 [unchanged] app/src/main/res/values-hu/strings.xml
 [unchanged] app/src/main/res/values-hus/strings.xml
             - "about_content" contains invalid XHTML (attributes construct error, line 10, column 11 (line 10)); Falling back to loose parser.
 [unchanged] app/src/main/res/values-iw/strings.xml
 [unchanged] app/src/main/res/values-ur/strings.xml
 [unchanged] app/src/main/res/values-cak/strings.xml
     [mkdir] app/src/main/res/values-zh-CN
   [created] app/src/main/res/values-zh-CN/strings.xml
 [unchanged] app/src/main/res/values-ms/strings.xml
 [unchanged] app/src/main/res/values-mr/strings.xml
 [unchanged] app/src/main/res/values-my/strings.xml
 [unchanged] app/src/main/res/values-af/strings.xml
 [unchanged] app/src/main/res/values-vi/strings.xml
 [unchanged] app/src/main/res/values-am/strings.xml
 [unchanged] app/src/main/res/values-it/strings.xml
 [unchanged] app/src/main/res/values-an/strings.xml
 [unchanged] app/src/main/res/values-ay/strings.xml
 [unchanged] app/src/main/res/values-ar/strings.xml
 [unchanged] app/src/main/res/values-anp/strings.xml
     [mkdir] app/src/main/res/values-bn-BD
   [created] app/src/main/res/values-bn-BD/strings.xml
 [unchanged] app/src/main/res/values-ia/strings.xml
 [unchanged] app/src/main/res/values-az/strings.xml
     [mkdir] app/src/main/res/values-es-ES
   [created] app/src/main/res/values-es-ES/strings.xml
 [unchanged] app/src/main/res/values-in/strings.xml
 [unchanged] app/src/main/res/values-sr/strings.xml
 [unchanged] app/src/main/res/values-nl/strings.xml
 [unchanged] app/src/main/res/values-mix/strings.xml
 [unchanged] app/src/main/res/values-pai/strings.xml
 [unchanged] app/src/main/res/values-kab/strings.xml
 [unchanged] app/src/main/res/values-fr/strings.xml
 [unchanged] app/src/main/res/values-fa/strings.xml
 [unchanged] app/src/main/res/values-fi/strings.xml
 [unchanged] app/src/main/res/values-ka/strings.xml
 [unchanged] app/src/main/res/values-kk/strings.xml
     [mkdir] app/src/main/res/values-hy-AM
   [created] app/src/main/res/values-hy-AM/strings.xml
 [unchanged] app/src/main/res/values-sq/strings.xml
 [unchanged] app/src/main/res/values-ko/strings.xml
 [unchanged] app/src/main/res/values-su/strings.xml
     [mkdir] app/src/main/res/values-es-MX
   [created] app/src/main/res/values-es-MX/strings.xml
 [unchanged] app/src/main/res/values-sk/strings.xml
 [unchanged] app/src/main/res/values-kw/strings.xml
 [unchanged] app/src/main/res/values-sl/strings.xml
Fixing ./values-gu-IN -> ./values-gu-rIN
Fixing ./values-pa-IN -> ./values-pa-rIN
Fixing ./values-ne-NP -> ./values-ne-rNP
Fixing ./values-es-CL -> ./values-es-rCL
Fixing ./values-es-MX -> ./values-es-rMX
Fixing ./values-en-CA -> ./values-en-rCA
Fixing ./values-es-AR -> ./values-es-rAR
Fixing ./values-es-ES -> ./values-es-rES
Fixing ./values-zh-CN -> ./values-zh-rCN
Fixing ./values-hy-AM -> ./values-hy-rAM
Fixing ./values-ga-IE -> ./values-ga-rIE
Fixing ./values-bn-BD -> ./values-bn-rBD
Fixing ./values-pt-BR -> ./values-pt-rBR
Fixing ./values-sv-SE -> ./values-sv-rSE
Fixing ./values-hi-IN -> ./values-hi-rIN
Fixing ./values-bn-IN -> ./values-bn-rIN
Fixing ./values-nb-NO -> ./values-nb-rNO
Fixing ./values-nn-NO -> ./values-nn-rNO
Fixing ./values-fy-NL -> ./values-fy-rNL
Fixing ./values-zh-TW -> ./values-zh-rTW
Checking for placeholders in translation files...
Warning: * [values-eo/strings.xml] number of placeholders not matching, key: firstrun_shortcut_text
Warning: * [values-pl/strings.xml] number of placeholders not matching, key: firstrun_shortcut_text
Warning: * [values-tr/strings.xml] number of placeholders not matching, key: your_rights_content5
Warning: * [values-ppl/strings.xml] number of placeholders not matching, key: tip_set_default_browser

```
