### PR TITLE
Enable WebViewDataTest.java for Klar build

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/privacy/WebViewDataTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/privacy/WebViewDataTest.java
@@ -16,7 +16,6 @@ import android.util.Log;
 import junit.framework.Assert;
 
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,7 +50,6 @@ import static org.mozilla.focus.helpers.TestHelper.waitingTime;
  * The test uses a whitelist so it might fail as soon as you store new files on disk.
  */
 @RunWith(AndroidJUnit4.class)
-@Ignore("This test fails permanently, see https://github.com/mozilla-mobile/focus-android/issues/2940")
 public class WebViewDataTest {
     private static final String LOGTAG = "WebViewDataTest";
 
@@ -136,6 +134,9 @@ public class WebViewDataTest {
         protected void beforeActivityLaunched() {
             super.beforeActivityLaunched();
 
+            // Klar is used to test Geckoview. make sure it's set to Gecko
+            TestHelper.selectGeckoForKlar();
+
             appContext = InstrumentationRegistry.getInstrumentation()
                     .getTargetContext()
                     .getApplicationContext();
@@ -145,8 +146,9 @@ public class WebViewDataTest {
                     .putBoolean(FIRSTRUN_PREF, true)
                     .apply();
 
-            // This test is for webview only. Debug is defaulted to Webview, and Klar is used for GV testing.
-            org.junit.Assume.assumeTrue(!AppConstants.INSTANCE.isGeckoBuild() && !AppConstants.INSTANCE.isKlarBuild());
+            // This test fails permanently on webview, see https://github.com/mozilla-mobile/focus-android/issues/2940")
+            // For now, enable on Klar build only
+            org.junit.Assume.assumeTrue(AppConstants.INSTANCE.isKlarBuild());
 
             webServer = new MockWebServer();
 


### PR DESCRIPTION
This PR enables webview data removal test for Geckoview (Klar)