### PR TITLE
Disable uploading of Focus Release to Nimbledroid

### DIFF
--- a/tools/taskcluster/schedule-master-build.py
+++ b/tools/taskcluster/schedule-master-build.py
@@ -123,7 +123,7 @@ def upload_apk_nimbledroid_task(dependencies):
 		name = "(Focus for Android) Upload Debug APK to Nimbledroid",
 		description = "Upload APKs to Nimbledroid for performance measurement and tracking.",
 		command = ('echo "--" > .adjust_token'
-				   ' && ./gradlew --no-daemon clean assembleFocusArmRelease assembleKlarArmNightly'
+				   ' && ./gradlew --no-daemon clean assembleKlarArmNightly'
 				   ' && python tools/taskcluster/upload_apk_nimbledroid.py'),
 		dependencies = dependencies,
 		scopes = [ 'secrets:get:project/focus/nimbledroid' ],

--- a/tools/taskcluster/upload_apk_nimbledroid.py
+++ b/tools/taskcluster/upload_apk_nimbledroid.py
@@ -35,8 +35,9 @@ def uploadApk(apk,key):
 secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
 data = secrets.get('project/focus/nimbledroid')
 
+# disable focus webview upload until https://github.com/mozilla-mobile/focus-android/issues/3574 is resolved
 klar_file = {'apk': open('app/build/outputs/apk/klarArm/nightly/app-klar-arm-nightly-unsigned.apk')}
-focus_file = {'apk': open('app/build/outputs/apk/focusArm/release/app-focus-arm-release-unsigned.apk')}
+# focus_file = {'apk': open('app/build/outputs/apk/focusArm/release/app-focus-arm-release-unsigned.apk')}
 
 uploadApk(klar_file, data['secret']['api_key'])
-uploadApk(focus_file, data['secret']['api_key'])
+# uploadApk(focus_file, data['secret']['api_key'])


### PR DESCRIPTION
Now with Fretboard, we can't guarantee that Focus Release would use webview as default, so we need to disable uploading of Focus Release to Nimbledroid to collect 'Focus Webview' metric