### PR TITLE
fix #3547 : Keyboard pop up over first run

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -358,6 +358,10 @@ class UrlInputFragment :
     override fun onStart() {
         super.onStart()
 
+        val showFirstRun = activity?.let { Settings.getInstance(it.applicationContext).shouldShowFirstrun() }
+        if (showFirstRun) {
+            return
+        }
         showKeyboard()
     }
 


### PR DESCRIPTION
The Keyboard used to pop up earlier on first run. This patch fixed that issue referenced as #3547 . Now the keyboard pops up only after first run fragment is closed.