### PR TITLE
Use Mozilla Android Components from maven.mozilla.org.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,7 +135,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 repositories {
-    mavenCentral()
     maven {
         //  For the latest version of GeckoView (moving target!):
         //
@@ -184,18 +183,18 @@ dependencies {
     compileOnly 'net.jcip:jcip-annotations:1.0'
     compileOnly "com.github.spotbugs:spotbugs-annotations:$spotbugs_version"
 
-    implementation "org.mozilla.components:session:$mozilla_components_version"
-    implementation "org.mozilla.components:engine:$mozilla_components_version"
-    implementation "org.mozilla.components:telemetry:$mozilla_components_version"
-    implementation "org.mozilla.components:ktx:$mozilla_components_version"
-    implementation "org.mozilla.components:utils:$mozilla_components_version"
-    implementation "org.mozilla.components:domains:$mozilla_components_version"
-    implementation "org.mozilla.components:autocomplete:$mozilla_components_version"
-    implementation "org.mozilla.components:search:$mozilla_components_version"
-    implementation "org.mozilla.photon:colors:$mozilla_components_version"
-    implementation "org.mozilla.components:fretboard:$mozilla_components_version", {
+    implementation "org.mozilla.components:browser-session:$mozilla_components_version"
+    implementation "org.mozilla.components:browser-domains:$mozilla_components_version"
+    implementation "org.mozilla.components:browser-search:$mozilla_components_version"
+    implementation "org.mozilla.components:concept-engine:$mozilla_components_version"
+    implementation "org.mozilla.components:ui-autocomplete:$mozilla_components_version"
+    implementation "org.mozilla.components:ui-colors:$mozilla_components_version"
+    implementation "org.mozilla.components:service-telemetry:$mozilla_components_version"
+    implementation "org.mozilla.components:service-fretboard:$mozilla_components_version", {
         exclude group: 'android.arch.work', module: 'work-runtime'
     }
+    implementation "org.mozilla.components:support-ktx:$mozilla_components_version"
+    implementation "org.mozilla.components:support-utils:$mozilla_components_version"
 
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.geckoview_revision = '33bec02bb81f303b8e3d22586b9e67690e939dbb'
     ext.geckoview_version = '62.0.3.20181001191808' // GeckoView 62 RelBranch from 2018.10.01
     ext.spotbugs_version = '3.1.2'
-    ext.mozilla_components_version = '0.25'
+    ext.mozilla_components_version = '0.26.0'
 
     repositories {
         google()
@@ -49,6 +49,9 @@ detekt {
 allprojects {
     repositories {
         google()
+        maven {
+            url "https://maven.mozilla.org/maven2"
+        }
         jcenter()
     }
 }


### PR DESCRIPTION
This patch uses the latest version of the android components (0.26) and adds
maven.mozilla.org as new repository (new artifact names).

Closes #3505