### PR TITLE
Use new artifact names for Android components from maven.mozilla.org.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -178,16 +178,14 @@ dependencies {
     compileOnly 'net.jcip:jcip-annotations:1.0'
     compileOnly "com.github.spotbugs:spotbugs-annotations:$spotbugs_version"
 
-    implementation "org.mozilla.components:telemetry:$mozilla_components_version"
-    implementation "org.mozilla.components:ktx:$mozilla_components_version"
-    implementation "org.mozilla.components:utils:$mozilla_components_version"
-    implementation "org.mozilla.components:domains:$mozilla_components_version"
-    implementation "org.mozilla.components:autocomplete:$mozilla_components_version"
-    implementation "org.mozilla.components:search:$mozilla_components_version"
-    implementation "org.mozilla.photon:colors:$mozilla_components_version"
-    implementation "org.mozilla.components:fretboard:$mozilla_components_version", {
+    implementation "org.mozilla.components:browser-domains:$mozilla_components_version"
+    implementation "org.mozilla.components:browser-search:$mozilla_components_version"
+    implementation "org.mozilla.components:ui-autocomplete:$mozilla_components_version"
+    implementation "org.mozilla.components:ui-colors:$mozilla_components_version"
+    implementation "org.mozilla.components:service-fretboard:$mozilla_components_version", {
         exclude group: 'android.arch.work', module: 'work-runtime'
     }
+    implementation "org.mozilla.components:service-telemetry:$mozilla_components_version"
     implementation "org.mozilla.components:support-ktx:$mozilla_components_version"
     implementation "org.mozilla.components:support-utils:$mozilla_components_version"
 


### PR DESCRIPTION
Note: This merges to `releases/v7.0`.