### PR TITLE
Bug 1486089 - Enable full Chain of Trust on nightly and github-releases

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -78,9 +78,9 @@ tasks:
             taskclusterProxy: true
           env:
             TASK_ID: {$eval: as_slugid("decision_task")}
-            GITHUB_HEAD_REPO_URL: ${event.repository.clone_url}
-            GITHUB_HEAD_BRANCH: ${event.ref}
-            GITHUB_HEAD_SHA: ${event.after}
+            MOBILE_HEAD_REPOSITORY: ${event.repository.clone_url}
+            MOBILE_HEAD_BRANCH: ${event.ref}
+            MOBILE_HEAD_REV: ${event.after}
           command:
             - /bin/bash
             - --login
@@ -106,68 +106,159 @@ tasks:
 ###############################################################################
   - $if: 'tasks_for == "github-release"'
     then:
-      taskId: {$eval: as_slugid("decision_task")}
-      # The next line won't be needed anymore after https://github.com/taskcluster/taskcluster-github/pull/273
-      taskGroupId: {$eval: as_slugid("decision_task")}
-      created: {$fromNow: ''}
-      deadline: {$fromNow: '2 hours'}
-      expires: {$fromNow: '1 year'}
-      provisionerId: aws-provisioner-v1
-      workerType: gecko-focus   # This workerType has ChainOfTrust enabled
-      scopes:
-        - queue:create-task:aws-provisioner-v1/github-worker
-        - queue:create-task:highest:aws-provisioner-v1/gecko-focus
-        - queue:create-task:highest:scriptworker-prov-v1/mobile-signing-v1
-        - queue:create-task:highest:scriptworker-prov-v1/mobile-pushapk-v1
-        - queue:scheduler-id:taskcluster-github
-        - project:mobile:focus:releng:signing:cert:release-signing
-        - project:mobile:focus:releng:signing:format:focus-jar
-        - project:mobile:focus:releng:googleplay:product:focus
-        - secrets:get:project/focus/tokens
-        - queue:route:index.project.mobile.focus.release.latest
-      payload:
-        maxRunTime: 7200
-        image: mozillamobile/focus-android:1.2
-        features:
-          taskclusterProxy: true
-          chainOfTrust: true
-        env:
-          TASK_ID: {$eval: as_slugid("decision_task")}
-          GITHUB_HEAD_REPO_URL: ${event.repository.clone_url}
-          GITHUB_HEAD_BRANCH: ${event.release.target_commitish}
-          GITHUB_HEAD_SHA: ${event.release.tag_name}
-        command:
-          - /bin/bash
-          - --login
-          - -cx
-          - >-
-            git fetch origin --tags
-            && git config advice.detachedHead false
-            && git checkout ${event.release.tag_name}
-            && python tools/taskcluster/release.py \
-              --tag ${event.release.tag_name} \
-              --track alpha \
-              --commit \
-              --output /opt/focus-android/app/build/outputs/apk \
-              --apk focusX86/release/app-focus-x86-release-unsigned.apk \
-              --apk klarX86/release/app-klar-x86-release-unsigned.apk \
-              --apk focusArm/release/app-focus-arm-release-unsigned.apk \
-              --apk klarArm/release/app-klar-arm-release-unsigned.apk
-        artifacts:
-          public/task-graph.json:
-            type: file
-            path: /opt/focus-android/task-graph.json
-            expires: {$fromNow: '1 year'}
-          public/actions.json:
-            type: file
-            path: /opt/focus-android/actions.json
-            expires: {$fromNow: '1 year'}
-          public/parameters.yml:
-            type: file
-            path: /opt/focus-android/parameters.yml
-            expires: {$fromNow: '1 year'}
-      metadata:
-        name: (Focus for Android) Decision task (${event.release.tag_name})
-        description: Scheduling tasks for releasing Focus/Klar
-        owner: ${event.sender.login}@users.noreply.github.com
-        source: ${event.repository.clone_url}
+      $let:
+        decision_task_id: {$eval: as_slugid("decision_task")}
+        expires_in: {$fromNow: '1 year'}
+        repository: https://github.com/mozilla-mobile/focus-android
+        scheduler_id: taskcluster-github
+      in:
+        taskId: ${decision_task_id}
+        taskGroupId: ${decision_task_id}  # Must be explicit because of Chain of Trust
+        created: {$fromNow: ''}
+        deadline: {$fromNow: '2 hours'}
+        expires: ${expires_in}
+        schedulerId: ${scheduler_id}   # Must be explicit because of Chain of Trust
+        provisionerId: aws-provisioner-v1
+        workerType: gecko-focus   # This workerType has ChainOfTrust enabled
+        requires: all-completed   # Must be explicit because of Chain of Trust
+        priority: highest
+        retries: 5
+        scopes:
+          - queue:scheduler-id:${scheduler_id}
+          - queue:create-task:highest:aws-provisioner-v1/gecko-focus
+          - queue:create-task:highest:scriptworker-prov-v1/mobile-signing-v1
+          - queue:create-task:highest:scriptworker-prov-v1/mobile-pushapk-v1
+          - project:mobile:focus:releng:signing:cert:release-signing
+          - project:mobile:focus:releng:signing:format:focus-jar
+          - project:mobile:focus:releng:googleplay:product:focus
+          - secrets:get:project/focus/tokens
+          - queue:route:index.project.mobile.focus.release.latest
+        payload:
+          maxRunTime: 600   # Decision should remain fast enough to schedule a handful of tasks
+          image: mozillamobile/focus-android:1.2
+          features:
+            taskclusterProxy: true
+            chainOfTrust: true
+          env:
+            TASK_ID: ${decision_task_id}
+            SCHEDULER_ID: ${scheduler_id}
+            MOBILE_HEAD_REPOSITORY: ${repository}
+            MOBILE_HEAD_BRANCH: ${event.release.target_commitish}
+            MOBILE_HEAD_REV: ${event.release.tag_name}
+            MOBILE_TRIGGERED_BY: ${event.sender.login}
+          command:
+            - /bin/bash
+            - --login
+            - -cx
+            - >-
+              git fetch origin --tags
+              && git config advice.detachedHead false
+              && git checkout ${event.release.tag_name}
+              && python tools/taskcluster/release.py \
+                --tag ${event.release.tag_name} \
+                --track alpha \
+                --commit \
+                --output /opt/focus-android/app/build/outputs/apk \
+                --apk focusX86/release/app-focus-x86-release-unsigned.apk \
+                --apk klarX86/release/app-klar-x86-release-unsigned.apk \
+                --apk focusArm/release/app-focus-arm-release-unsigned.apk \
+                --apk klarArm/release/app-klar-arm-release-unsigned.apk
+          artifacts:
+            public/task-graph.json:
+              type: file
+              path: /opt/focus-android/task-graph.json
+              expires: ${expires_in}
+            public/actions.json:
+              type: file
+              path: /opt/focus-android/actions.json
+              expires: ${expires_in}
+            public/parameters.yml:
+              type: file
+              path: /opt/focus-android/parameters.yml
+              expires: ${expires_in}
+        extra:
+            tasks_for: ${tasks_for}
+        metadata:
+          name: (Focus for Android) Decision task (${event.release.tag_name})
+          description: Scheduling tasks for releasing Focus/Klar
+          owner: ${event.sender.login}@users.noreply.github.com
+          source: ${repository}/raw/${event.release.tag_name}/.taskcluster.yml
+# Nighly builds
+  - $if: 'tasks_for == "cron"'
+    then:
+      $let:
+        decision_task_id: {$eval: as_slugid("decision_task")}
+        expires_in: {$fromNow: '1 year'}
+        repository: https://github.com/mozilla-mobile/focus-android
+        scheduler_id: focus-nightly-sched
+      in:
+        taskId: ${decision_task_id}
+        taskGroupId: ${decision_task_id}  # Must be explicit because of Chain of Trust
+        created: {$fromNow: ''}
+        deadline: {$fromNow: '2 hours'}
+        expires: ${expires_in}
+        schedulerId: ${scheduler_id}    # Must be explicit because of Chain of Trust
+        provisionerId: aws-provisioner-v1
+        workerType: gecko-focus   # This workerType has ChainOfTrust enabled
+        requires: all-completed   # Must be explicit because of Chain of Trust
+        priority: medium
+        retries: 5
+        scopes:
+          - queue:scheduler-id:${scheduler_id}
+          - queue:create-task:highest:aws-provisioner-v1/gecko-focus
+          - queue:create-task:highest:scriptworker-prov-v1/mobile-signing-v1
+          - queue:create-task:highest:scriptworker-prov-v1/mobile-pushapk-v1
+          - project:mobile:focus:releng:signing:cert:release-signing
+          - project:mobile:focus:releng:signing:format:focus-jar
+          - project:mobile:focus:releng:googleplay:product:focus
+          - secrets:get:project/focus/tokens
+          - queue:route:index.project.mobile.focus.nightly.latest
+        payload:
+          maxRunTime: 600   # Decision should remain fast enough to schedule a handful of tasks
+          image: mozillamobile/focus-android:1.2
+          features:
+            taskclusterProxy: true
+            chainOfTrust: true
+          env:
+            TASK_ID: ${decision_task_id}
+            SCHEDULER_ID: ${scheduler_id}
+            MOBILE_HEAD_REPOSITORY: ${repository}
+            MOBILE_HEAD_BRANCH: ${event.release.target_commitish}
+            MOBILE_HEAD_REV: ${event.release.tag_name}
+            MOBILE_TRIGGERED_BY: ${event.sender.login}
+          command:
+            - /bin/bash
+            - --login
+            - -cx
+            - >-
+              git fetch origin
+              && git reset --hard origin/master
+              && python tools/taskcluster/release.py \
+                --track nightly \
+                --commit \
+                --output /opt/focus-android/app/build/outputs/apk \
+                --apk klarArm/nightly/app-klar-arm-nightly-unsigned.apk \
+                --apk klarX86/nightly/app-klar-x86-nightly-unsigned.apk \
+                --apk focusArm/nightly/app-focus-arm-nightly-unsigned.apk \
+                --apk focusX86/nightly/app-focus-x86-nightly-unsigned.apk
+          artifacts:
+            public/task-graph.json:
+              type: file
+              path: /opt/focus-android/task-graph.json
+              expires: ${expires_in}
+            public/actions.json:
+              type: file
+              path: /opt/focus-android/actions.json
+              expires: ${expires_in}
+            public/parameters.yml:
+              type: file
+              path: /opt/focus-android/parameters.yml
+              expires: ${expires_in}
+        extra:
+          cron: {$json: {$eval: 'cron'}}
+          tasks_for: ${tasks_for}
+        metadata:
+          name: (Focus for Android) Focus/Klar Nightly Builds (Public)
+          description: Decision task scheduled by cron task [${cron.task_id}](https://tools.taskcluster.net/tasks/${cron.task_id})
+          owner: ${event.sender.login}@users.noreply.github.com
+          source: ${repository}/raw/${event.release.tag_name}/.taskcluster.yml

--- a/tools/taskcluster/lib/tasks.py
+++ b/tools/taskcluster/lib/tasks.py
@@ -7,14 +7,16 @@ import json
 import os
 import taskcluster
 
+
 class TaskBuilder(object):
-    def __init__(self, task_id, repo_url, branch, commit, owner, source):
+    def __init__(self, task_id, repo_url, branch, commit, owner, source, scheduler_id):
         self.task_id = task_id
         self.repo_url = repo_url
         self.branch = branch
         self.commit = commit
         self.owner = owner
         self.source = source
+        self.scheduler_id = scheduler_id
 
     def build_task(self, name, description, command, dependencies = [], artifacts = {}, scopes = [], routes = [], features = {}, worker_type = 'github-worker'):
         created = datetime.datetime.now()
@@ -29,12 +31,12 @@ class TaskBuilder(object):
         return {
             "workerType": worker_type,
             "taskGroupId": self.task_id,
+            "schedulerId": self.scheduler_id,
             "expires": taskcluster.stringDate(expires),
             "retries": 5,
             "created": taskcluster.stringDate(created),
             "tags": {},
             "priority": "lowest",
-            "schedulerId": "taskcluster-github",
             "deadline": taskcluster.stringDate(deadline),
             "dependencies": [ self.task_id ] + dependencies,
             "routes": routes,
@@ -71,12 +73,12 @@ class TaskBuilder(object):
         return {
             "workerType": 'mobile-signing-v1',
             "taskGroupId": self.task_id,
+            "schedulerId": self.scheduler_id,
             "expires": taskcluster.stringDate(expires),
             "retries": 5,
             "created": taskcluster.stringDate(created),
             "tags": {},
             "priority": "lowest",
-            "schedulerId": "taskcluster-github",
             "deadline": taskcluster.stringDate(deadline),
             "dependencies": [ self.task_id, build_task_id],
             "routes": routes,
@@ -112,12 +114,12 @@ class TaskBuilder(object):
         return {
             "workerType": 'mobile-pushapk-v1',
             "taskGroupId": self.task_id,
+            "schedulerId": self.scheduler_id,
             "expires": taskcluster.stringDate(expires),
             "retries": 5,
             "created": taskcluster.stringDate(created),
             "tags": {},
             "priority": "lowest",
-            "schedulerId": "taskcluster-github",
             "deadline": taskcluster.stringDate(deadline),
             "dependencies": [ self.task_id, signing_task_id],
             "routes": [],

--- a/tools/taskcluster/release.py
+++ b/tools/taskcluster/release.py
@@ -15,14 +15,17 @@ import taskcluster
 import lib.tasks
 
 TASK_ID = os.environ.get('TASK_ID')
+SCHEDULER_ID = os.environ.get('SCHEDULER_ID')
+HEAD_REV = os.environ.get('MOBILE_HEAD_REV')
 
 BUILDER = lib.tasks.TaskBuilder(
     task_id=TASK_ID,
-    repo_url=os.environ.get('GITHUB_HEAD_REPO_URL'),
-    branch=os.environ.get('GITHUB_HEAD_BRANCH'),
-    commit=os.environ.get('GITHUB_HEAD_SHA'),
+    repo_url=os.environ.get('MOBILE_HEAD_REPOSITORY'),
+    branch=os.environ.get('MOBILE_HEAD_BRANCH'),
+    commit=HEAD_REV,
     owner="skaspari@mozilla.com",
-    source="https://github.com/mozilla-mobile/focus-android/tree/master/tools/taskcluster"
+    source='https://github.com/mozilla-mobile/focus-android/raw/{}/.taskcluster.yml'.format(HEAD_REV),
+    scheduler_id=SCHEDULER_ID,
 )
 
 def generate_build_task(apks, tag):

--- a/tools/taskcluster/schedule-master-build.py
+++ b/tools/taskcluster/schedule-master-build.py
@@ -13,10 +13,13 @@ import json
 import taskcluster
 import os
 
+from lib.tasks import schedule_task
+
+
 TASK_ID = os.environ.get('TASK_ID')
-REPO_URL = os.environ.get('GITHUB_HEAD_REPO_URL')
-BRANCH = os.environ.get('GITHUB_HEAD_BRANCH')
-COMMIT = os.environ.get('GITHUB_HEAD_SHA')
+REPO_URL = os.environ.get('MOBILE_HEAD_REPOSITORY')
+BRANCH = os.environ.get('MOBILE_HEAD_BRANCH')
+COMMIT = os.environ.get('MOBILE_HEAD_REV')
 OWNER = "skaspari@mozilla.com"
 SOURCE = "https://github.com/mozilla-mobile/focus-android/tree/master/tools/taskcluster"
 
@@ -172,14 +175,6 @@ def generate_task(name, description, command, dependencies = [], artifacts = {},
 			"source": SOURCE
 		}
 	}
-
-
-def schedule_task(queue, taskId, task):
-	print "TASK", taskId
-	print json.dumps(task, indent=4, separators=(',', ': '))
-
-	result = queue.createTask(taskId, task)
-	print json.dumps(result)
 
 
 if __name__ == "__main__":

--- a/tools/taskcluster/schedule-nightly-graph.py
+++ b/tools/taskcluster/schedule-nightly-graph.py
@@ -1,0 +1,84 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import datetime
+import jsone
+import pipes
+import yaml
+import os
+import slugid
+import taskcluster
+
+from git import Repo
+from lib.tasks import schedule_task
+
+ROOT = os.path.join(os.path.dirname(__file__), '../..')
+
+
+def calculate_branch_and_head_rev(root):
+    repo = Repo(root)
+    branch = repo.head.reference
+    return str(branch), str(branch.commit)
+
+
+def make_decision_task(params):
+    """Generate a basic decision task, based on the root .taskcluster.yml"""
+    with open(os.path.join(ROOT, '.taskcluster.yml'), 'rb') as f:
+        taskcluster_yml = yaml.safe_load(f)
+
+    slugids = {}
+
+    def as_slugid(name):
+        if name not in slugids:
+            slugids[name] = slugid.nice()
+        return slugids[name]
+
+    # provide a similar JSON-e context to what taskcluster-github provides
+    context = {
+        'tasks_for': 'cron',
+        'cron': {
+            'task_id': params['cron_task_id'],
+        },
+        'now': datetime.datetime.utcnow().isoformat()[:23] + 'Z',
+        'as_slugid': as_slugid,
+        'event': {
+            'repository': {
+                'clone_url': params['repository_url'],
+            },
+            'release': {
+                'tag_name': params['head_rev'],
+                'target_commitish': params['branch'],
+            },
+            'sender': {
+                'login': 'TaskclusterHook'
+            },
+        },
+    }
+
+    rendered = jsone.render(taskcluster_yml, context)
+    if len(rendered['tasks']) != 1:
+        raise Exception("Expected .taskcluster.yml to only produce one cron task")
+    task = rendered['tasks'][0]
+
+    task_id = task.pop('taskId')
+    return (task_id, task)
+
+
+if __name__ == "__main__":
+    queue = taskcluster.Queue({ 'baseUrl': 'http://taskcluster/queue/v1' })
+
+    branch, head_rev = calculate_branch_and_head_rev(ROOT)
+
+    params = {
+        'repository_url': 'https://github.com/mozilla-mobile/focus-android'
+        'head_rev': head_rev,
+        'branch': branch,
+        'cron_task_id': os.environ.get('CRON_TASK_ID', '<cron_task_id>')
+    }
+    decisionTaskId, decisionTask = make_decision_task(params)
+    schedule_task(queue, decisionTaskId, decisionTask)
+    print('All scheduled!')


### PR DESCRIPTION
**:warning: Please don't merge if I'm not around to see how releases go. This may break them** (even though, I tested these changes thoroughly against my fork):

* Fake release: https://github.com/JohanLorenzo/focus-android/releases/tag/v99.20 https://tools.taskcluster.net/groups/IgIJ3WhLT8OttJN0y7ZA0A/tasks/Qol4_SHFTDeXcIw_7Un8Aw/details
* Fake nightly: https://tools.taskcluster.net/groups/JEvgbzMRSxeyedR_WNUu8g/tasks/JEvgbzMRSxeyedR_WNUu8g/ https://tools.taskcluster.net/groups/IgIJ3WhLT8OttJN0y7ZA0A/tasks/Qol4_SHFTDeXcIw_7Un8Aw/details 

I ran `verify_cot --task-type signing --cleanup --cot-product mobile -- ${SIGNING_TASK_ID}` to check them out. `verify_cot` is a CLI tool in the scriptworker repo.

## What do these changes do?

### Trace nightly/release graphs back to repo
It enables [scriptworker](https://github.com/mozilla-releng/scriptworker) (meaning the signing and the push-apk workers) to trace a task back to the `focus-android` repo. Before then, there was [a special instruction](https://github.com/mozilla-releng/scriptworker/pull/264/files#diff-340a1f42e56ecb68f523d2badfa58686L1218) which skipped it. 

### Nightly hook doesn't spin a decision task anymore
As a consequence of the point, the nightly graph can't be fully defined in [the hook](https://tools.taskcluster.net/hooks/project-mobile/focus-nightly-public) anymore. This means the hook now just reads `.taskcluster.yml` and schedules a decision task as if it were `taskcluster-github`. This way, scriptworker can compare the decision task with what's defined in-tree. Scriptworker doesn't look back at the hook because the definition of the decision task is checked against the `focus-android` repo. If someone hacked the way the hook work, he/she would have to inject a commit somewhere on the main repo (including branches outside of `master`)


r? @pocmo @csadilek 