### PR TITLE
Fix Queue args after taskcluster 5.0.0 breaking API release.

### DIFF
--- a/tools/taskcluster/release.py
+++ b/tools/taskcluster/release.py
@@ -120,7 +120,7 @@ def populate_chain_of_trust_required_but_unused_files():
 
 
 def release(apks, track, commit, tag):
-    queue = taskcluster.Queue({ 'baseUrl': 'http://taskcluster/queue/v1' })
+    queue = taskcluster.Queue(options={ 'rootUrl': 'http://taskcluster/queue/v1' })
 
     task_graph = {}
 

--- a/tools/taskcluster/schedule-master-build.py
+++ b/tools/taskcluster/schedule-master-build.py
@@ -183,7 +183,7 @@ def schedule_task(queue, taskId, task):
 
 
 if __name__ == "__main__":
-	queue = taskcluster.Queue({ 'baseUrl': 'http://taskcluster/queue/v1' })
+	queue = taskcluster.Queue(options={ 'rootUrl': 'http://taskcluster/queue/v1' })
 
 	buildTaskId, buildTask = generate_build_task()
 	schedule_task(queue, buildTaskId, buildTask)

--- a/tools/taskcluster/schedule-screenshots.py
+++ b/tools/taskcluster/schedule-screenshots.py
@@ -86,8 +86,8 @@ def chunks(locales, n):
 if __name__ == "__main__":
 	print "Task:", TASK_ID
 
-	queue = taskcluster.Queue({
-		'baseUrl': 'http://taskcluster/queue/v1'
+	queue = taskcluster.Queue(options={
+		'rootUrl': 'http://taskcluster/queue/v1'
 	})
 
 	for chunk in chunks(SCREENSHOT_LOCALES, LOCALES_PER_TASK):


### PR DESCRIPTION
As @JohanLorenzo mentioned, most likely the Docker image bumped [here](https://github.com/mozilla-mobile/focus-android/pull/3621/files#diff-ac0229d1171c0983b27003af4c7441a5R23) introduced the `taskcluster-client.py` bump as well to `5.0.0` which had breaking API changes within its last release (https://pypi.org/project/taskcluster/). We faced the same issues in `android-components` and we fixed them [here](https://github.com/mozilla-mobile/android-components/pull/993/files). 

If we can confirm the Dockerfile bumped the `taskcluster` I think we're safe to merge this and fix the CI taskcluster issues.