### PR TITLE
Fix Taskcluster rootUrl

### DIFF
--- a/tools/taskcluster/release.py
+++ b/tools/taskcluster/release.py
@@ -120,7 +120,7 @@ def populate_chain_of_trust_required_but_unused_files():
 
 
 def release(apks, track, commit, tag):
-    queue = taskcluster.Queue(options={ 'rootUrl': 'http://taskcluster/queue/v1' })
+    queue = taskcluster.Queue(options={ 'rootUrl': 'https://taskcluster' })
 
     task_graph = {}
 

--- a/tools/taskcluster/schedule-master-build.py
+++ b/tools/taskcluster/schedule-master-build.py
@@ -183,7 +183,7 @@ def schedule_task(queue, taskId, task):
 
 
 if __name__ == "__main__":
-	queue = taskcluster.Queue(options={ 'rootUrl': 'http://taskcluster/queue/v1' })
+	queue = taskcluster.Queue(options={ 'rootUrl': 'https://taskcluster' })
 
 	buildTaskId, buildTask = generate_build_task()
 	schedule_task(queue, buildTaskId, buildTask)

--- a/tools/taskcluster/schedule-screenshots.py
+++ b/tools/taskcluster/schedule-screenshots.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
 	print "Task:", TASK_ID
 
 	queue = taskcluster.Queue(options={
-		'rootUrl': 'http://taskcluster/queue/v1'
+		'rootUrl': 'https://taskcluster'
 	})
 
 	for chunk in chunks(SCREENSHOT_LOCALES, LOCALES_PER_TASK):


### PR DESCRIPTION
Based on https://github.com/mozilla-mobile/android-components/commit/fd0d3b1f8039d97a9cf7c4f13da7ea471b28c076#diff-0a857cfaa87b74898a918a88177112e4R200, the url shouldn't contain `queue/v1`. I didn't put `.net` because tasks talk to the Queue via the TC-proxy. In the previous link, the task doesn't have to use the TC-proxy because it only accesses read-only data. 

Follow #3649