### PR TITLE
Fix API url for taskcluster-client calls.

### DIFF
--- a/tools/taskcluster/release.py
+++ b/tools/taskcluster/release.py
@@ -120,7 +120,7 @@ def populate_chain_of_trust_required_but_unused_files():
 
 
 def release(apks, track, commit, tag):
-    queue = taskcluster.Queue(options={ 'rootUrl': 'https://taskcluster' })
+    queue = taskcluster.Queue(options={ 'rootUrl': 'https://taskcluster.net' })
 
     task_graph = {}
 

--- a/tools/taskcluster/schedule-master-build.py
+++ b/tools/taskcluster/schedule-master-build.py
@@ -183,7 +183,7 @@ def schedule_task(queue, taskId, task):
 
 
 if __name__ == "__main__":
-	queue = taskcluster.Queue(options={ 'rootUrl': 'https://taskcluster' })
+	queue = taskcluster.Queue(options={ 'rootUrl': 'https://taskcluster.net' })
 
 	buildTaskId, buildTask = generate_build_task()
 	schedule_task(queue, buildTaskId, buildTask)

--- a/tools/taskcluster/schedule-screenshots.py
+++ b/tools/taskcluster/schedule-screenshots.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
 	print "Task:", TASK_ID
 
 	queue = taskcluster.Queue(options={
-		'rootUrl': 'https://taskcluster'
+		'rootUrl': 'https://taskcluster.net'
 	})
 
 	for chunk in chunks(SCREENSHOT_LOCALES, LOCALES_PER_TASK):


### PR DESCRIPTION
Follow-up PR fix after https://github.com/mozilla-mobile/focus-android/pull/3649, https://github.com/mozilla-mobile/focus-android/pull/3653 and https://github.com/mozilla-mobile/focus-android/pull/3654