### PR TITLE
Fixes #3625: Crash when saving custom search engine

### DIFF
--- a/app/src/main/java/org/mozilla/focus/search/RadioSearchEngineListPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/search/RadioSearchEngineListPreference.kt
@@ -37,7 +37,8 @@ class RadioSearchEngineListPreference : SearchEngineListPreference, RadioGroup.O
 
         /* onCheckedChanged is called intermittently before the search engine table is full, so we
            must check these conditions to prevent crashes and inconsistent states. */
-        if (group.childCount != searchEngines.count() || !group.getChildAt(checkedId).isPressed) {
+        if (group.childCount != searchEngines.count() || group.getChildAt(checkedId) == null ||
+                !group.getChildAt(checkedId).isPressed) {
             return
         }
 


### PR DESCRIPTION
This crash occurred because onCheckedChanged was being called with the largest index (including the new engine) before the searchEngines list was retrieved (after a save), which caused an out of bounds crash.