### PR TITLE
Fixes #3624: Application restarts when interrupted

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,7 +67,7 @@
         </activity>
 
         <activity android:name=".activity.MainActivity"
-            android:launchMode="singleTask"
+            android:launchMode="singleTop"
             android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout"
             android:windowSoftInputMode="adjustResize|stateAlwaysHidden"
             android:label="@string/app_name">

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -48,6 +48,13 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        if (!isTaskRoot) {
+            if (intent.hasCategory(Intent.CATEGORY_LAUNCHER) && Intent.ACTION_MAIN == intent.action) {
+                finish()
+                return
+            }
+        }
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             SentryWrapper.init(this)
         }

--- a/app/src/main/java/org/mozilla/focus/activity/TextActionActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/TextActionActivity.kt
@@ -26,11 +26,7 @@ class TextActionActivity : Activity() {
         val intent = SafeIntent(intent)
 
         val searchTextCharSequence = intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)
-        val searchText = if (searchTextCharSequence != null) {
-            searchTextCharSequence.toString()
-        } else {
-            ""
-        }
+        val searchText = searchTextCharSequence?.toString() ?: ""
 
         val searchUrl = UrlUtils.createSearchUrl(this, searchText)
 
@@ -38,6 +34,7 @@ class TextActionActivity : Activity() {
         searchIntent.action = Intent.ACTION_VIEW
         searchIntent.putExtra(EXTRA_TEXT_SELECTION, true)
         searchIntent.data = Uri.parse(searchUrl)
+        searchIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
 
         startActivity(searchIntent)
 


### PR DESCRIPTION
Here's a better fix which handles the launcher action, but doesn't mess with alternate intents to open the app.