### PR TITLE
Fix zh-CN locale correction

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/LocaleListPreference.java
+++ b/app/src/main/java/org/mozilla/focus/widget/LocaleListPreference.java
@@ -202,8 +202,8 @@ public class LocaleListPreference extends ListPreference {
 
             if (languageCodeToNameMap.containsKey(locale.getLanguage())) {
                 displayName = languageCodeToNameMap.get(locale.getLanguage());
-            } else if (localeToNameMap.containsKey(locale.getCountry())) {
-                displayName = localeToNameMap.get(locale.getCountry());
+            } else if (localeToNameMap.containsKey(locale.toLanguageTag())) {
+                displayName = localeToNameMap.get(locale.toLanguageTag());
             } else {
                 displayName = locale.getDisplayName(locale);
             }


### PR DESCRIPTION
I noticed this issue while addressing a crash spotted in LocaleListPreference. The locale to name map is not correctly matching by the locale tag.