### PR TITLE
Resolve TravisCI issues

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,10 @@
+pluginManagement {
+    repositories {
+        google()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+}
+
 include ':app'


### PR DESCRIPTION
Travis CI is looking for Google plugins on jcenter and failing. Set an explicit plugin resolution order.