### PR TITLE
Closes #3759: Add notify to Master build, UI tests

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -68,6 +68,8 @@ tasks:
         deadline: {$fromNow: '2 hours'}
         provisionerId: aws-provisioner-v1
         workerType: github-worker
+        routes:
+          - 'notify.irc-channel.#android-ci.on-any'
         scopes:
           - queue:create-task:aws-provisioner-v1/github-worker
           - queue:scheduler-id:taskcluster-github

--- a/tools/taskcluster/execute-firebase-tests.sh
+++ b/tools/taskcluster/execute-firebase-tests.sh
@@ -105,7 +105,7 @@ test_targets=$(echo "${test_targets}" | sed '$!s~$~\\~g')
 sed "s/TEST_TARGETS/${test_targets}/g" $FLANK_CONF_TEMPLATE > $FLANK_CONF
 rm -f TEST_TARGETS
 $JAVA_BIN -jar $FLANK_BIN android run --config=$FLANK_CONF
-cp -r "$PATH_TOOLS/results" "$WORKDIR/test_artifacts"
+cp -r "$WORKDIR/results" "$WORKDIR/test_artifacts"
 
 exitcode=$?
 


### PR DESCRIPTION
Closes #3759 
also, fix for "cp: cannot stat '/opt/focus-android/tools/taskcluster/results': No such file or directory"
per flank folks, results get deposited into the CWD