### PR TITLE
Use clientID for Fretboard

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -50,7 +50,6 @@ import java.util.Locale
 object TelemetryWrapper {
     private const val TELEMETRY_APP_NAME_FOCUS = "Focus"
     private const val TELEMETRY_APP_NAME_KLAR = "Klar"
-    private const val TELEMETRY_APP_ENGINE_GECKOVIEW = "GeckoView"
     private const val LAST_MOBILE_METRICS_PINGS = "LAST_MOBILE_METRICS_PINGS"
 
     private val dateFormat = SimpleDateFormat("yyyyMMdd", Locale.US)
@@ -245,9 +244,7 @@ object TelemetryWrapper {
                     .setSettingsProvider(TelemetrySettingsProvider(context))
                     .setCollectionEnabled(telemetryEnabled)
                     .setUploadEnabled(telemetryEnabled)
-                    .setBuildId(TelemetryConfiguration(context).buildId +
-                    (if (AppConstants.isGeckoBuild)
-                        ("-$TELEMETRY_APP_ENGINE_GECKOVIEW") else ""))
+                    .setBuildId(TelemetryConfiguration(context).buildId)
 
             val serializer = JSONPingSerializer()
             val storage = FileTelemetryStorage(configuration, serializer)
@@ -258,12 +255,13 @@ object TelemetryWrapper {
                     .addPingBuilder(TelemetryCorePingBuilder(configuration))
                     .addPingBuilder(TelemetryEventPingBuilder(configuration))
                     .setDefaultSearchProvider(createDefaultSearchProvider(context)))
-
-            TelemetryWrapper.recordActiveExperiments(context)
         } finally {
             StrictMode.setThreadPolicy(threadPolicy)
         }
     }
+
+    val clientId: String
+        get() = TelemetryHolder.get().clientId
 
     private fun createDefaultSearchProvider(context: Context): DefaultSearchMeasurement.DefaultSearchEngineProvider {
         return DefaultSearchMeasurement.DefaultSearchEngineProvider {


### PR DESCRIPTION
Fretboard currently generates its own ID for bucketing users. We want to use the Telemetry client ID instead. This also requires breaking dependencies between the two.