### PR TITLE
Closes #3753 - Show Option to Open in Focus in Custom Tab Context Menu

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -492,7 +492,7 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
             override fun onRequestDesktopStateChanged(shouldRequestDesktop: Boolean) {}
 
             override fun onLongPress(hitTarget: IWebView.HitTarget) {
-                WebContextMenu.show(requireActivity(), this, hitTarget)
+                WebContextMenu.show(requireActivity(), this, hitTarget, session)
             }
 
             override fun onEnterFullScreen(callback: IWebView.FullscreenCallback, view: View?) {

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -628,6 +628,19 @@ object TelemetryWrapper {
     }
 
     @JvmStatic
+    fun openLinkInFullBrowserFromCustomTabEvent() {
+        withSessionCounts(
+            TelemetryEvent.create(
+                Category.ACTION,
+                Method.OPEN,
+                Object.BROWSER_CONTEXTMENU,
+                Value.FULL_BROWSER
+            )
+        )
+            .queue()
+    }
+
+    @JvmStatic
     fun openWebContextMenuEvent() {
         TelemetryEvent.create(Category.ACTION, Method.LONG_PRESS, Object.BROWSER).queue()
     }

--- a/app/src/main/res/menu/menu_browser_context.xml
+++ b/app/src/main/res/menu/menu_browser_context.xml
@@ -10,6 +10,9 @@
         android:id="@+id/menu_new_tab"
         android:title="@string/contextmenu_open_in_new_tab" />
     <item
+        android:id="@+id/menu_open_in_focus"
+        android:title="@string/menu_open_with_default_browser2" />
+    <item
         android:id="@+id/menu_link_share"
         android:title="@string/contextmenu_link_share" />
     <item


### PR DESCRIPTION
Added a telem probe for this new action so will have to get data review. What do we think about possibly adding two differentiated actions to the menu - something like  "Open now in Focus", and "Send link to Focus in background". I went with the "Open now in Focus" approach so send the link and intent to open Focus to view the new link immediately, but I'm realizing maybe that's not desired behavior for every situation. Pinging @brampitoyo for UX feedback