### PR TITLE
Closes #3754 - Only Select Normal Browsing Sessions

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -104,7 +104,9 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
     private fun registerSessionObserver() {
         components.sessionManager.register(object : SessionManager.Observer {
             override fun onSessionSelected(session: Session) {
-                showBrowserScreenForCurrentSession()
+                if (!session.isCustomTabSession()) {
+                    showBrowserScreenForCurrentSession()
+                }
             }
 
             override fun onAllSessionsRemoved() {


### PR DESCRIPTION
This fixes the problem I was seeing, but not sure if we will ever need to `showBrowserScreenForCurrentSession` on selection of a custom tab? I couldn't think of a case where we would have to since custom tabs don't have multitasking. Maybe someone from A-C can sanity check this fix? 