### PR TITLE
Add co, nv, sn, zh-HK to l10n.toml

### DIFF
--- a/l10n.toml
+++ b/l10n.toml
@@ -18,6 +18,7 @@ locales = [
   "bs",
   "ca",
   "cak",
+  "co",
   "cs",
   "cy",
   "da",
@@ -67,6 +68,7 @@ locales = [
   "ne-NP",
   "nl",
   "nn-NO",
+  "nv",
   "oc",
   "pa-IN",
   "pai",
@@ -79,6 +81,7 @@ locales = [
   "ru",
   "sk",
   "sl",
+  "sn",
   "sq",
   "sr",
   "su",
@@ -97,6 +100,7 @@ locales = [
   "yua",
   "zam",
   "zh-CN",
+  "zh-HK",
   "zh-TW",
   ]
 [env]


### PR DESCRIPTION
We landed a couple of new localizations, but they're not in the l10n.toml config yet.

CC @Delphine @pocmo 

Commits that added the locales are

https://github.com/mozilla-mobile/focus-android/commit/23eed95f9d281aba47ce20e9ad9fbce1fe1eb479
https://github.com/mozilla-mobile/focus-android/commit/cd83c0b26602924f023eeb63d833df7d46dba703
