### PR TITLE
Closes #3754 - Remove SessionManager Hack With AC 31

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -107,9 +107,7 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
     private fun registerSessionObserver() {
         components.sessionManager.register(object : SessionManager.Observer {
             override fun onSessionSelected(session: Session) {
-                if (!session.isCustomTabSession()) {
-                    showBrowserScreenForCurrentSession()
-                }
+                showBrowserScreenForCurrentSession()
             }
 
             override fun onAllSessionsRemoved() {


### PR DESCRIPTION
We shouldn't need this check anymore, and according to the AC team, this check could cause other issues.