### PR TITLE
Update compare-locales to recent major version, stop using l10n_base in config

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -34,7 +34,7 @@ tasks:
             && echo "--" > .adjust_token
             && python tools/l10n/check_locales.py
             && ./gradlew --no-daemon clean assembleFocusX86Debug assembleKlarX86Nightly assembleRelease detektCheck ktlint lintFocusX86Debug lintKlarX86Nightly pmd checkstyle spotbugs assembleFocusX86DebugAndroidTest testFocusX86DebugUnitTest testKlarX86NightlyUnitTest
-            && pip install "compare-locales>=4.0.1,<5.0"
+            && pip install "compare-locales>=5.0.2,<6.0"
             && compare-locales --validate l10n.toml .
         artifacts:
           public:

--- a/l10n.toml
+++ b/l10n.toml
@@ -107,4 +107,4 @@ locales = [
 
 [[paths]]
   reference = "app/src/main/res/values/strings.xml"
-  l10n = "{l10n_base}/app/src/main/res/values-{android_locale}/strings.xml"
+  l10n = "app/src/main/res/values-{android_locale}/strings.xml"

--- a/tools/taskcluster/schedule-master-build.py
+++ b/tools/taskcluster/schedule-master-build.py
@@ -53,7 +53,7 @@ def generate_compare_locales_task():
     return taskcluster.slugId(), generate_task(
         name="(Focus for Android) String validation",
         description="Check Focus/Klar for Android for errors in en-US and l10n.",
-        command=('pip install "compare-locales>=4.0.1,<5.0"'
+        command=('pip install "compare-locales>=5.0.2,<6.0"'
                  ' && mkdir -p /opt/focus-android/test_artifacts'
                  ' && compare-locales --validate l10n.toml .'
                  ' && compare-locales --json=/opt/focus-android/test_artifacts/data.json l10n.toml .'),
@@ -189,4 +189,3 @@ if __name__ == "__main__":
 
     uploadNDTaskId, uploadNDTask = upload_apk_nimbledroid_task([unitTestTaskId, codeQualityTaskId])
     schedule_task(queue, uploadNDTaskId, uploadNDTask)
-


### PR DESCRIPTION
l10n_base is actually in the way of creating a l10n-only cross-product repo,
it turns out. It's not really needed for Android projects anyway, removing it.