### PR TITLE
Fixes #4015 - Adds bo, sn and co to production locales

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/LocaleListPreference.java
+++ b/app/src/main/java/org/mozilla/focus/widget/LocaleListPreference.java
@@ -67,6 +67,7 @@ public class LocaleListPreference extends ListPreference {
         languageCodeToNameMap.put("su", "Basa Sunda");
         languageCodeToNameMap.put("hus", "Tének");
         languageCodeToNameMap.put("co", "Corsu");
+        languageCodeToNameMap.put("sn", "ChiShona");
     }
     static {
         // Override the native name for certain locale regions based on language community needs.

--- a/tools/l10n/android2po/env.py
+++ b/tools/l10n/android2po/env.py
@@ -205,6 +205,12 @@ MISSING_LOCALES = {
         'local_name': 'Corsu',
         'plural_rule': 'pt',
         'team': 'anp <LL@li.org>\n'
+    },
+    'sn': {
+        'name': 'Shona',
+        'local_name': 'ChiShona',
+        'plural_rule': 'az',
+        'team': 'anp <LL@li.org>\n'
     }
 }
 

--- a/tools/l10n/locales.py
+++ b/tools/l10n/locales.py
@@ -31,9 +31,11 @@ RELEASE_LOCALES = [
 	"bg",
 	"bn-BD",
 	"bn-IN",
+	"bo",
 	"bs",
 	"ca",
 	"cak",
+	"co",
 	"cs",
 	"cy",
 	"da",
@@ -94,6 +96,7 @@ RELEASE_LOCALES = [
 	"ru",
 	"sk",
 	"sl",
+	"sn",
 	"sq",
 	"sr",
 	"sv-SE",
@@ -122,12 +125,9 @@ RELEASE_LOCALES = [
 
 ADDITIONAL_SCREENSHOT_LOCALES = [
 	"jv",
-	"bo",
 	"ace",
 	"zh-HK",
-	"nv",
-	"sn",
-	"co"
+	"nv"
 ]
 
 # Those are locales that we take automated screenshots of.


### PR DESCRIPTION
@Delphine All these locales already existed in `l10n.toml`. Is there anything else we have to do