### PR TITLE
WIP #4017: Display adblock onboarding card for existing users after update

### DIFF
--- a/app/src/main/java/org/mozilla/focus/firstrun/FirstrunPagerAdapter.kt
+++ b/app/src/main/java/org/mozilla/focus/firstrun/FirstrunPagerAdapter.kt
@@ -31,13 +31,12 @@ class FirstrunPagerAdapter(
 
     init {
         val appName = context.getString(R.string.app_name)
+        val shortAppName = appName.replaceBefore(" ", "")
 
         if (isUpdateRun) {
-            // TODO: Don't show skip button
-            // TODO:
             this.pages = arrayOf(FirstrunPage(
-                    context.getString(R.string.firstrun_defaultbrowser_title),
-                    context.getString(R.string.firstrun_defaultbrowser_text2),
+                    context.getString(R.string.block_ads_card_title, shortAppName),
+                    context.getString(R.string.block_ads_card_description),
                     R.drawable.onboarding_img1))
         } else {
             this.pages = arrayOf(
@@ -76,8 +75,10 @@ class FirstrunPagerAdapter(
 
         val buttonView: Button = view.findViewById(R.id.button)
         buttonView.setOnClickListener(listener)
-        if (position == pages.size - 1) {
-            buttonView.setText(R.string.firstrun_close_button)
+
+        if (position == pages.size - 1 ) {
+            if (isUpdateRun) buttonView.setText(R.string.action_ok) else
+                buttonView.setText(R.string.firstrun_close_button)
             buttonView.id = R.id.finish
             buttonView.contentDescription = buttonView.text.toString().toLowerCase()
         } else {

--- a/app/src/main/java/org/mozilla/focus/firstrun/FirstrunPagerAdapter.kt
+++ b/app/src/main/java/org/mozilla/focus/firstrun/FirstrunPagerAdapter.kt
@@ -19,7 +19,8 @@ import org.mozilla.focus.R
 
 class FirstrunPagerAdapter(
     private val context: Context,
-    private val listener: View.OnClickListener
+    private val listener: View.OnClickListener,
+    private val isUpdateRun: Boolean
 ) : PagerAdapter() {
 
     private data class FirstrunPage(val title: String, val text: String, val imageResource: Int) {
@@ -30,23 +31,33 @@ class FirstrunPagerAdapter(
 
     init {
         val appName = context.getString(R.string.app_name)
-        this.pages = arrayOf(
-                FirstrunPage(
-                        context.getString(R.string.firstrun_defaultbrowser_title),
-                        context.getString(R.string.firstrun_defaultbrowser_text2),
-                        R.drawable.onboarding_img1),
-                FirstrunPage(
-                        context.getString(R.string.firstrun_search_title),
-                        context.getString(R.string.firstrun_search_text),
-                        R.drawable.onboarding_img4),
-                FirstrunPage(
-                        context.getString(R.string.firstrun_shortcut_title),
-                        context.getString(R.string.firstrun_shortcut_text, appName),
-                        R.drawable.onboarding_img3),
-                FirstrunPage(
-                        context.getString(R.string.firstrun_privacy_title),
-                        context.getString(R.string.firstrun_privacy_text, appName),
-                        R.drawable.onboarding_img2))
+
+        if (isUpdateRun) {
+            // TODO: Don't show skip button
+            // TODO:
+            this.pages = arrayOf(FirstrunPage(
+                    context.getString(R.string.firstrun_defaultbrowser_title),
+                    context.getString(R.string.firstrun_defaultbrowser_text2),
+                    R.drawable.onboarding_img1))
+        } else {
+            this.pages = arrayOf(
+                    FirstrunPage(
+                            context.getString(R.string.firstrun_defaultbrowser_title),
+                            context.getString(R.string.firstrun_defaultbrowser_text2),
+                            R.drawable.onboarding_img1),
+                    FirstrunPage(
+                            context.getString(R.string.firstrun_search_title),
+                            context.getString(R.string.firstrun_search_text),
+                            R.drawable.onboarding_img4),
+                    FirstrunPage(
+                            context.getString(R.string.firstrun_shortcut_title),
+                            context.getString(R.string.firstrun_shortcut_text, appName),
+                            R.drawable.onboarding_img3),
+                    FirstrunPage(
+                            context.getString(R.string.firstrun_privacy_title),
+                            context.getString(R.string.firstrun_privacy_text, appName),
+                            R.drawable.onboarding_img2))
+        }
     }
 
     private fun getView(position: Int, pager: ViewPager): View {

--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
@@ -12,6 +12,7 @@ import android.support.design.widget.TabLayout
 import android.support.v4.app.Fragment
 import android.support.v4.view.ViewPager
 import android.transition.TransitionInflater
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -27,7 +28,7 @@ import org.mozilla.focus.utils.StatusBarUtils
 class FirstrunFragment : Fragment(), View.OnClickListener {
 
     private var viewPager: ViewPager? = null
-
+    private val isUpdateRun: Boolean? = null
     private var background: View? = null
 
     override fun onAttach(context: Context?) {
@@ -50,7 +51,16 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
 
         background = view.findViewById(R.id.background)
 
-        val adapter = FirstrunPagerAdapter(container!!.context, this)
+        val isUpdateRun = arguments!!.getBoolean(IS_UPDATE_RUN)
+
+        val adapter: FirstrunPagerAdapter?
+
+        if (isUpdateRun) {
+            // Set the custom pages:
+            adapter = FirstrunPagerAdapter(container!!.context, this, true)
+        } else {
+            adapter = FirstrunPagerAdapter(container!!.context, this, false)
+        }
 
         viewPager = view.findViewById(R.id.pager)
         viewPager!!.contentDescription = adapter.getPageAccessibilityDescription(0)
@@ -111,6 +121,10 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
             .edit()
             .putBoolean(FIRSTRUN_PREF, true)
             .apply()
+        PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .edit()
+                .putBoolean(FIRSTRUNUPDATE_PREF, true)
+                .apply()
 
         val sessionUUID = arguments!!.getString(ARGUMENT_SESSION_UUID)
         val sessionManager = requireContext().components.sessionManager
@@ -147,14 +161,17 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
     companion object {
         const val FRAGMENT_TAG = "firstrun"
         const val FIRSTRUN_PREF = "firstrun_shown"
+        const val FIRSTRUNUPDATE_PREF = "firstrunupdate_show"
 
+        private const val IS_UPDATE_RUN = "isUpdateRun"
         private const val ARGUMENT_SESSION_UUID = "sessionUUID"
 
-        fun create(currentSession: Session?): FirstrunFragment {
+        fun create(currentSession: Session?, isUpdateRun: Boolean = false): FirstrunFragment {
             val uuid = currentSession?.id
 
             val arguments = Bundle()
             arguments.putString(ARGUMENT_SESSION_UUID, uuid)
+            arguments.putBoolean(IS_UPDATE_RUN, isUpdateRun)
 
             val fragment = FirstrunFragment()
             fragment.arguments = arguments

--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
@@ -16,7 +16,9 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import kotlinx.android.synthetic.main.firstrun_page.*
+import kotlinx.android.synthetic.main.fragment_firstrun.*
 import kotlinx.android.synthetic.main.fragment_urlinput.*
 import mozilla.components.browser.session.Session
 import org.mozilla.focus.R
@@ -28,7 +30,6 @@ import org.mozilla.focus.utils.StatusBarUtils
 class FirstrunFragment : Fragment(), View.OnClickListener {
 
     private var viewPager: ViewPager? = null
-    private val isUpdateRun: Boolean? = null
     private var background: View? = null
 
     override fun onAttach(context: Context?) {
@@ -52,15 +53,10 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
         background = view.findViewById(R.id.background)
 
         val isUpdateRun = arguments!!.getBoolean(IS_UPDATE_RUN)
+        val adapter = FirstrunPagerAdapter(container!!.context, this, isUpdateRun)
 
-        val adapter: FirstrunPagerAdapter?
-
-        if (isUpdateRun) {
-            // Set the custom pages:
-            adapter = FirstrunPagerAdapter(container!!.context, this, true)
-        } else {
-            adapter = FirstrunPagerAdapter(container!!.context, this, false)
-        }
+        val skipButton = view.findViewById<Button>(R.id.skip)
+        if (isUpdateRun) skipButton.visibility = View.INVISIBLE else View.VISIBLE
 
         viewPager = view.findViewById(R.id.pager)
         viewPager!!.contentDescription = adapter.getPageAccessibilityDescription(0)

--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
@@ -83,15 +83,6 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
         val tabLayout = view.findViewById<TabLayout>(R.id.tabs)
         tabLayout.setupWithViewPager(viewPager, true)
 
-
-        blockAdsSwitch.setOnCheckedChangeListener { _, isChecked ->
-            if (isChecked) {
-                // TODO: Make pink blockAdsSwitch.trackTintList =
-                // TODO: Handle preference change
-            } else {
-                // TODO: Make grey
-            }
-        }
         return view
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
@@ -15,6 +15,8 @@ import android.transition.TransitionInflater
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import kotlinx.android.synthetic.main.firstrun_page.*
+import kotlinx.android.synthetic.main.fragment_urlinput.*
 import mozilla.components.browser.session.Session
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
@@ -81,6 +83,15 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
         val tabLayout = view.findViewById<TabLayout>(R.id.tabs)
         tabLayout.setupWithViewPager(viewPager, true)
 
+
+        blockAdsSwitch.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                // TODO: Make pink blockAdsSwitch.trackTintList =
+                // TODO: Handle preference change
+            } else {
+                // TODO: Make grey
+            }
+        }
         return view
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -172,6 +172,15 @@ class UrlInputFragment :
         arguments?.getString(ARGUMENT_SESSION_UUID)?.let { id ->
             session = requireComponents.sessionManager.findSessionById(id)
         }
+
+        if (arguments?.getString(ARGUMENT_SESSION_UUID) == null) {
+            if (Settings.getInstance(context!!).shouldShowFirstRunUpdateCard()) {
+                fragmentManager
+                        ?.beginTransaction()
+                        ?.add(R.id.container, FirstrunFragment.create(session, true), FirstrunFragment.FRAGMENT_TAG)
+                        ?.commit()
+            }
+        }
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -18,6 +18,7 @@ import android.text.SpannableString
 import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
 import android.text.style.ForegroundColorSpan
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -221,6 +222,7 @@ class UrlInputFragment :
         val context = context ?: return
         val tip = TipManager.getNextTipIfAvailable(context)
         updateSubtitle(tip)
+        updateSwitch(tip)
     }
 
     private fun updateSubtitle(tip: Tip?) {
@@ -259,6 +261,19 @@ class UrlInputFragment :
         }
 
         homeViewTipsLabel.text = textWithDeepLink
+    }
+
+    private fun updateSwitch(tip: Tip?) {
+        if (tip == null || tip.preferenceKey == null) {
+            homeViewTipSwitch.visibility = View.INVISIBLE
+            return
+        }
+
+        homeViewTipSwitch.visibility = View.VISIBLE
+        homeViewTipSwitch.setOnCheckedChangeListener { _, isChecked ->
+            //TODO: Set the preference identified in tip.preferenceKey
+            Log.d("homeViewTip", "isChecked: " + isChecked)
+        }
     }
 
     private fun showFocusSubtitle() {

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -174,12 +174,12 @@ class UrlInputFragment :
         }
 
         if (arguments?.getString(ARGUMENT_SESSION_UUID) == null) {
-            if (Settings.getInstance(context!!).shouldShowFirstRunUpdateCard()) {
+            //if (Settings.getInstance(context!!).shouldShowFirstRunUpdateCard()) {
                 fragmentManager
                         ?.beginTransaction()
                         ?.add(R.id.container, FirstrunFragment.create(session, true), FirstrunFragment.FRAGMENT_TAG)
                         ?.commit()
-            }
+            //}
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
+++ b/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
@@ -19,6 +19,8 @@ import org.mozilla.focus.R.string.tip_explain_allowlist
 import org.mozilla.focus.R.string.tip_open_in_new_tab
 import org.mozilla.focus.R.string.tip_request_desktop
 import org.mozilla.focus.R.string.tip_set_default_browser
+import org.mozilla.focus.R.string.tip_block_ads
+import org.mozilla.focus.R.string.preference_privacy_block_ads
 import org.mozilla.focus.exceptions.ExceptionDomains
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.locale.LocaleAwareAppCompatActivity
@@ -30,7 +32,8 @@ import org.mozilla.focus.utils.isInExperiment
 import org.mozilla.focus.utils.Browsers
 import java.util.Random
 
-class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val deepLink: (() -> Unit)? = null) {
+class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val deepLink: (() -> Unit)? = null,
+          val preferenceKey: Int? = null) {
     companion object {
         private const val FORCE_SHOW_DISABLE_TIPS_LAUNCH_COUNT = 2
         private const val FORCE_SHOW_DISABLE_TIPS_INTERVAL = 30
@@ -191,6 +194,19 @@ class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val d
 
             return Tip(id, name, shouldDisplayDisableTips, deepLinkDisableTips)
         }
+
+        fun createBlockAdsTip(context: Context): Tip {
+            val id = tip_block_ads
+            val name = context.resources.getString(id)
+
+            val shouldDisplayBlockAdsTip = {
+                // TODO: Check ad block toggle
+                //!Settings.getInstance(context).hasToggledAdBlocking()
+                true
+            }
+
+            return Tip(id, name, shouldDisplayBlockAdsTip, null, preference_privacy_block_ads)
+        }
     }
 }
 
@@ -205,6 +221,7 @@ object TipManager {
     private var tipsShown = 0
 
     private fun populateListOfTips(context: Context) {
+        /*
         addAllowlistTip(context)
         addTrackingProtectionTip(context)
         addHomescreenTip(context)
@@ -213,12 +230,14 @@ object TipManager {
         addOpenInNewTabTip(context)
         addRequestDesktopTip(context)
         addDisableTipsTip(context)
+        */
+        addBlockAdsTip(context)
     }
 
     // Will not return a tip if tips are disabled or if MAX TIPS have already been shown.
     @Suppress("ReturnCount") // Using early returns
     fun getNextTipIfAvailable(context: Context): Tip? {
-        if (!context.isInExperiment(homeScreenTipsExperimentDescriptor)) return null
+        //if (!context.isInExperiment(homeScreenTipsExperimentDescriptor)) return null
         if (!Settings.getInstance(context).shouldDisplayHomescreenTips()) return null
 
         if (!listInitialized) {
@@ -295,6 +314,11 @@ object TipManager {
 
     private fun addDisableTipsTip(context: Context) {
         val tip = Tip.createDisableTipsTip(context)
+        listOfTips.add(tip)
+    }
+
+    private fun addBlockAdsTip(context: Context) {
+        val tip = Tip.createBlockAdsTip(context)
         listOfTips.add(tip)
     }
 }

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -103,6 +103,9 @@ class Settings private constructor(context: Context) {
     fun shouldShowFirstrun(): Boolean =
             !preferences.getBoolean(FirstrunFragment.FIRSTRUN_PREF, false)
 
+    fun shouldShowFirstRunUpdateCard(): Boolean =
+            !preferences.getBoolean(FirstrunFragment.FIRSTRUNUPDATE_PREF, false)
+
     fun isFirstGeckoRun(): Boolean =
             preferences.getBoolean(GeckoWebViewProvider.PREF_FIRST_GECKO_RUN, true)
 

--- a/app/src/main/res/layout/firstrun_page.xml
+++ b/app/src/main/res/layout/firstrun_page.xml
@@ -3,6 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:cardview="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -70,6 +71,19 @@
                         android:textColor="#ff737373"
                         android:textSize="14sp"
                         tools:text="@string/firstrun_tracking_text" />
+
+                    <android.support.v7.widget.SwitchCompat
+                        android:id="@+id/blockAdsSwitch"
+                        android:text="@string/block_ads_title"
+                        android:textColor="#ff737373"
+                        android:layout_gravity="center"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="20dp"
+                        android:layout_marginBottom="20dp"
+                        app:thumbTint="#EDEDF0"
+                        app:trackTint="@color/photonMagenta70"
+                        app:switchPadding="20dp"/>
 
                     <View
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_urlinput.xml
+++ b/app/src/main/res/layout/fragment_urlinput.xml
@@ -39,6 +39,14 @@
             android:textSize="14sp"
             android:focusable="false" />
 
+        <Switch
+            android:id="@+id/homeViewTipSwitch"
+            android:text="@string/block_ads_title"
+            android:switchPadding="20dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"/>
+
     </org.mozilla.focus.widget.ResizableKeyboardLinearLayout>
 
     <FrameLayout android:id="@+id/urlInputLayout"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -561,6 +561,12 @@ be temporary, and you can try again later.</li>
     <string name="firstrun_skip_button">Skip</string>
     <string name="firstrun_next_button">Next</string>
 
+    <!-- Title for intro card shown to users after updating. %1$s will be replaced with the name of the app (e.g. Firefox Focus) -->
+    <string name="block_ads_card_title">%1$s is ready to block ads</string>
+
+    <!-- Description for intro card shown to users after updating. -->
+    <string name="block_ads_card_description">New feature! Browse faster by stopping ads and code that follow you around the web.</string>
+
     <!-- Indicator that no trackers are being blocked because content blocking is disabled; normally shows the number of blocked trackers -->
     <string name="content_blocking_disabled">-</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -774,6 +774,12 @@ be temporary, and you can try again later.</li>
         Allowlist disables Tracking Protection for sites you know and trust.
     </string>
 
+    <!-- Tip displayed on home view explaining ad blocking -->
+    <string name="tip_block_ads">Browse faster by stopping ads and code that follows you around the web.</string>
+
+    <!-- Title for a switch that enables or disables ads -->
+    <string name="block_ads_title">Ad blocking</string>
+
     <!-- Label for the snackbar when a user opens a new tab -->
     <string name="new_tab_opened_snackbar">New tab opened</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -540,7 +540,7 @@ be temporary, and you can try again later.</li>
     <!-- First run tour (Default browser): Title -->
     <string name="firstrun_defaultbrowser_title">Power up your privacy</string>
     <!-- First run tour (Default browser): Text. -->
-    <string name="firstrun_defaultbrowser_text2">Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times.</string>
+    <string name="firstrun_defaultbrowser_text2">Block content like ads and code that follow you around the web and slow you down. Turn on ad blocking to browse faster without annoying ads.</string>
 
     <!-- First run tour (Search): Title -->
     <string name="firstrun_search_title">Your search, your way</string>


### PR DESCRIPTION
This should be the last of the three adblock onboarding PR's to be merged.

_Note: this is waiting on the actual adblock preference, but all other UI/logic is complete_

<img width=300 src=https://user-images.githubusercontent.com/4400286/49963514-3599b880-fee6-11e8-9239-eb944bf0f795.png>


