### PR TITLE
Fixes #4041: Removes long label from erase&open

### DIFF
--- a/app/src/focusBeta/res/xml-v25/shortcuts.xml
+++ b/app/src/focusBeta/res/xml-v25/shortcuts.xml
@@ -21,7 +21,7 @@
       android:enabled="true"
       android:icon="@drawable/ic_shortcut_erase"
       android:shortcutShortLabel="@string/shortcut_erase_and_open_short_label"
-      android:shortcutLongLabel="@string/shortcut_erase_and_open_long_label">
+      android:shortcutLongLabel="@string/shortcut_erase_and_open_short_label">
     <intent
         android:action="erase"
         android:targetPackage="org.mozilla.focus.beta"

--- a/app/src/focusDebug/res/xml-v25/shortcuts.xml
+++ b/app/src/focusDebug/res/xml-v25/shortcuts.xml
@@ -21,7 +21,7 @@
       android:enabled="true"
       android:icon="@drawable/ic_shortcut_erase"
       android:shortcutShortLabel="@string/shortcut_erase_and_open_short_label"
-      android:shortcutLongLabel="@string/shortcut_erase_and_open_long_label">
+      android:shortcutLongLabel="@string/shortcut_erase_and_open_short_label">
     <intent
         android:action="erase"
         android:targetPackage="org.mozilla.focus.debug"

--- a/app/src/focusNightly/res/xml-v25/shortcuts.xml
+++ b/app/src/focusNightly/res/xml-v25/shortcuts.xml
@@ -21,7 +21,7 @@
       android:enabled="true"
       android:icon="@drawable/ic_shortcut_erase"
       android:shortcutShortLabel="@string/shortcut_erase_and_open_short_label"
-      android:shortcutLongLabel="@string/shortcut_erase_and_open_long_label">
+      android:shortcutLongLabel="@string/shortcut_erase_and_open_short_label">
     <intent
         android:action="erase"
         android:targetPackage="org.mozilla.focus"

--- a/app/src/focusRelease/res/xml-v25/shortcuts.xml
+++ b/app/src/focusRelease/res/xml-v25/shortcuts.xml
@@ -21,7 +21,7 @@
       android:enabled="true"
       android:icon="@drawable/ic_shortcut_erase"
       android:shortcutShortLabel="@string/shortcut_erase_and_open_short_label"
-      android:shortcutLongLabel="@string/shortcut_erase_and_open_long_label">
+      android:shortcutLongLabel="@string/shortcut_erase_and_open_short_label">
     <intent
         android:action="erase"
         android:targetPackage="org.mozilla.focus"

--- a/app/src/klarDebug/res/xml-v25/shortcuts.xml
+++ b/app/src/klarDebug/res/xml-v25/shortcuts.xml
@@ -21,7 +21,7 @@
       android:enabled="true"
       android:icon="@drawable/ic_shortcut_erase"
       android:shortcutShortLabel="@string/shortcut_erase_and_open_short_label"
-      android:shortcutLongLabel="@string/shortcut_erase_and_open_long_label">
+      android:shortcutLongLabel="@string/shortcut_erase_and_open_short_label">
     <intent
         android:action="erase"
         android:targetPackage="org.mozilla.klar.debug"

--- a/app/src/klarNightly/res/xml-v25/shortcuts.xml
+++ b/app/src/klarNightly/res/xml-v25/shortcuts.xml
@@ -21,7 +21,7 @@
       android:enabled="true"
       android:icon="@drawable/ic_shortcut_erase"
       android:shortcutShortLabel="@string/shortcut_erase_and_open_short_label"
-      android:shortcutLongLabel="@string/shortcut_erase_and_open_long_label">
+      android:shortcutLongLabel="@string/shortcut_erase_and_open_short_label">
     <intent
         android:action="erase"
         android:targetPackage="org.mozilla.klar"

--- a/app/src/klarRelease/res/xml-v25/shortcuts.xml
+++ b/app/src/klarRelease/res/xml-v25/shortcuts.xml
@@ -21,7 +21,7 @@
       android:enabled="true"
       android:icon="@drawable/ic_shortcut_erase"
       android:shortcutShortLabel="@string/shortcut_erase_and_open_short_label"
-      android:shortcutLongLabel="@string/shortcut_erase_and_open_long_label">
+      android:shortcutLongLabel="@string/shortcut_erase_and_open_short_label">
     <intent
         android:action="erase"
         android:targetPackage="org.mozilla.klar"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,12 +108,6 @@
          This is the label for this shortcut. Android recommends a maximum length of 10 characters. -->
     <string name="shortcut_erase_and_open_short_label">Erase &amp; open</string>
 
-    <!-- The same as 'shortcut_erase_short_label' but more descriptive. The launcher shows this
-         instead of the short title when it has enough space. Android recommends a maximum length
-         of 25 characters.
-         %1$s will be replaced by the app name (e.g. Firefox Focus) -->
-    <string name="shortcut_erase_and_open_long_label">Erase and open %1$s</string>
-
 
     <!-- This is the label of an action we offer when the user selects text in other third-party apps.
          Clicking this action will launch Focus and perform a search in the default search engine. -->


### PR DESCRIPTION
Since we're creating these labels entirely in XML, there isn't an easy way for us to insert the name of the app into the long label (which is resulting in the placeholder text still appearing for end users). I think just using the short label is sufficient since users will know which app icon they're taking the shortcut action on.