### PR TITLE
Do not trigger any Taskcluster job on tags

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -49,6 +49,7 @@ tasks:
 # Task: Builds on branches of the main repo
 #
 # Triggered whenever something is pushed/merged to the mozilla-mobile repo.
+# Tags (which are considered to be pushes) are ignored.
 #
 # Creates the following task pipeline:
 #
@@ -58,7 +59,7 @@ tasks:
 ###############################################################################
   - $if: 'tasks_for == "github-push"'
     then:
-      $if: 'event.repository.fork == false'
+      $if: 'event.repository.fork == false && event.ref[:10] != "refs/tags/"'
       then:
         taskId: {$eval: as_slugid("decision_task")}
         # The next line won't be needed anymore after https://github.com/taskcluster/taskcluster-github/pull/273
@@ -107,7 +108,7 @@ tasks:
 ###############################################################################
 # Task: Release builds
 #
-# Triggered when a new tag or release is published (in any branch)
+# Triggered when a new GitHub release is created (in any branch)
 #
 # - Builds release versions of Focus and Klar
 # - Signs the builds with the release key


### PR DESCRIPTION
Fixes messages like https://github.com/mozilla-mobile/focus-android/commit/9c55b33eb69e8c1ab9567e9e50bc59917ae21994#commitcomment-31671535 and confusion like what happened yesterday:

```
23:02:02 UTC <ColinTheShots>  How do I find the available hooks? I'm wondering if there's a hook to trigger a Focus release build.
23:03:36 UTC <bstack> ColinTheShots: https://tools.taskcluster.net/hooks
23:38:22 UTC <ColinTheShots> Thanks! I don't see the hook I need, but it looks like I can re-trigger the old build.
23:41:40 UTC <aki> ColinTheShots: https://github.com/mozilla-mobile/focus-android/blob/master/.taskcluster.yml#L108-L110 looks like it needs a tag or release
23:42:13 UTC <ColinTheShots> Oh, of course. That makes sense.
23:46:26 UTC <ColinTheShots> TaskCluster seems to be getting insufficient scopes... https://github.com/mozilla-mobile/focus-android/commit/b0f53d7af10227f5780095dfc9cda01e0ef478f1
23:47:13 UTC <aki> hm, i wonder which task that is
23:49:04 UTC <aki> it looks like https://tools.taskcluster.net/auth/roles/repo%3Agithub.com%2Fmozilla-mobile%2Ffocus-android%3Abranch%3A* has those scopes, but i'm guessing we're using https://tools.taskcluster.net/auth/roles/repo%3Agithub.com%2Fmozilla-mobile%2Ffocus-android%3Arelease
23:50:22 UTC <aki> i don't have perms to add those 2 scopes
[...]
```

What really happened yesterday is:
1. https://github.com/mozilla-mobile/focus-android/releases/tag/v8.0-RC9 was created
2. 2 different GitHub events were triggered: the [release event](https://developer.github.com/v3/activity/events/types/#releaseevent) and a **[push event](https://developer.github.com/v3/activity/events/types/#pushevent)** because Github pushed a new tag to the repo. These 2 events are [interpreted by Taskcluster-Github](https://docs.taskcluster.net/docs/reference/integrations/taskcluster-github/docs/taskcluster-yml-v1#json-e-rendering)
3. The release event kicked off [these tasks](https://tools.taskcluster.net/groups/XPEDpDrDRbmjUgjm09rU8A). The build task hanged for an unknown reason (which is unrelated to the current fix). These are the only tasks that matter.
4. The push event failed because we didn't specify any scopes for tags events. 

Therefore, let's just kill the tag event, like [described here](https://docs.taskcluster.net/docs/reference/integrations/taskcluster-github/docs/taskcluster-yml-v1#tags)