### PR TITLE
String import 20181221-120908

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -60,7 +60,7 @@
   <string name="preference_autocomplete_action_add">+ Ajouter une adresse personnalisée</string>
   <string name="preference_autocomplete_title_add">Ajouter une adresse personnalisée</string>
   <string name="custom_autocomplete_quick_add">Ajouter une adresse personnalisée</string>
-  <string name="add_custom_autocomplete_label">Ajouter un lien à la saisie semi-automatique</string>
+  <string name="add_custom_autocomplete_label">Ajouter le lien à la saisie semi-automatique</string>
   <string name="preference_category_cookies">Cookies et données de sites</string>
   <string name="preference_category_data_choices">Données collectées</string>
   <string name="preference_autocomplete_title_remove">Supprimer des adresses personnalisées</string>
@@ -85,10 +85,10 @@
   <string name="preference_privacy_block_social_summary">Ils sont insérés sur certains sites pour pister vos visites et afficher des fonctionnalités comme des boutons de partage</string>
   <string name="preference_privacy_block_content">Bloquer les autres traqueurs de contenu</string>
   <string name="preference_privacy_block_content_summary2">Activer cette option peut provoquer des problèmes sur certaines pages</string>
-  <string name="preference_privacy_category_cookies">Interdire les cookies</string>
+  <string name="preference_privacy_category_cookies">Bloquer les cookies</string>
   <string name="preference_privacy_should_block_cookies_no_option">Non</string>
   <string name="preference_privacy_should_block_cookies_third_party_tracker_cookies_option">Bloquer uniquement les cookies tiers utilisés pour le pistage</string>
-  <string name="preference_privacy_should_block_cookies_third_party_only_option">Interdire les cookies tiers uniquement</string>
+  <string name="preference_privacy_should_block_cookies_third_party_only_option">Bloquer les cookies tiers uniquement</string>
   <string name="preference_privacy_should_block_cookies_yes_option">Oui</string>
   <string name="preference_security_biometric">Utiliser une empreinte digitale pour déverrouiller l’application</string>
   <string name="preference_security_biometric_summary">Votre empreinte digitale peut déverrouiller %1$s si une URL est déjà ouverte au sein de l’application. Le mode furtif sera activé.</string>

--- a/app/src/main/res/values-jv/strings.xml
+++ b/app/src/main/res/values-jv/strings.xml
@@ -30,6 +30,7 @@
   <string name="shortcut_erase_long_label">Busak riwayat dlajahan</string>
   <string name="shortcut_erase_and_open_short_label">Busak &amp; bukak</string>
   <string name="shortcut_erase_and_open_long_label">Busak lan bukak %1$s</string>
+  <string name="preference_privacy_and_security_header">Privasi &amp; Kaamanan</string>
   <string name="preference_mozilla_summary">Ngenani %1$s, pitulung</string>
   <string name="preference_category_web_content">Kontèn Wèb</string>
   <string name="preference_category_switching_apps">Ganti aplikasi</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -87,8 +87,8 @@
   <string name="preference_privacy_block_content_summary2">Aktivering kan leda till att vissa sidor uppträder oväntat</string>
   <string name="preference_privacy_category_cookies">Blockera kakor</string>
   <string name="preference_privacy_should_block_cookies_no_option">Nej</string>
-  <string name="preference_privacy_should_block_cookies_third_party_tracker_cookies_option">Blockera endast tredjepartspårarkakor</string>
-  <string name="preference_privacy_should_block_cookies_third_party_only_option">Blockera endast tredjepartskakor</string>
+  <string name="preference_privacy_should_block_cookies_third_party_tracker_cookies_option">Blockera endast spårningskakor från tredje part</string>
+  <string name="preference_privacy_should_block_cookies_third_party_only_option">Blockera endast kakor från tredje part</string>
   <string name="preference_privacy_should_block_cookies_yes_option">Ja</string>
   <string name="preference_security_biometric">Använd fingeravtryck för att låsa upp appen</string>
   <string name="preference_security_biometric_summary">Ditt fingeravtryck kan låsa upp %1$s om en webbadress redan har öppnats i appen. Dolt läge kommer att slås på.</string>


### PR DESCRIPTION

Automated import 20181221-120908

Log:
```
     [mkdir] app/src/main/res/values-zh-TW
   [created] app/src/main/res/values-zh-TW/strings.xml
     [mkdir] app/src/main/res/values-pa-IN
   [created] app/src/main/res/values-pa-IN/strings.xml
 [unchanged] app/src/main/res/values-gl/strings.xml
     [mkdir] app/src/main/res/values-ne-NP
   [created] app/src/main/res/values-ne-NP/strings.xml
 [unchanged] app/src/main/res/values-lo/strings.xml
 [unchanged] app/src/main/res/values-tt/strings.xml
 [unchanged] app/src/main/res/values-tr/strings.xml
 [unchanged] app/src/main/res/values-lt/strings.xml
 [unchanged] app/src/main/res/values-tsz/strings.xml
 [unchanged] app/src/main/res/values-th/strings.xml
 [unchanged] app/src/main/res/values-te/strings.xml
 [unchanged] app/src/main/res/values-ta/strings.xml
     [mkdir] app/src/main/res/values-bn-IN
   [created] app/src/main/res/values-bn-IN/strings.xml
 [unchanged] app/src/main/res/values-de/strings.xml
 [unchanged] app/src/main/res/values-da/strings.xml
     [mkdir] app/src/main/res/values-pt-BR
   [created] app/src/main/res/values-pt-BR/strings.xml
     [mkdir] app/src/main/res/values-nb-NO
   [created] app/src/main/res/values-nb-NO/strings.xml
     [mkdir] app/src/main/res/values-gu-IN
   [created] app/src/main/res/values-gu-IN/strings.xml
     [mkdir] app/src/main/res/values-ga-IE
   [created] app/src/main/res/values-ga-IE/strings.xml
     [mkdir] app/src/main/res/values-es-CL
   [created] app/src/main/res/values-es-CL/strings.xml
 [unchanged] app/src/main/res/values-trs/strings.xml
 [unchanged] app/src/main/res/values-el/strings.xml
 [unchanged] app/src/main/res/values-eo/strings.xml
     [mkdir] app/src/main/res/values-zh-HK
   [created] app/src/main/res/values-zh-HK/strings.xml
 [unchanged] app/src/main/res/values-eu/strings.xml
     [mkdir] app/src/main/res/values-sv-SE
   [created] app/src/main/res/values-sv-SE/strings.xml
 [unchanged] app/src/main/res/values-ru/strings.xml
 [unchanged] app/src/main/res/values-quy/strings.xml
 [unchanged] app/src/main/res/values-ro/strings.xml
 [unchanged] app/src/main/res/values-dsb/strings.xml
 [unchanged] app/src/main/res/values-hsb/strings.xml
 [unchanged] app/src/main/res/values-bg/strings.xml
 [unchanged] app/src/main/res/values-ms/strings.xml
 [unchanged] app/src/main/res/values-ast/strings.xml
 [unchanged] app/src/main/res/values-wo/strings.xml
   [updated] app/src/main/res/values-jv/strings.xml
 [unchanged] app/src/main/res/values-bo/strings.xml
 [unchanged] app/src/main/res/values-meh/strings.xml
 [unchanged] app/src/main/res/values-quc/strings.xml
 [unchanged] app/src/main/res/values-bs/strings.xml
 [unchanged] app/src/main/res/values-ja/strings.xml
 [unchanged] app/src/main/res/values-ace/strings.xml
     [mkdir] app/src/main/res/values-es-AR
   [created] app/src/main/res/values-es-AR/strings.xml
 [unchanged] app/src/main/res/values-oc/strings.xml
     [mkdir] app/src/main/res/values-nn-NO
   [created] app/src/main/res/values-nn-NO/strings.xml
     [mkdir] app/src/main/res/values-fy-NL
   [created] app/src/main/res/values-fy-NL/strings.xml
 [unchanged] app/src/main/res/values-yua/strings.xml
             - "error_hostLookup_message" contains invalid XHTML (Opening and ending tag mismatch: strong line 3 and li, line 4, column 48 (line 4)); Falling back to loose parser.
 [unchanged] app/src/main/res/values-zam/strings.xml
 [unchanged] app/src/main/res/values-co/strings.xml
 [unchanged] app/src/main/res/values-ca/strings.xml
 [unchanged] app/src/main/res/values-ppl/strings.xml
 [unchanged] app/src/main/res/values-cy/strings.xml
 [unchanged] app/src/main/res/values-cs/strings.xml
     [mkdir] app/src/main/res/values-en-CA
   [created] app/src/main/res/values-en-CA/strings.xml
 [unchanged] app/src/main/res/values-ixl/strings.xml
     [mkdir] app/src/main/res/values-hi-IN
   [created] app/src/main/res/values-hi-IN/strings.xml
 [unchanged] app/src/main/res/values-pl/strings.xml
 [unchanged] app/src/main/res/values-hr/strings.xml
 [unchanged] app/src/main/res/values-hu/strings.xml
 [unchanged] app/src/main/res/values-hus/strings.xml
 [unchanged] app/src/main/res/values-iw/strings.xml
 [unchanged] app/src/main/res/values-ur/strings.xml
 [unchanged] app/src/main/res/values-cak/strings.xml
     [mkdir] app/src/main/res/values-zh-CN
   [created] app/src/main/res/values-zh-CN/strings.xml
 [unchanged] app/src/main/res/values-uk/strings.xml
 [unchanged] app/src/main/res/values-mr/strings.xml
 [unchanged] app/src/main/res/values-my/strings.xml
 [unchanged] app/src/main/res/values-af/strings.xml
 [unchanged] app/src/main/res/values-vi/strings.xml
 [unchanged] app/src/main/res/values-am/strings.xml
 [unchanged] app/src/main/res/values-it/strings.xml
 [unchanged] app/src/main/res/values-an/strings.xml
 [unchanged] app/src/main/res/values-ay/strings.xml
 [unchanged] app/src/main/res/values-ar/strings.xml
 [unchanged] app/src/main/res/values-anp/strings.xml
     [mkdir] app/src/main/res/values-bn-BD
   [created] app/src/main/res/values-bn-BD/strings.xml
 [unchanged] app/src/main/res/values-ia/strings.xml
 [unchanged] app/src/main/res/values-az/strings.xml
     [mkdir] app/src/main/res/values-es-ES
   [created] app/src/main/res/values-es-ES/strings.xml
 [unchanged] app/src/main/res/values-in/strings.xml
 [unchanged] app/src/main/res/values-sr/strings.xml
 [unchanged] app/src/main/res/values-nl/strings.xml
 [unchanged] app/src/main/res/values-mix/strings.xml
 [unchanged] app/src/main/res/values-pai/strings.xml
 [unchanged] app/src/main/res/values-nv/strings.xml
 [unchanged] app/src/main/res/values-kab/strings.xml
   [updated] app/src/main/res/values-fr/strings.xml
 [unchanged] app/src/main/res/values-fa/strings.xml
 [unchanged] app/src/main/res/values-fi/strings.xml
 [unchanged] app/src/main/res/values-ka/strings.xml
 [unchanged] app/src/main/res/values-kk/strings.xml
     [mkdir] app/src/main/res/values-hy-AM
   [created] app/src/main/res/values-hy-AM/strings.xml
 [unchanged] app/src/main/res/values-sq/strings.xml
 [unchanged] app/src/main/res/values-ko/strings.xml
 [unchanged] app/src/main/res/values-su/strings.xml
     [mkdir] app/src/main/res/values-es-MX
   [created] app/src/main/res/values-es-MX/strings.xml
 [unchanged] app/src/main/res/values-sk/strings.xml
 [unchanged] app/src/main/res/values-kw/strings.xml
 [unchanged] app/src/main/res/values-sn/strings.xml
             - "error_connectionfailure_message" contains invalid XHTML (expected '>', line 3, column 136 (line 3)); Falling back to loose parser.
 [unchanged] app/src/main/res/values-sl/strings.xml
Fixing ./values-sv-SE -> ./values-sv-rSE
Fixing ./values-nb-NO -> ./values-nb-rNO
Fixing ./values-gu-IN -> ./values-gu-rIN
Fixing ./values-pt-BR -> ./values-pt-rBR
Fixing ./values-fy-NL -> ./values-fy-rNL
Fixing ./values-pa-IN -> ./values-pa-rIN
Fixing ./values-bn-BD -> ./values-bn-rBD
Fixing ./values-hy-AM -> ./values-hy-rAM
Fixing ./values-bn-IN -> ./values-bn-rIN
Fixing ./values-zh-CN -> ./values-zh-rCN
Fixing ./values-ga-IE -> ./values-ga-rIE
Fixing ./values-en-CA -> ./values-en-rCA
Fixing ./values-es-CL -> ./values-es-rCL
Fixing ./values-nn-NO -> ./values-nn-rNO
Fixing ./values-zh-HK -> ./values-zh-rHK
Fixing ./values-es-ES -> ./values-es-rES
Fixing ./values-es-AR -> ./values-es-rAR
Fixing ./values-zh-TW -> ./values-zh-rTW
Fixing ./values-ne-NP -> ./values-ne-rNP
Fixing ./values-hi-IN -> ./values-hi-rIN
Fixing ./values-es-MX -> ./values-es-rMX
Checking for placeholders in translation files...
Warning: * [values-tr/strings.xml] number of placeholders not matching, key: your_rights_content5
Warning: * [values-pl/strings.xml] number of placeholders not matching, key: firstrun_shortcut_text
Warning: * [values-eo/strings.xml] number of placeholders not matching, key: firstrun_shortcut_text

```
