### PR TITLE
Handle malformed URLs without crashing

### DIFF
--- a/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -5,6 +5,7 @@
 
 package org.mozilla.focus
 
+import android.content.Context
 import android.os.StrictMode
 import android.support.v7.preference.PreferenceManager
 import kotlinx.coroutines.CoroutineScope
@@ -16,6 +17,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import mozilla.components.service.fretboard.Fretboard
+import mozilla.components.service.fretboard.ValuesProvider
 import mozilla.components.service.fretboard.source.kinto.KintoExperimentSource
 import mozilla.components.service.fretboard.storage.flatfile.FlatFileExperimentStorage
 import mozilla.components.support.base.log.Log
@@ -96,7 +98,12 @@ class FocusApplication : LocaleAwareApplication(), CoroutineScope {
         val experimentSource = KintoExperimentSource(
             EXPERIMENTS_BASE_URL, EXPERIMENTS_BUCKET_NAME, EXPERIMENTS_COLLECTION_NAME
         )
-        fretboard = Fretboard(experimentSource, FlatFileExperimentStorage(experimentsFile))
+        fretboard = Fretboard(experimentSource, FlatFileExperimentStorage(experimentsFile),
+            object : ValuesProvider() {
+                override fun getClientId(context: Context): String {
+                    return TelemetryWrapper.clientId
+                }
+            })
         fretboard.loadExperiments()
         WebViewProvider.determineEngine(this@FocusApplication)
     }

--- a/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -12,10 +12,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeoutOrNull
 import mozilla.components.service.fretboard.Fretboard
 import mozilla.components.service.fretboard.ValuesProvider
 import mozilla.components.service.fretboard.source.kinto.KintoExperimentSource
@@ -47,10 +44,6 @@ class FocusApplication : LocaleAwareApplication(), CoroutineScope {
     override val coroutineContext: CoroutineContext
         get() = job + Dispatchers.Main
 
-    companion object {
-        private const val FRETBOARD_BLOCKING_NETWORK_READ_TIMEOUT = 10000L
-    }
-
     val components: Components by lazy { Components() }
 
     var visibilityLifeCycleCallback: VisibilityLifeCycleCallback? = null
@@ -66,6 +59,7 @@ class FocusApplication : LocaleAwareApplication(), CoroutineScope {
 
         PreferenceManager.setDefaultValues(this, R.xml.settings, false)
 
+        TelemetryWrapper.init(this)
         loadExperiments()
 
         enableStrictMode()
@@ -78,7 +72,6 @@ class FocusApplication : LocaleAwareApplication(), CoroutineScope {
             registerForLocaleUpdates(this@FocusApplication)
         }
 
-        TelemetryWrapper.init(this@FocusApplication)
         AdjustHelper.setupAdjustIfNeeded(this@FocusApplication)
 
         visibilityLifeCycleCallback = VisibilityLifeCycleCallback(this@FocusApplication)
@@ -90,7 +83,7 @@ class FocusApplication : LocaleAwareApplication(), CoroutineScope {
             register(CleanupSessionObserver(this@FocusApplication))
         }
 
-        async(IO) { updateExperiments() }
+        launch(IO) { fretboard.updateExperiments() }
     }
 
     private fun loadExperiments() {
@@ -105,14 +98,8 @@ class FocusApplication : LocaleAwareApplication(), CoroutineScope {
                 }
             })
         fretboard.loadExperiments()
+        TelemetryWrapper.recordActiveExperiments(this)
         WebViewProvider.determineEngine(this@FocusApplication)
-    }
-
-    private suspend fun updateExperiments() = coroutineScope {
-        val updateExperimentsAsync = async { fretboard.updateExperiments() }
-        withTimeoutOrNull(FRETBOARD_BLOCKING_NETWORK_READ_TIMEOUT) {
-            updateExperimentsAsync.await() // then update disk and memory from the network
-        }
     }
 
     private fun enableStrictMode() {

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -54,7 +54,6 @@ import kotlin.collections.HashSet
 object TelemetryWrapper {
     private const val TELEMETRY_APP_NAME_FOCUS = "Focus"
     private const val TELEMETRY_APP_NAME_KLAR = "Klar"
-    private const val TELEMETRY_APP_ENGINE_GECKOVIEW = "GeckoView"
     private const val LAST_MOBILE_METRICS_PINGS = "LAST_MOBILE_METRICS_PINGS"
 
     private val dateFormat = SimpleDateFormat("yyyyMMdd", Locale.US)
@@ -254,9 +253,7 @@ object TelemetryWrapper {
                     .setSettingsProvider(TelemetrySettingsProvider(context))
                     .setCollectionEnabled(telemetryEnabled)
                     .setUploadEnabled(telemetryEnabled)
-                    .setBuildId(TelemetryConfiguration(context).buildId +
-                    (if (AppConstants.isGeckoBuild)
-                        ("-$TELEMETRY_APP_ENGINE_GECKOVIEW") else ""))
+                    .setBuildId(TelemetryConfiguration(context).buildId)
 
             val serializer = JSONPingSerializer()
             val storage = FileTelemetryStorage(configuration, serializer)
@@ -285,12 +282,13 @@ object TelemetryWrapper {
                                 .apply()
                     }
                     .setDefaultSearchProvider(createDefaultSearchProvider(context)))
-
-            TelemetryWrapper.recordActiveExperiments(context)
         } finally {
             StrictMode.setThreadPolicy(threadPolicy)
         }
     }
+
+    val clientId: String
+        get() = TelemetryHolder.get().clientId
 
     private fun createDefaultSearchProvider(context: Context): DefaultSearchMeasurement.DefaultSearchEngineProvider {
         return DefaultSearchMeasurement.DefaultSearchEngineProvider {

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -40,6 +40,7 @@ import org.mozilla.telemetry.ping.TelemetryMobileMetricsPingBuilder
 import org.mozilla.telemetry.schedule.jobscheduler.JobSchedulerTelemetryScheduler
 import org.mozilla.telemetry.serialize.JSONPingSerializer
 import org.mozilla.telemetry.storage.FileTelemetryStorage
+import java.net.MalformedURLException
 import java.net.URL
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -331,17 +332,21 @@ object TelemetryWrapper {
 
     @JvmStatic
     fun addLoadToHistogram(url: String, newLoadTime: Long) {
-        domainMap.add(UrlUtils.stripCommonSubdomains(URL(url).host))
-        numUri++
-        var histogramLoadIndex = (newLoadTime / BUCKET_SIZE_MS).toInt()
+        try {
+            domainMap.add(UrlUtils.stripCommonSubdomains(URL(url).host))
+            numUri++
+            var histogramLoadIndex = (newLoadTime / BUCKET_SIZE_MS).toInt()
 
-        if (histogramLoadIndex > (HISTOGRAM_SIZE - 2)) {
-            histogramLoadIndex = HISTOGRAM_SIZE - 1
-        } else if (histogramLoadIndex < HISTOGRAM_MIN_INDEX) {
-            histogramLoadIndex = HISTOGRAM_MIN_INDEX
+            if (histogramLoadIndex > (HISTOGRAM_SIZE - 2)) {
+                histogramLoadIndex = HISTOGRAM_SIZE - 1
+            } else if (histogramLoadIndex < HISTOGRAM_MIN_INDEX) {
+                histogramLoadIndex = HISTOGRAM_MIN_INDEX
+            }
+
+            histogram[histogramLoadIndex]++
+        } catch (e: MalformedURLException) {
+            // ignore invalid URLs
         }
-
-        histogram[histogramLoadIndex]++
     }
 
     @JvmStatic


### PR DESCRIPTION
Handle malformed URLs without crashing. Use clientID for Fretboard.