### PR TITLE
Bug 1517732 - Expose routes.statuses because taskcluster-github now a…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -17,8 +17,8 @@ tasks:
       deadline: {$fromNow: '2 hours'}
       provisionerId: aws-provisioner-v1
       workerType: github-worker
-      routes: []
       scopes: []
+      routes: []
       payload:
         maxRunTime: 7200
         image: mozillamobile/focus-android:1.2
@@ -143,6 +143,8 @@ tasks:
           - project:mobile:focus:releng:googleplay:product:focus
           - secrets:get:project/focus/tokens
           - queue:route:index.project.mobile.focus.release.latest
+        routes:
+          - statuses  # Automatically added by taskcluster-github. It must be explicit because of Chain of Trust
         payload:
           maxRunTime: 600   # Decision should remain fast enough to schedule a handful of tasks
           image: mozillamobile/focus-android:1.2
@@ -223,6 +225,8 @@ tasks:
           - project:mobile:focus:releng:googleplay:product:focus
           - secrets:get:project/focus/tokens
           - queue:route:index.project.mobile.focus.nightly.latest
+        routes:
+          - statuses  # Automatically added by taskcluster-github. It must be explicit because of Chain of Trust
         payload:
           maxRunTime: 600   # Decision should remain fast enough to schedule a handful of tasks
           image: mozillamobile/focus-android:1.2


### PR DESCRIPTION
…dds it

See https://github.com/mozilla-mobile/android-components/pull/1650. Depends on https://github.com/taskcluster/taskcluster/pull/29