### PR TITLE
Closes #4105 Separate Erase All Fun For Just Erase Icon

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -83,6 +83,7 @@ import org.mozilla.focus.open.OpenWithFragment
 import org.mozilla.focus.popup.PopupUtils
 import org.mozilla.focus.session.SessionCallbackProxy
 import org.mozilla.focus.session.removeAndCloseAllSessions
+import org.mozilla.focus.session.removeAndCloseSession
 import org.mozilla.focus.session.ui.SessionsSheetFragment
 import org.mozilla.focus.telemetry.CrashReporterWrapper
 import org.mozilla.focus.telemetry.TelemetryWrapper
@@ -988,6 +989,27 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
 
         webView?.cleanup()
 
+        requireComponents.sessionManager.removeAndCloseSession(session)
+    }
+
+    fun eraseAll() {
+        val webView = getWebView()
+        val context = context
+
+        // Notify the user their session has been erased if Talk Back is enabled:
+        if (context != null) {
+            val manager = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+            if (manager.isEnabled) {
+                val event = AccessibilityEvent.obtain()
+                event.eventType = AccessibilityEvent.TYPE_ANNOUNCEMENT
+                event.className = javaClass.name
+                event.packageName = getContext()!!.packageName
+                event.text.add(getString(R.string.feedback_erase))
+            }
+        }
+
+        webView?.cleanup()
+
         requireComponents.sessionManager.removeAndCloseAllSessions()
     }
 
@@ -1038,7 +1060,7 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
             R.id.erase -> {
                 TelemetryWrapper.eraseEvent()
 
-                erase()
+                eraseAll()
             }
 
             R.id.tabs -> {


### PR DESCRIPTION
When I moved the erase button to the toolbar, I changed the erase function to erase all sessions to match the new behavior, but missed that erase() needs to be used in other cases to just erase the current session. This adds a function to eraseAll() in the case of the new toolbar erase button. 

I can separate the talkback/cleanup code out into its own function, but @boek I wanted your eyes on it to check if any of the crash reporter code should be using eraseAll instead of erase?