### PR TITLE
Closes #4109: Update A-C to v0.37

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -202,8 +202,7 @@ dependencies {
     implementation "org.mozilla.components:support-ktx:$mozilla_components_version"
     implementation "org.mozilla.components:support-utils:$mozilla_components_version"
     implementation "org.mozilla.components:lib-crash:$mozilla_components_version"
-
-    implementation 'com.squareup.okhttp3:okhttp:3.11.0'
+    implementation "org.mozilla.components:lib-fetch-okhttp:$mozilla_components_version"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"

--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -14,8 +14,10 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
+import org.json.JSONObject
 import org.mozilla.focus.search.BingSearchEngineFilter
 import org.mozilla.focus.search.CustomSearchEngineProvider
 import org.mozilla.focus.search.HiddenSearchEngineFilter
@@ -48,6 +50,14 @@ class Components {
  */
 private class DummyEngine : Engine {
     override val settings: Settings = DefaultSettings()
+
+    override fun speculativeConnect(url: String) {
+        TODO("not implemented")
+    }
+
+    override fun createSessionState(json: JSONObject): EngineSessionState {
+        TODO("not implemented")
+    }
 
     override fun createSession(private: Boolean): EngineSession {
         throw NotImplementedError()

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import mozilla.components.browser.domains.CustomDomains
 import mozilla.components.browser.domains.autocomplete.CustomDomainsProvider
+import mozilla.components.browser.domains.autocomplete.DomainAutocompleteResult
 import mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider
 import mozilla.components.browser.session.Session
 import mozilla.components.support.utils.ThreadUtils
@@ -790,12 +791,16 @@ class UrlInputFragment :
         }
 
         view?.let {
-            var result = shippedAutoCompleteProvider.getAutocompleteSuggestion(searchText)
-
-            // Fall back on custom domain completion if shipped list fails to autocomplete
+            var result: DomainAutocompleteResult? = null
             val settings = Settings.getInstance(context!!)
-            if (settings.shouldAutocompleteFromCustomDomainList() && result == null) {
+
+            if (settings.shouldAutocompleteFromCustomDomainList()) {
                 result = customAutoCompleteProvider.getAutocompleteSuggestion(searchText)
+            }
+
+            // Fall back on shipped domain completion if custom list fails to autocomplete
+            if (result == null) {
+                result = shippedAutoCompleteProvider.getAutocompleteSuggestion(searchText)
             }
 
             // If result is still null, don't autocomplete

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -16,6 +16,7 @@ import android.preference.PreferenceManager
 import android.support.annotation.CheckResult
 import android.support.annotation.VisibleForTesting
 import kotlinx.coroutines.runBlocking
+import mozilla.components.lib.fetch.okhttp.OkHttpClient
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 import org.json.JSONObject
 import org.mozilla.focus.BuildConfig
@@ -33,7 +34,7 @@ import org.mozilla.telemetry.config.TelemetryConfiguration
 import org.mozilla.telemetry.event.TelemetryEvent
 import org.mozilla.telemetry.measurement.DefaultSearchMeasurement
 import org.mozilla.telemetry.measurement.SearchesMeasurement
-import org.mozilla.telemetry.net.HttpURLConnectionTelemetryClient
+import org.mozilla.telemetry.net.TelemetryClient
 import org.mozilla.telemetry.ping.TelemetryCorePingBuilder
 import org.mozilla.telemetry.ping.TelemetryEventPingBuilder
 import org.mozilla.telemetry.ping.TelemetryMobileMetricsPingBuilder
@@ -261,7 +262,8 @@ object TelemetryWrapper {
 
             val serializer = JSONPingSerializer()
             val storage = FileTelemetryStorage(configuration, serializer)
-            val client = HttpURLConnectionTelemetryClient()
+            val client = TelemetryClient(OkHttpClient())
+
             val scheduler = JobSchedulerTelemetryScheduler()
 
             TelemetryHolder.set(Telemetry(configuration, storage, client, scheduler)
@@ -400,9 +402,9 @@ object TelemetryWrapper {
 
     private fun browseEvent(autocompleteResult: InlineAutocompleteEditText.AutocompleteResult) {
         val event = TelemetryEvent.create(Category.ACTION, Method.TYPE_URL, Object.SEARCH_BAR)
-                .extra(Extra.AUTOCOMPLETE, (!autocompleteResult.isEmpty).toString())
+                .extra(Extra.AUTOCOMPLETE, (autocompleteResult.totalItems > 0).toString())
 
-        if (!autocompleteResult.isEmpty) {
+        if (autocompleteResult.totalItems > 0) {
             event.extra(Extra.TOTAL, autocompleteResult.totalItems.toString())
             event.extra(Extra.SOURCE, autocompleteResult.source)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext.geckoview_revision = '448b0b631dd99e6e27559598c1cc191d4cbf10f7'
     ext.geckoview_version = '64.0.20181214004633' // GV 64 Rel Branch 12.14.2018
     ext.spotbugs_version = '3.1.4'
-    ext.mozilla_components_version = '0.32.0'
+    ext.mozilla_components_version = '0.37.0'
 
     repositories {
         google()


### PR DESCRIPTION
I left a couple of the new functions for domain completion as "TODO" as I don't believe we will need them for Focus.

It seems like most of the breaking changes were with autocompletion. I have tested it pretty thoroughly on my end, but this should likely be QA verified on the original ticket once approved.