### PR TITLE
Fixes #4155: Allow to disable Safe Browsing

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/PrivacySecuritySettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/PrivacySecuritySettingsFragment.kt
@@ -37,10 +37,10 @@ class PrivacySecuritySettingsFragment : BaseSettingsFragment(),
 
         val safeBrowsingPreference =
             findPreference(getString(R.string.pref_key_category_safe_browsing))
-        preferenceScreen.removePreference(safeBrowsingPreference)
         val cookiesPreference =
             findPreference(getString(R.string.pref_key_performance_enable_cookies)) as CookiesPreference
         if (!AppConstants.isGeckoBuild) {
+            preferenceScreen.removePreference(safeBrowsingPreference)
             val cookiesStringsWV =
                 requireContext().resources.getStringArray(R.array.preference_privacy_cookies_options)
                     .filter {


### PR DESCRIPTION
Fixing a regression that happened in mid-November where the setting was removed by accident along with setting the GeckoView default to block 3rd party tracker cookies. This is in response to a couple Reddit threads worrying about the disappearing setting.