### PR TITLE
Staging builds are configured against the nightly track

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -206,10 +206,10 @@ tasks:
         scheduler_id: focus-nightly-sched
         is_mozilla_mobile_repo:
           $eval: event.repository.html_url == 'https://github.com/mozilla-mobile/focus-android'
-        track:
+        command_staging_flag:
           $if: event.repository.html_url == 'https://github.com/mozilla-mobile/focus-android'
-          then: 'nightly'
-          else: 'staging-nightly'
+          then: ''
+          else: '--staging'
       in:
         taskId: ${decision_task_id}
         taskGroupId: ${decision_task_id}  # Must be explicit because of Chain of Trust
@@ -266,14 +266,15 @@ tasks:
               && git clone ${repository} repository
               && cd repository
               && python tools/taskcluster/release.py \
-                --track ${track} \
+                --track nightly \
                 --commit \
                 --output /opt/repository/app/build/outputs/apk \
                 --apk klarArm/nightly/app-klar-arm-nightly-unsigned.apk \
                 --apk klarX86/nightly/app-klar-x86-nightly-unsigned.apk \
                 --apk focusArm/nightly/app-focus-arm-nightly-unsigned.apk \
                 --apk focusX86/nightly/app-focus-x86-nightly-unsigned.apk \
-                --date ${now}
+                --date ${now} \
+                ${command_staging_flag}
           artifacts:
             public/task-graph.json:
               type: file


### PR DESCRIPTION
(disclaimer: staging builds aren't actually deployed to the Google Play nightly track! This is just for staging verification)

When I set up automation earlier. I had staging builds target a `staging-nightly` Google Play track. Since these staging builds aren't ever deployed to Google Play, it's unnecessary to make up a brand new track.
Instead, staging builds should more-closely match "real" builds (just "faked out" when it comes to deployment).