### PR TITLE
Closes #4213: Fix crash on rapid clicking of Erase browsing history

### DIFF
--- a/app/src/main/java/org/mozilla/focus/session/ui/EraseViewHolder.kt
+++ b/app/src/main/java/org/mozilla/focus/session/ui/EraseViewHolder.kt
@@ -20,9 +20,11 @@ class EraseViewHolder(
     itemView: View
 ) : RecyclerView.ViewHolder(itemView), View.OnClickListener {
 
+    private val textView: TextView
+
     init {
-        val textView = itemView as TextView
-        val leftDrawable = AppCompatResources.getDrawable(itemView.getContext(), R.drawable.ic_delete)
+        textView = itemView as TextView
+        val leftDrawable = AppCompatResources.getDrawable(itemView.context, R.drawable.ic_delete)
         textView.setCompoundDrawablesWithIntrinsicBounds(leftDrawable, null, null, null)
         textView.setOnClickListener(this)
     }
@@ -30,6 +32,7 @@ class EraseViewHolder(
     override fun onClick(view: View) {
         TelemetryWrapper.eraseInTabsTrayEvent()
 
+        textView.setOnClickListener(null)
         fragment.animateAndDismiss().addListener(object : AnimatorListenerAdapter() {
             override fun onAnimationEnd(animation: Animator) {
                 fragment.requireComponents.sessionManager.removeAndCloseAllSessions()


### PR DESCRIPTION
Since animation takes some time to end, the user can click on the textview again. But by that time, the fragment might have been detached from context, leading to a crash. 