### PR TITLE
Fix some further URL autocomplete issues (#4272 and #4274).

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import mozilla.components.browser.domains.CustomDomains
 import mozilla.components.browser.domains.autocomplete.CustomDomainsProvider
+import mozilla.components.browser.domains.autocomplete.DomainAutocompleteResult
 import mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider
 import mozilla.components.browser.session.Session
 import mozilla.components.support.utils.ThreadUtils
@@ -797,16 +798,20 @@ class UrlInputFragment :
         }
 
         view?.let {
-            val result = if (useShipped) {
-                shippedDomainsProvider.getAutocompleteSuggestion(searchText)
-            } else if (useCustom) {
-                customDomainsProvider.getAutocompleteSuggestion(searchText)
-            } else {
-                null
+            var result : DomainAutocompleteResult? = null
+            if (useCustom) {
+                result = customDomainsProvider.getAutocompleteSuggestion(searchText)
             }
+
+            if (useShipped && result == null) {
+                result = shippedDomainsProvider.getAutocompleteSuggestion(searchText)
+            }
+
             if (result != null) {
                 view.applyAutocompleteResult(AutocompleteResult(
                         result.text, result.source, result.totalItems, { result.url }))
+            } else {
+                view.noAutocompleteResult()
             }
         }
 


### PR DESCRIPTION
Use both custom & shipped domain lists for autocomplete when both are enabled, giving preference to custom; this should fix #4274.
Clear autocomplete suggestion when we fail to get a valid suggestion from either list; this should fix #4272.

Both confirmed fixed on a local build.