### PR TITLE
Closes #4286 Replace deprecated `SearchEngineManager.load()` with `loadAsync()`

### DIFF
--- a/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -66,7 +66,7 @@ class FocusApplication : LocaleAwareApplication(), CoroutineScope {
 
         components.searchEngineManager.apply {
             launch(IO) {
-                load(this@FocusApplication)
+                loadAsync(this@FocusApplication)
             }
 
             registerForLocaleUpdates(this@FocusApplication)

--- a/app/src/main/java/org/mozilla/focus/search/SearchEngineListPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/search/SearchEngineListPreference.kt
@@ -64,7 +64,7 @@ abstract class SearchEngineListPreference : Preference, CoroutineScope {
     fun refetchSearchEngines() {
         launch(Main) {
             searchEngines = context.components.searchEngineManager
-                    .load(this@SearchEngineListPreference.context)
+                    .loadAsync(this@SearchEngineListPreference.context)
                     .await()
                     .sortedBy { it.name }
             refreshSearchEngineViews(this@SearchEngineListPreference.context)


### PR DESCRIPTION
Replaces deprecated `SearchEngineManager.load()` with `SearchEngineManager.loadAsync()` in both  occurrences 