### PR TITLE
Don't split build into two products

### DIFF
--- a/tools/taskcluster/lib/variant.py
+++ b/tools/taskcluster/lib/variant.py
@@ -2,9 +2,9 @@ import taskcluster
 
 
 class VariantApk:
-    def __init__(self, build_type, abi, engine, file_name):
+    def __init__(self, build_type, abi, product, file_name):
         self.abi = abi
-        self.taskcluster_path = 'public/build/{}/{}/target.apk'.format(abi, engine)
+        self.taskcluster_path = 'public/build/{}/{}/target.apk'.format(abi, product)
         self.absolute_path = '/opt/focus-android/app/build/outputs/apk/{}/{}/{}'.format(engine, build_type, file_name)
 
 


### PR DESCRIPTION
Splitting into two products makes signing and pushing harder