### PR TITLE
Updates taskcluster python package to no longer be locked to <5

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -5,7 +5,7 @@
 # Inspired by:
 # https://hub.docker.com/r/runmymind/docker-android-sdk/~/dockerfile/
 
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 MAINTAINER Sebastian Kaspari "skaspari@mozilla.com"
 
@@ -102,10 +102,7 @@ RUN ./gradlew --no-daemon assemble testFocusX86DebugUnitTest lint pmd checkstyle
 RUN pip install -r tools/l10n/android2po/requirements.txt
 
 # Install taskcluster python library (used by decision tasks)
-# 5.0.0 is still incompatible with taskclusterProxy, meaning no decision task is able
-# to schedule the rest of the Taskcluster tasks. Please upgrade to taskcluster>=5 once
-# https://bugzilla.mozilla.org/show_bug.cgi?id=1460015 is fixed
-RUN pip install 'taskcluster>=4,<5'
+RUN pip install taskcluster
 
 # Install Google Cloud SDK for using Firebase Device Lab
 RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-184.0.0-linux-x86_64.tar.gz --output /gcloud.tar.gz

--- a/tools/taskcluster/create-pull-request.py
+++ b/tools/taskcluster/create-pull-request.py
@@ -21,7 +21,7 @@ if len(sys.argv) != 2:
 	exit(1)
 
 # Get token for GitHub bot account from secrets service
-secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
+secrets = taskcluster.Secrets({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
 data = secrets.get('project/focus/github')
 token = data['secret']['botAccountToken']
 

--- a/tools/taskcluster/get-adjust-token.py
+++ b/tools/taskcluster/get-adjust-token.py
@@ -12,7 +12,7 @@ import os
 import taskcluster
 
 # Get JSON data from taskcluster secrets service
-secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
+secrets = taskcluster.Secrets({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
 data = secrets.get('project/focus/tokens')
 
 token_file_path = os.path.join(os.path.dirname(__file__), '../../.adjust_token')

--- a/tools/taskcluster/get-google-firebase-token.py
+++ b/tools/taskcluster/get-google-firebase-token.py
@@ -13,7 +13,7 @@ import os
 import taskcluster
 
 # Get JSON data from taskcluster secrets service
-secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
+secrets = taskcluster.Secrets({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
 data = secrets.get('project/focus/firebase')
 
 with open(os.path.join(os.path.dirname(__file__), '../../.firebase_token.json'), 'w') as file:

--- a/tools/taskcluster/get-sentry-token.py
+++ b/tools/taskcluster/get-sentry-token.py
@@ -12,7 +12,7 @@ import os
 import taskcluster
 
 # Get JSON data from taskcluster secrets service
-secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
+secrets = taskcluster.Secrets({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
 data = secrets.get('project/focus/tokens')
 
 token_file_path = os.path.join(os.path.dirname(__file__), '../../.sentry_token')

--- a/tools/taskcluster/release.py
+++ b/tools/taskcluster/release.py
@@ -127,7 +127,7 @@ def populate_chain_of_trust_required_but_unused_files():
 
 
 def release(apks, channel, commit, tag):
-    queue = taskcluster.Queue({ 'baseUrl': 'http://taskcluster/queue/v1' })
+    queue = taskcluster.Queue({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
 
     task_graph = {}
 

--- a/tools/taskcluster/schedule-master-build.py
+++ b/tools/taskcluster/schedule-master-build.py
@@ -167,7 +167,7 @@ def generate_task(name, description, command, dependencies=[], artifacts={}, sco
 
 if __name__ == "__main__":
 
-    queue = taskcluster.Queue({'baseUrl': 'http://taskcluster/queue/v1'})
+    queue = taskcluster.Queue({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
 
     buildTaskId, buildTask = generate_build_task()
     schedule_task(queue, buildTaskId, buildTask)

--- a/tools/taskcluster/schedule-nightly-graph.py
+++ b/tools/taskcluster/schedule-nightly-graph.py
@@ -69,7 +69,7 @@ def make_decision_task(params):
 
 
 if __name__ == "__main__":
-    queue = taskcluster.Queue({ 'baseUrl': 'http://taskcluster/queue/v1' })
+    queue = taskcluster.Queue({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
 
     branch, head_rev = calculate_branch_and_head_rev(ROOT)
 

--- a/tools/taskcluster/schedule-screenshots.py
+++ b/tools/taskcluster/schedule-screenshots.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
 	print "Task:", TASK_ID
 
 	queue = taskcluster.Queue({
-		'baseUrl': 'http://taskcluster/queue/v1'
+		'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']
 	})
 
 	for chunk in chunks(SCREENSHOT_LOCALES, LOCALES_PER_TASK):

--- a/tools/taskcluster/upload_apk_nimbledroid.py
+++ b/tools/taskcluster/upload_apk_nimbledroid.py
@@ -7,6 +7,7 @@ This script talks to the taskcluster secrets service to obtain the
 Nimbledroid account key and upload Klar and Focus apk to Nimbledroid for perf analysis.
 """
 
+import os
 import taskcluster
 import requests
 import json
@@ -39,7 +40,7 @@ def uploadGeckoViewExampleApk(key):
 	uploadApk({'apk' : open('geckoview_example_nd.apk')},key)
 
 # Get JSON data from taskcluster secrets service
-secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
+secrets = taskcluster.Secrets({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
 data = secrets.get('project/focus/nimbledroid')
 
 # disable focus webview upload until https://github.com/mozilla-mobile/focus-android/issues/3574 is resolved


### PR DESCRIPTION
I had to update the base docker image from `ubuntu:17.10` to `ubuntu:18.04` since 17.10 is EOL.
Additionally, the `taskcluster` sdk now needs `rootUrl` instead of `baseUrl`