### PR TITLE
Fix unsecure connection on about pages

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
@@ -181,6 +181,6 @@ public class UrlUtils {
 
     public static boolean isLocalizedContent(@Nullable String url) {
         return url != null &&
-            (url.equals(LocalizedContent.URL_ABOUT) || url.equals(LocalizedContent.URL_RIGHTS) || url.equals("about:blank"));
+            (url.equals(LocalizedContent.URL_ABOUT) || url.equals(LocalizedContent.URL_RIGHTS) || url.startsWith("about:"));
     }
 }


### PR DESCRIPTION
Fixes #4398 
The comment "We can't use "about:" because webview silently swallows about: pages, hence we use a custom scheme." on `LocalizedContent.java` seems to be outdated.