### PR TITLE
Revert "Updates taskcluster python package to no longer be locked to <5"

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -5,7 +5,7 @@
 # Inspired by:
 # https://hub.docker.com/r/runmymind/docker-android-sdk/~/dockerfile/
 
-FROM ubuntu:18.04
+FROM ubuntu:17.10
 
 MAINTAINER Sebastian Kaspari "skaspari@mozilla.com"
 
@@ -102,7 +102,10 @@ RUN ./gradlew --no-daemon assemble testFocusX86DebugUnitTest lint pmd checkstyle
 RUN pip install -r tools/l10n/android2po/requirements.txt
 
 # Install taskcluster python library (used by decision tasks)
-RUN pip install taskcluster
+# 5.0.0 is still incompatible with taskclusterProxy, meaning no decision task is able
+# to schedule the rest of the Taskcluster tasks. Please upgrade to taskcluster>=5 once
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1460015 is fixed
+RUN pip install 'taskcluster>=4,<5'
 
 # Install Google Cloud SDK for using Firebase Device Lab
 RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-184.0.0-linux-x86_64.tar.gz --output /gcloud.tar.gz

--- a/tools/taskcluster/create-pull-request.py
+++ b/tools/taskcluster/create-pull-request.py
@@ -21,7 +21,7 @@ if len(sys.argv) != 2:
 	exit(1)
 
 # Get token for GitHub bot account from secrets service
-secrets = taskcluster.Secrets({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
+secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
 data = secrets.get('project/focus/github')
 token = data['secret']['botAccountToken']
 

--- a/tools/taskcluster/get-adjust-token.py
+++ b/tools/taskcluster/get-adjust-token.py
@@ -12,7 +12,7 @@ import os
 import taskcluster
 
 # Get JSON data from taskcluster secrets service
-secrets = taskcluster.Secrets({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
+secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
 data = secrets.get('project/focus/tokens')
 
 token_file_path = os.path.join(os.path.dirname(__file__), '../../.adjust_token')

--- a/tools/taskcluster/get-google-firebase-token.py
+++ b/tools/taskcluster/get-google-firebase-token.py
@@ -13,7 +13,7 @@ import os
 import taskcluster
 
 # Get JSON data from taskcluster secrets service
-secrets = taskcluster.Secrets({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
+secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
 data = secrets.get('project/focus/firebase')
 
 with open(os.path.join(os.path.dirname(__file__), '../../.firebase_token.json'), 'w') as file:

--- a/tools/taskcluster/get-sentry-token.py
+++ b/tools/taskcluster/get-sentry-token.py
@@ -12,7 +12,7 @@ import os
 import taskcluster
 
 # Get JSON data from taskcluster secrets service
-secrets = taskcluster.Secrets({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
+secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
 data = secrets.get('project/focus/tokens')
 
 token_file_path = os.path.join(os.path.dirname(__file__), '../../.sentry_token')

--- a/tools/taskcluster/release.py
+++ b/tools/taskcluster/release.py
@@ -127,7 +127,7 @@ def populate_chain_of_trust_required_but_unused_files():
 
 
 def release(apks, channel, commit, tag):
-    queue = taskcluster.Queue({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
+    queue = taskcluster.Queue({ 'baseUrl': 'http://taskcluster/queue/v1' })
 
     task_graph = {}
 

--- a/tools/taskcluster/schedule-master-build.py
+++ b/tools/taskcluster/schedule-master-build.py
@@ -167,7 +167,7 @@ def generate_task(name, description, command, dependencies=[], artifacts={}, sco
 
 if __name__ == "__main__":
 
-    queue = taskcluster.Queue({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
+    queue = taskcluster.Queue({'baseUrl': 'http://taskcluster/queue/v1'})
 
     buildTaskId, buildTask = generate_build_task()
     schedule_task(queue, buildTaskId, buildTask)

--- a/tools/taskcluster/schedule-nightly-graph.py
+++ b/tools/taskcluster/schedule-nightly-graph.py
@@ -69,7 +69,7 @@ def make_decision_task(params):
 
 
 if __name__ == "__main__":
-    queue = taskcluster.Queue({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
+    queue = taskcluster.Queue({ 'baseUrl': 'http://taskcluster/queue/v1' })
 
     branch, head_rev = calculate_branch_and_head_rev(ROOT)
 

--- a/tools/taskcluster/schedule-screenshots.py
+++ b/tools/taskcluster/schedule-screenshots.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
 	print "Task:", TASK_ID
 
 	queue = taskcluster.Queue({
-		'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']
+		'baseUrl': 'http://taskcluster/queue/v1'
 	})
 
 	for chunk in chunks(SCREENSHOT_LOCALES, LOCALES_PER_TASK):

--- a/tools/taskcluster/upload_apk_nimbledroid.py
+++ b/tools/taskcluster/upload_apk_nimbledroid.py
@@ -7,7 +7,6 @@ This script talks to the taskcluster secrets service to obtain the
 Nimbledroid account key and upload Klar and Focus apk to Nimbledroid for perf analysis.
 """
 
-import os
 import taskcluster
 import requests
 import json
@@ -40,7 +39,7 @@ def uploadGeckoViewExampleApk(key):
 	uploadApk({'apk' : open('geckoview_example_nd.apk')},key)
 
 # Get JSON data from taskcluster secrets service
-secrets = taskcluster.Secrets({'rootUrl': os.environ['TASKCLUSTER_PROXY_URL']})
+secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
 data = secrets.get('project/focus/nimbledroid')
 
 # disable focus webview upload until https://github.com/mozilla-mobile/focus-android/issues/3574 is resolved


### PR DESCRIPTION
Reverts mozilla-mobile/focus-android#4409

This patch causes failures like https://tools.taskcluster.net/groups/EnCf1saBRCqX7vK-2_EQig/tasks/EnCf1saBRCqX7vK-2_EQig/runs/0/logs/public%2Flogs%2Flive_backing.log, which prevents v8.0.24 from being shipped. Here's why:

a. While modified `tools/docker/Dockerfile` hasn't been published to dockerhub.
b. Therefore, the decision task is calling `taskcluster.Queue({ 'baseUrl': 'http://taskcluster/queue/v1' })` but the taskcluster python client (baked in the docker image) is still at version 4. 
c. This client doesn't error out when an unknown key/value is passed (`baseUrl` has been supported since version 5)
d. Because it doesn't error out, the taskcluster python client opens a connection to the default taskcluster instance, which is `https://taskcluter.net` (note http**s** and **.net**). It should have used the proxy `http://taskcluster/` which does contain the scopes the decision task is given. Instead, the default instance doesn't have any scopes attached (which is expected).

This is why the decision task cannot spin a single task because it doesn't have any single scope.

The right fix would be to rebuild the docker image, but I've kept getting errors, yesterday. Thus, let's unblock the release by reverting the offending patch.