### PR TITLE
Updates automation to use new provisioner and workers

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -15,8 +15,8 @@ tasks:
     then:
       created: {$fromNow: ''}
       deadline: {$fromNow: '2 hours'}
-      provisionerId: aws-provisioner-v1
-      workerType: github-worker
+      provisionerId: mobile-1
+      workerType: b-linux
       scopes: []
       routes: []
       payload:
@@ -66,13 +66,13 @@ tasks:
         taskGroupId: {$eval: as_slugid("decision_task")}
         created: {$fromNow: ''}
         deadline: {$fromNow: '2 hours'}
-        provisionerId: aws-provisioner-v1
-        workerType: github-worker
+        provisionerId: mobile-3
+        workerType: b-linux
         routes:
           - 'notify.irc-channel.#android-ci.on-any'
         scopes:
-          - queue:create-task:aws-provisioner-v1/github-worker
-          - queue:scheduler-id:taskcluster-github
+          - queue:create-task:mobile-3/b-linux
+          - queue:scheduler-id:mobile-level-3
           - secrets:get:project/focus/firebase
           - secrets:get:project/focus/nimbledroid
           - queue:route:notify.irc-channel.#android-ci.on-any
@@ -121,7 +121,7 @@ tasks:
         decision_task_id: {$eval: as_slugid("decision_task")}
         expires_in: {$fromNow: '1 year'}
         repository: https://github.com/mozilla-mobile/focus-android
-        scheduler_id: taskcluster-github
+        scheduler_id: mobile-level-3
       in:
         taskId: ${decision_task_id}
         taskGroupId: ${decision_task_id}  # Must be explicit because of Chain of Trust
@@ -129,14 +129,14 @@ tasks:
         deadline: {$fromNow: '2 hours'}
         expires: ${expires_in}
         schedulerId: ${scheduler_id}   # Must be explicit because of Chain of Trust
-        provisionerId: aws-provisioner-v1
-        workerType: gecko-focus   # This workerType has ChainOfTrust enabled
+        provisionerId: mobile-3
+        workerType: b-linux
         requires: all-completed   # Must be explicit because of Chain of Trust
         priority: highest
         retries: 5
         scopes:
           - queue:scheduler-id:${scheduler_id}
-          - queue:create-task:highest:aws-provisioner-v1/gecko-focus
+          - queue:create-task:highest:mobile-3/b-linux
           - queue:create-task:highest:scriptworker-prov-v1/mobile-signing-v1
           - queue:create-task:highest:scriptworker-prov-v1/mobile-pushapk-v1
           - project:mobile:focus:releng:signing:cert:release-signing
@@ -204,7 +204,7 @@ tasks:
         decision_task_id: {$eval: as_slugid("decision_task")}
         expires_in: {$fromNow: '1 year'}
         repository: https://github.com/mozilla-mobile/focus-android
-        scheduler_id: focus-nightly-sched
+        scheduler_id: mobile-level-3
       in:
         taskId: ${decision_task_id}
         taskGroupId: ${decision_task_id}  # Must be explicit because of Chain of Trust
@@ -212,14 +212,14 @@ tasks:
         deadline: {$fromNow: '2 hours'}
         expires: ${expires_in}
         schedulerId: ${scheduler_id}    # Must be explicit because of Chain of Trust
-        provisionerId: aws-provisioner-v1
-        workerType: gecko-focus   # This workerType has ChainOfTrust enabled
+        provisionerId: mobile-3
+        workerType: b-linux
         requires: all-completed   # Must be explicit because of Chain of Trust
         priority: medium
         retries: 5
         scopes:
           - queue:scheduler-id:${scheduler_id}
-          - queue:create-task:highest:aws-provisioner-v1/gecko-focus
+          - queue:create-task:highest:mobile-3/b-linux
           - queue:create-task:highest:scriptworker-prov-v1/mobile-signing-v1
           - queue:create-task:highest:scriptworker-prov-v1/mobile-pushapk-v1
           - project:mobile:focus:releng:signing:cert:release-signing

--- a/tools/taskcluster/lib/tasks.py
+++ b/tools/taskcluster/lib/tasks.py
@@ -18,7 +18,7 @@ class TaskBuilder(object):
         self.source = source
         self.scheduler_id = scheduler_id
 
-    def build_task(self, name, description, command, dependencies = [], artifacts = {}, scopes = [], routes = [], features = {}, worker_type = 'github-worker'):
+    def build_task(self, name, description, command, dependencies = [], artifacts = {}, scopes = [], routes = [], features = {}):
         created = datetime.datetime.now()
         expires = taskcluster.fromNow('1 year')
         deadline = taskcluster.fromNow('1 day')
@@ -29,7 +29,7 @@ class TaskBuilder(object):
         })
 
         return {
-            "workerType": worker_type,
+            "workerType": "b-linux",
             "taskGroupId": self.task_id,
             "schedulerId": self.scheduler_id,
             "expires": taskcluster.stringDate(expires),
@@ -55,7 +55,7 @@ class TaskBuilder(object):
                 "artifacts": artifacts,
                 "deadline": taskcluster.stringDate(deadline)
             },
-            "provisionerId": "aws-provisioner-v1",
+            "provisionerId": "mobile-3",
             "metadata": {
                 "name": name,
                 "description": description,

--- a/tools/taskcluster/release.py
+++ b/tools/taskcluster/release.py
@@ -59,7 +59,6 @@ def generate_build_task(apks, tag):
             "chainOfTrust": True
         },
         artifacts = artifacts,
-        worker_type='gecko-focus',
         scopes=[
             "secrets:get:project/focus/tokens"
         ])

--- a/tools/taskcluster/schedule-master-build.py
+++ b/tools/taskcluster/schedule-master-build.py
@@ -127,14 +127,14 @@ def generate_task(name, description, command, dependencies=[], artifacts={}, sco
     deadline = taskcluster.fromNow('1 day')
 
     return {
-        "workerType": "github-worker",
+        "workerType": "b-linux",
         "taskGroupId": TASK_ID,
         "expires": taskcluster.stringDate(expires),
         "retries": 5,
         "created": taskcluster.stringDate(created),
         "tags": {},
         "priority": "lowest",
-        "schedulerId": "taskcluster-github",
+        "schedulerId": "mobile-level-3",
         "deadline": taskcluster.stringDate(deadline),
         "dependencies": [TASK_ID] + dependencies,
         "routes": routes,
@@ -155,7 +155,7 @@ def generate_task(name, description, command, dependencies=[], artifacts={}, sco
             "artifacts": artifacts,
             "deadline": taskcluster.stringDate(deadline)
         },
-        "provisionerId": "aws-provisioner-v1",
+        "provisionerId": "mobile-3",
         "metadata": {
             "name": name,
             "description": description,

--- a/tools/taskcluster/schedule-screenshots.py
+++ b/tools/taskcluster/schedule-screenshots.py
@@ -30,14 +30,14 @@ def generate_screenshot_task(locales):
 	deadline = taskcluster.fromNow('1 day')
 
 	return {
-	    "workerType": "github-worker",
+	    "workerType": "b-linux",
 	    "taskGroupId": TASK_ID,
 	    "expires": taskcluster.stringDate(expires),
 	    "retries": 5,
 	    "created": taskcluster.stringDate(created),
 	    "tags": {},
 	    "priority": "lowest",
-	    "schedulerId": "taskcluster-github",
+	    "schedulerId": "mobile-level-1",
 	    "deadline": taskcluster.stringDate(deadline),
 	    "dependencies": [ TASK_ID ],
 	    "routes": [],
@@ -67,7 +67,7 @@ def generate_screenshot_task(locales):
 	        },
 	        "deadline": taskcluster.stringDate(deadline)
 	    },
-		"provisionerId": "aws-provisioner-v1",
+		"provisionerId": "mobile-1",
 		"metadata": {
 			"name": "Screenshots for locales: %s" % parameters,
 			"description": "Generating screenshots of Focus for Android in the specified locales (%s)" % parameters,


### PR DESCRIPTION
With the taskcluster instance migration, we've updated the names of some of the workers. This PR modernizes `focus-android` accordingly