### PR TITLE
Resolves permissions issue for master-push CI

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -73,11 +73,13 @@ tasks:
         routes:
           - 'notify.irc-channel.#android-ci.on-any'
         scopes:
-          - queue:create-task:mobile-3/b-linux
-          - queue:scheduler-id:mobile-level-3
-          - secrets:get:project/focus/firebase
-          - secrets:get:project/focus/nimbledroid
-          - queue:route:notify.irc-channel.#android-ci.on-any
+          $let:
+            short_head_branch:
+              $if: 'event.ref[:11] == "refs/heads/"'
+              then: {$eval: 'event.ref[11:]'}
+              else: ${event.ref}
+          in:
+            - 'assume:repo:focus-android:branch:${short_head_branch}'
         payload:
           maxRunTime: 7200
           image: mozillamobile/focus-android:1.2
@@ -137,15 +139,7 @@ tasks:
         priority: highest
         retries: 5
         scopes:
-          - queue:scheduler-id:${scheduler_id}
-          - queue:create-task:highest:mobile-3/b-linux
-          - queue:create-task:highest:scriptworker-k8s/mobile-3-signing
-          - queue:create-task:highest:scriptworker-k8s/mobile-3-pushapk
-          - project:mobile:focus:releng:signing:cert:release-signing
-          - project:mobile:focus:releng:signing:format:autograph_focus
-          - project:mobile:focus:releng:googleplay:product:focus
-          - secrets:get:project/focus/tokens
-          - queue:route:index.project.mobile.focus.release.latest
+          - assume:repo:focus-android:release
         routes:
           - statuses  # Automatically added by taskcluster-github. It must be explicit because of Chain of Trust
         payload:
@@ -220,15 +214,7 @@ tasks:
         priority: medium
         retries: 5
         scopes:
-          - queue:scheduler-id:${scheduler_id}
-          - queue:create-task:highest:mobile-3/b-linux
-          - queue:create-task:highest:scriptworker-k8s/mobile-3-signing
-          - queue:create-task:highest:scriptworker-k8s/mobile-3-pushapk
-          - project:mobile:focus:releng:signing:cert:release-signing
-          - project:mobile:focus:releng:signing:format:autograph_focus
-          - project:mobile:focus:releng:googleplay:product:focus
-          - secrets:get:project/focus/tokens
-          - queue:route:index.project.mobile.focus.nightly.latest
+          - assume:repo:focus-android:cron:nightly
         routes:
           - statuses  # Automatically added by taskcluster-github. It must be explicit because of Chain of Trust
         payload:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -15,7 +15,7 @@ tasks:
     then:
       created: {$fromNow: ''}
       deadline: {$fromNow: '2 hours'}
-      schedulerId: mobile-level-1
+      schedulerId: taskcluster-github
       provisionerId: mobile-1
       workerType: b-linux
       scopes: []
@@ -67,7 +67,7 @@ tasks:
         taskGroupId: {$eval: as_slugid("decision_task")}
         created: {$fromNow: ''}
         deadline: {$fromNow: '2 hours'}
-        schedulerId: mobile-level-3
+        schedulerId: taskcluster-github
         provisionerId: mobile-3
         workerType: b-linux
         routes:
@@ -125,7 +125,7 @@ tasks:
         decision_task_id: {$eval: as_slugid("decision_task")}
         expires_in: {$fromNow: '1 year'}
         repository: https://github.com/mozilla-mobile/focus-android
-        scheduler_id: mobile-level-3
+        scheduler_id: taskcluster-github
       in:
         taskId: ${decision_task_id}
         taskGroupId: ${decision_task_id}  # Must be explicit because of Chain of Trust
@@ -200,7 +200,7 @@ tasks:
         decision_task_id: {$eval: as_slugid("decision_task")}
         expires_in: {$fromNow: '1 year'}
         repository: https://github.com/mozilla-mobile/focus-android
-        scheduler_id: mobile-level-3
+        scheduler_id: taskcluster-github
       in:
         taskId: ${decision_task_id}
         taskGroupId: ${decision_task_id}  # Must be explicit because of Chain of Trust


### PR DESCRIPTION
This issue seemed weird to me, since `queue:create-task:highest:mobile-3/*` should be sufficient to perform `queue:create-task:mobile-3/b-linux`. In fact, if you have that `highest` scope and perform the physical act of creating a task on `b-linux`, it works! However, if you have that `highest` scope to create a task that needs the other scope (the one without `highest`), it'll fail!

[This is because Taskcluster evaluates scopes differently: when checking if you have a scope, it checks literally. When actually creating the task, it uses a "scope expression".](https://mozilla.slack.com/archives/GEZ4ZJCRM/p1573580169031500)

You can work around this by having the task `assume` from the role, rather than just declaring the scopes it wants