### PR TITLE
Convenience functionality for disposing cookies and resuming to browse the current website on long press of erase button

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -135,11 +135,11 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
 
         val fragmentManager = supportFragmentManager
         val browserFragment =
-            fragmentManager.findFragmentByTag(BrowserFragment.FRAGMENT_TAG) as BrowserFragment?
+                fragmentManager.findFragmentByTag(BrowserFragment.FRAGMENT_TAG) as BrowserFragment?
         browserFragment?.cancelAnimation()
 
         val urlInputFragment =
-            fragmentManager.findFragmentByTag(UrlInputFragment.FRAGMENT_TAG) as UrlInputFragment?
+                fragmentManager.findFragmentByTag(UrlInputFragment.FRAGMENT_TAG) as UrlInputFragment?
         urlInputFragment?.cancelAnimation()
 
         super.onPause()
@@ -206,6 +206,7 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
         val fragmentManager = supportFragmentManager
         val browserFragment = fragmentManager.findFragmentByTag(BrowserFragment.FRAGMENT_TAG) as BrowserFragment?
 
+
         val isShowingBrowser = browserFragment != null
         val crashReporterIsVisible = browserFragment?.crashReporterIsVisible() ?: false
 
@@ -213,6 +214,14 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
             ViewUtils.showBrandedSnackbar(findViewById(android.R.id.content),
                     R.string.feedback_erase,
                     resources.getInteger(R.integer.erase_snackbar_delay))
+        }
+
+        val rememberedUrl = browserFragment?.let { browser ->
+            when {
+                browser.remember -> browser.url
+                else -> null
+
+            }
         }
 
         // We add the url input fragment to the layout if it doesn't exist yet.
@@ -240,7 +249,7 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
         // Ideally we'd make it possible to pause observers while the app is in the background:
         // https://github.com/mozilla-mobile/android-components/issues/876
         transaction
-                .replace(R.id.container, UrlInputFragment.createWithoutSession(), UrlInputFragment.FRAGMENT_TAG)
+                .replace(R.id.container, UrlInputFragment.createWithoutSession(rememberedUrl), UrlInputFragment.FRAGMENT_TAG)
                 .commitAllowingStateLoss()
     }
 
@@ -265,14 +274,14 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
         val isNewSession = previousSessionCount < components.sessionManager.sessions.count() && previousSessionCount > 0
 
         if ((currentSession.source == Session.Source.ACTION_SEND ||
-                currentSession.source == Session.Source.HOME_SCREEN) && isNewSession) {
+                        currentSession.source == Session.Source.HOME_SCREEN) && isNewSession) {
             browserFragment.openedFromExternalLink = true
         }
 
         fragmentManager
                 .beginTransaction()
                 .replace(R.id.container, browserFragment, BrowserFragment.FRAGMENT_TAG)
-            .commitAllowingStateLoss()
+                .commitAllowingStateLoss()
 
         previousSessionCount = components.sessionManager.sessions.count()
     }
@@ -288,7 +297,7 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
         val fragmentManager = supportFragmentManager
 
         val sessionsSheetFragment = fragmentManager.findFragmentByTag(
-            SessionsSheetFragment.FRAGMENT_TAG) as SessionsSheetFragment?
+                SessionsSheetFragment.FRAGMENT_TAG) as SessionsSheetFragment?
         if (sessionsSheetFragment != null &&
                 sessionsSheetFragment.isVisible &&
                 sessionsSheetFragment.onBackPressed()) {

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -162,6 +162,8 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
 
     private var biometricController: BiometricAuthenticationHandler? = null
 
+    var remember: Boolean = false
+
     private var job = Job()
     override val coroutineContext: CoroutineContext
         get() = job + Dispatchers.Main
@@ -170,7 +172,7 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
     // but sometimes it's null, and sometimes it returns a null URL. Sometimes it returns a data:
     // URL for error pages. The URL we show in the toolbar is (A) always correct and (B) what the
     // user is probably expecting to share, so lets use that here:
-    val url: String
+    public val url: String
         get() = urlView!!.text.toString()
 
     var openedFromExternalLink: Boolean = false
@@ -351,6 +353,7 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
     private fun initialiseNormalBrowserUi(view: View) {
         val eraseButton = view.findViewById<FloatingEraseButton>(R.id.erase)
         eraseButton.setOnClickListener(this)
+        eraseButton.setOnLongClickListener(this)
 
         urlView!!.setOnClickListener(this)
 
@@ -1301,17 +1304,22 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
 
     override fun onLongClick(view: View): Boolean {
         // Detect long clicks on display_url
-        if (view.id == R.id.display_url) {
-            val context = activity ?: return false
+        when (view.id) {
+            R.id.display_url -> {
 
-            if (session.isCustomTabSession()) {
-                val clipBoard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                val uri = Uri.parse(url)
-                clipBoard.primaryClip = ClipData.newRawUri("Uri", uri)
-                Toast.makeText(context, getString(R.string.custom_tab_copy_url_action), Toast.LENGTH_SHORT).show()
+                val context = activity ?: return false
+
+                if (session.isCustomTabSession()) {
+                    val clipBoard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    val uri = Uri.parse(url)
+                    clipBoard.primaryClip = ClipData.newRawUri("Uri", uri)
+                    Toast.makeText(context, getString(R.string.custom_tab_copy_url_action), Toast.LENGTH_SHORT).show()
+                }
+            }
+            R.id.erase -> {
+                remember = true
             }
         }
-
         return false
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
@@ -115,7 +115,7 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
 
         val fragment: Fragment
         fragment = if (sessionUUID == null) {
-            UrlInputFragment.createWithoutSession()
+            UrlInputFragment.createWithoutSession(null)
         } else {
             val session = sessionManager.findSessionById(sessionUUID)
             BrowserFragment.createForSession(session!!)

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -76,29 +76,31 @@ class UrlInputFragment :
     SharedPreferences.OnSharedPreferenceChangeListener,
     CoroutineScope {
     companion object {
-        @JvmField
-        val FRAGMENT_TAG = "url_input"
+        const val FRAGMENT_TAG = "url_input"
 
         private const val duckDuckGo = "DuckDuckGo"
 
-        private val ARGUMENT_ANIMATION = "animation"
-        private val ARGUMENT_X = "x"
-        private val ARGUMENT_Y = "y"
-        private val ARGUMENT_WIDTH = "width"
-        private val ARGUMENT_HEIGHT = "height"
+        private const val ARGUMENT_ANIMATION = "animation"
+        private const val ARGUMENT_X = "x"
+        private const val ARGUMENT_Y = "y"
+        private const val ARGUMENT_WIDTH = "width"
+        private const val ARGUMENT_HEIGHT = "height"
 
-        private val ARGUMENT_SESSION_UUID = "sesssion_uuid"
+        private const val ARGUMENT_SESSION_UUID = "sesssion_uuid"
 
-        private val ANIMATION_BROWSER_SCREEN = "browser_screen"
+        private const val ARGUMENT_REMEMBERED_URL = "url"
 
-        private val ANIMATION_DURATION = 200
-        private val TIPS_ALPHA = 0.65f
+        private const val ANIMATION_BROWSER_SCREEN = "browser_screen"
+
+        private const val ANIMATION_DURATION = 200
+        private const val TIPS_ALPHA = 0.65f
 
         private lateinit var searchSuggestionsViewModel: SearchSuggestionsViewModel
 
         @JvmStatic
-        fun createWithoutSession(): UrlInputFragment {
+        fun createWithoutSession(url: String?): UrlInputFragment {
             val arguments = Bundle()
+            arguments.putString(ARGUMENT_REMEMBERED_URL, url)
 
             val fragment = UrlInputFragment()
             fragment.arguments = arguments
@@ -293,6 +295,7 @@ class UrlInputFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         listOf(dismissView, clearView).forEach { it.setOnClickListener(this) }
 
+        urlView?.setText(arguments?.getString(ARGUMENT_REMEMBERED_URL))
         urlView?.setOnFilterListener(::onFilter)
         urlView?.setOnTextChangeListener(::onTextChange)
         urlView?.imeOptions = urlView.imeOptions or ViewUtils.IME_FLAG_NO_PERSONALIZED_LEARNING


### PR DESCRIPTION
This PR adds functionality which enables pre-filling of the current session URL in a new blank session when the erase button is being long pressed.

This is a convenience functionality for disposing cookies and simultaneously want to resume browsing the current website. This functionality replaces the manual action of:
- navigating to the URL navigation
- copy the URL
- erase the current session
- paste URL in the URL navigation
