### PR TITLE
Bug 1608153 - part 2: .taskcluster.yml, restrict event to `published`…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -119,7 +119,7 @@ tasks:
 # - Signs the builds with the release key
 # - Uploads the builds to the "alpha" track on Google Play
 ###############################################################################
-  - $if: 'tasks_for == "github-release" && event["action"] in ["published", "prereleased"]'
+  - $if: 'tasks_for == "github-release" && event["action"] == "published"'
     then:
       $let:
         decision_task_id: {$eval: as_slugid("decision_task")}


### PR DESCRIPTION
… only

Follows https://github.com/mozilla-mobile/focus-android/pull/4454 up. See [bug 1608153 comment 3](https://bugzilla.mozilla.org/show_bug.cgi?id=1608153#c3) for rationale.