### PR TITLE
Update to AC 35.0.0 and GV 74.0.20200305014626

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         targetSdkVersion 28
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
                        // override this with a generated versionCode at build time.
-        versionName "8.0.26"
+        versionName "8.1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled true

--- a/app/src/main/java/org/mozilla/focus/web/GeckoWebViewProvider.kt
+++ b/app/src/main/java/org/mozilla/focus/web/GeckoWebViewProvider.kt
@@ -244,6 +244,9 @@ class GeckoWebViewProvider : IWebViewProvider {
             geckoSession.settings.userAgentMode =
                     if (shouldRequestDesktop) GeckoSessionSettings.USER_AGENT_MODE_DESKTOP
                     else GeckoSessionSettings.USER_AGENT_MODE_MOBILE
+            geckoSession.settings.viewportMode =
+                    if (shouldRequestDesktop) GeckoSessionSettings.VIEWPORT_MODE_DESKTOP
+                    else GeckoSessionSettings.VIEWPORT_MODE_MOBILE
             callback?.onRequestDesktopStateChanged(shouldRequestDesktop)
         }
 
@@ -471,7 +474,7 @@ class GeckoWebViewProvider : IWebViewProvider {
                     callback?.onSecurityChanged(
                         isSecure,
                         securityInfo.host,
-                        securityInfo.issuerOrganization
+                        securityInfo.certificate?.issuerDN?.name
                     )
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     ext.espresso_version = '3.1.0-alpha4'
     ext.kotlin_version = '1.3.61'
     ext.coroutines_version = '1.3.0'
-    ext.mozilla_components_version = '32.0.0'
-    ext.gecko_release_version = '73.0.20200211134023'
+    ext.mozilla_components_version = '35.0.1'
+    ext.gecko_release_version = '74.0.20200309095159'
 
     repositories {
         google()


### PR DESCRIPTION
Includes API upgrades and a desktop mode viewport fix that was missing
from the previous upgrade.

Minor version bump to signify a GV version upgrade. This resets it
back to the old versioning system instead of using the patch version.