### PR TITLE
Fixes Issue #4394 - Newly added search engines only listed and usable after re-opening the app

### DIFF
--- a/app/src/main/java/org/mozilla/focus/search/CustomSearchEngineStore.kt
+++ b/app/src/main/java/org/mozilla/focus/search/CustomSearchEngineStore.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.util.Log
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.SearchEngineParser
+import org.mozilla.focus.Components
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.shortcut.IconGenerator
 import org.xmlpull.v1.XmlPullParserException
@@ -17,8 +18,8 @@ object CustomSearchEngineStore {
     fun isSearchEngineNameUnique(context: Context, engineName: String): Boolean {
         val sharedPreferences = context.getSharedPreferences(PREF_FILE_SEARCH_ENGINES,
                 Context.MODE_PRIVATE)
-
-        val defaultEngines = context.components.searchEngineManager.getSearchEngines(context)
+        val components: Components by lazy { Components() }
+        val defaultEngines = components.searchEngineManager.getSearchEngines(context)
 
         return !sharedPreferences.contains(engineName) && !defaultEngines.any { it.name == engineName }
     }

--- a/app/src/main/java/org/mozilla/focus/search/SearchEngineListPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/search/SearchEngineListPreference.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import mozilla.components.browser.search.SearchEngine
+import org.mozilla.focus.Components
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.utils.Settings
@@ -47,8 +48,8 @@ abstract class SearchEngineListPreference : Preference, CoroutineScope {
         super.onBindViewHolder(holder)
         searchEngineGroup = holder!!.itemView.findViewById(R.id.search_engine_group)
         val context = searchEngineGroup!!.context
-
-        searchEngines = context.components.searchEngineManager.getSearchEngines(context)
+        val components: Components by lazy { Components() }
+        searchEngines = components.searchEngineManager.getSearchEngines(context)
             .sortedBy { it.name }
 
         refreshSearchEngineViews(context)
@@ -63,7 +64,8 @@ abstract class SearchEngineListPreference : Preference, CoroutineScope {
 
     fun refetchSearchEngines() {
         launch(Main) {
-            searchEngines = context.components.searchEngineManager
+            val components: Components by lazy { Components() }
+            searchEngines = components.searchEngineManager
                     .loadAsync(this@SearchEngineListPreference.context)
                     .await()
                     .list
@@ -79,8 +81,8 @@ abstract class SearchEngineListPreference : Preference, CoroutineScope {
             // so searchEngineGroup is not set yet.
             return
         }
-
-        val defaultSearchEngine = context.components.searchEngineManager.getDefaultSearchEngine(
+        val components: Components by lazy { Components() }
+        val defaultSearchEngine = components.searchEngineManager.getDefaultSearchEngine(
                 context,
                 Settings.getInstance(context).defaultSearchEngineName
         ).identifier

--- a/app/src/main/java/org/mozilla/focus/search/SearchEnginePreference.kt
+++ b/app/src/main/java/org/mozilla/focus/search/SearchEnginePreference.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.preference.Preference
 import android.util.AttributeSet
+import org.mozilla.focus.Components
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.utils.Settings
@@ -43,9 +44,9 @@ class SearchEnginePreference : Preference, SharedPreferences.OnSharedPreferenceC
             summary = defaultSearchEngineName
         }
     }
-
+    private val components: Components by lazy { Components() }
     private val defaultSearchEngineName: String
-        get() = context.components.searchEngineManager.getDefaultSearchEngine(
+        get() = components.searchEngineManager.getDefaultSearchEngine(
                 getContext(),
                 Settings.getInstance(context).defaultSearchEngineName).name
 }

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
@@ -239,6 +239,11 @@ class ManualAddSearchEngineSettingsFragment : BaseSettingsFragment() {
                 Snackbar.make(fragment.view!!, R.string.search_add_confirmation, Snackbar.LENGTH_SHORT).show()
                 Settings.getInstance(fragment.activity!!).setDefaultSearchEngineByName(engineName)
                 fragment.fragmentManager!!.popBackStack()
+                // Reload the SearchSettingsFragment to refresh the default search engine selected, then navigate to InstalledSearchEnginesSettingsFragment
+                fragment.fragmentManager!!.popBackStack()
+                fragment.fragmentManager!!.popBackStack()
+                fragment.navigateToFragment(SearchSettingsFragment.newInstance())
+                fragment.navigateToFragment(InstalledSearchEnginesSettingsFragment.newInstance())
             } else {
                 showServerError(fragment)
             }

--- a/app/src/main/java/org/mozilla/focus/settings/SearchSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/SearchSettingsFragment.kt
@@ -6,6 +6,7 @@ package org.mozilla.focus.settings
 
 import android.content.SharedPreferences
 import android.os.Bundle
+import androidx.fragment.app.FragmentTransaction
 import androidx.preference.Preference
 import org.mozilla.focus.R
 import org.mozilla.focus.autocomplete.AutocompleteSettingsFragment
@@ -46,6 +47,8 @@ class SearchSettingsFragment : BaseSettingsFragment(),
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+        var reloadFragment = fragmentManager!!.beginTransaction()
+        reloadFragment.detach(this).attach(this).commit()
         TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
     }
 

--- a/app/src/main/java/org/mozilla/focus/settings/SearchSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/SearchSettingsFragment.kt
@@ -47,8 +47,6 @@ class SearchSettingsFragment : BaseSettingsFragment(),
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        var reloadFragment = fragmentManager!!.beginTransaction()
-        reloadFragment.detach(this).attach(this).commit()
         TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
     }
 

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -20,6 +20,7 @@ import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 import org.json.JSONObject
 import org.mozilla.focus.BuildConfig
+import org.mozilla.focus.Components
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.search.CustomSearchEngineStore
@@ -504,7 +505,8 @@ object TelemetryWrapper {
     }
 
     private fun getDefaultSearchEngineIdentifierForTelemetry(context: Context): String {
-        val searchEngine = context.components.searchEngineManager.getDefaultSearchEngine(
+        val components: Components by lazy { Components() }
+        val searchEngine = components.searchEngineManager.getDefaultSearchEngine(
             context,
             Settings.getInstance(context).defaultSearchEngineName
         ).identifier

--- a/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
@@ -12,6 +12,8 @@ import androidx.annotation.Nullable;
 import android.text.TextUtils;
 import android.webkit.URLUtil;
 import mozilla.components.browser.search.SearchEngine;
+
+import org.mozilla.focus.Components;
 import org.mozilla.focus.browser.LocalizedContent;
 import org.mozilla.focus.ext.ContextKt;
 
@@ -61,9 +63,8 @@ public class UrlUtils {
 
     public static String createSearchUrl(Context context, String searchTerm) {
         final String defaultIdentifier = Settings.getInstance(context).getDefaultSearchEngineName();
-
-        final SearchEngine searchEngine = ContextKt.getComponents(context).getSearchEngineManager()
-                .getDefaultSearchEngine(context, defaultIdentifier);
+        Components components = new Components();
+        final SearchEngine searchEngine = components.getSearchEngineManager().getDefaultSearchEngine(context, defaultIdentifier);
 
         return searchEngine.buildSearchUrl(searchTerm);
     }


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/focus-android/issues/4394