### PR TITLE
Fixes Issue #4395 - Learn More links not redirecting to relevant settings menu after clicking back

### DIFF
--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteCustomDomainsPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteCustomDomainsPreference.kt
@@ -6,6 +6,8 @@ package org.mozilla.focus.autocomplete
 
 import android.content.Context
 import android.util.AttributeSet
+import org.mozilla.focus.R
+import org.mozilla.focus.R.string.preference_subitem_autocomplete
 import org.mozilla.focus.settings.LearnMoreSwitchPreference
 import org.mozilla.focus.utils.SupportUtils
 
@@ -13,8 +15,9 @@ import org.mozilla.focus.utils.SupportUtils
  * Switch preference for enabling/disabling autocompletion for custom domains entered by the user.
  */
 class AutocompleteCustomDomainsPreference(
-    context: Context?,
-    attrs: AttributeSet?
+        context: Context?,
+        attrs: AttributeSet?
 ) : LearnMoreSwitchPreference(context, attrs) {
     override fun getLearnMoreUrl() = SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.AUTOCOMPLETE)
+    override fun getPreferenceTitle(): String = context.getString(preference_subitem_autocomplete)
 }

--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteCustomDomainsPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteCustomDomainsPreference.kt
@@ -6,7 +6,6 @@ package org.mozilla.focus.autocomplete
 
 import android.content.Context
 import android.util.AttributeSet
-import org.mozilla.focus.R
 import org.mozilla.focus.R.string.preference_subitem_autocomplete
 import org.mozilla.focus.settings.LearnMoreSwitchPreference
 import org.mozilla.focus.utils.SupportUtils

--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteDefaultDomainsPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteDefaultDomainsPreference.kt
@@ -6,6 +6,7 @@ package org.mozilla.focus.autocomplete
 
 import android.content.Context
 import android.util.AttributeSet
+import org.mozilla.focus.R
 import org.mozilla.focus.settings.LearnMoreSwitchPreference
 import org.mozilla.focus.utils.SupportUtils
 
@@ -13,8 +14,9 @@ import org.mozilla.focus.utils.SupportUtils
  * Switch preference for enabling/disabling autocompletion for default domains that ship with the app.
  */
 class AutocompleteDefaultDomainsPreference(
-    context: Context?,
-    attrs: AttributeSet?
+        context: Context?,
+        attrs: AttributeSet?
 ) : LearnMoreSwitchPreference(context, attrs) {
     override fun getLearnMoreUrl() = SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.AUTOCOMPLETE)
+    override fun getPreferenceTitle(): String = context.getString(R.string.preference_subitem_autocomplete)
 }

--- a/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsPreference.kt
@@ -7,6 +7,7 @@ package org.mozilla.focus.searchsuggestions.ui
 import android.content.Context
 import android.util.AttributeSet
 import org.mozilla.focus.R
+import org.mozilla.focus.R.string.preference_category_search_suggestions
 import org.mozilla.focus.settings.LearnMoreSwitchPreference
 import org.mozilla.focus.utils.SupportUtils
 
@@ -14,8 +15,8 @@ import org.mozilla.focus.utils.SupportUtils
  * Switch preference for enabling/disabling autocompletion for default domains that ship with the app.
  */
 class SearchSuggestionsPreference(
-    context: Context?,
-    attrs: AttributeSet?
+        context: Context?,
+        attrs: AttributeSet?
 ) : LearnMoreSwitchPreference(context, attrs) {
     override fun getLearnMoreUrl(): String =
             SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.SEARCH_SUGGESTIONS)
@@ -23,4 +24,6 @@ class SearchSuggestionsPreference(
     override fun getDescription(): String? =
             context.getString(R.string.preference_show_search_suggestions_summary,
                     context.getString(R.string.app_name))
+
+    override fun getPreferenceTitle(): String = context.getString(preference_category_search_suggestions)
 }

--- a/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
@@ -2,6 +2,7 @@ package org.mozilla.focus.settings
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.graphics.Paint
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceViewHolder
@@ -10,12 +11,15 @@ import android.util.AttributeSet
 import android.view.ContextThemeWrapper
 import android.view.View
 import android.widget.TextView
+import androidx.core.content.ContextCompat.startActivity
+import com.facebook.stetho.inspector.elements.android.AccessibilityNodeInfoWrapper.getDescription
 import mozilla.components.browser.session.Session
 import org.mozilla.focus.R
+import org.mozilla.focus.activity.InfoActivity
 import org.mozilla.focus.ext.components
 
 abstract class LearnMoreSwitchPreference(context: Context?, attrs: AttributeSet?) :
-    SwitchPreferenceCompat(context, attrs) {
+        SwitchPreferenceCompat(context, attrs) {
 
     init {
         layoutResource = R.layout.preference_switch_learn_more
@@ -36,19 +40,15 @@ abstract class LearnMoreSwitchPreference(context: Context?, attrs: AttributeSet?
         learnMoreLink.setOnClickListener {
             // This is a hardcoded link: if we ever end up needing more of these links, we should
             // move the link into an xml parameter, but there's no advantage to making it configurable now.
-            val session = Session(getLearnMoreUrl(), source = Session.Source.MENU)
-            context.components.sessionManager.add(session, selected = true)
-            if (context is ContextThemeWrapper) {
-                if ((context as ContextThemeWrapper).baseContext is Activity) {
-                    ((context as ContextThemeWrapper).baseContext as Activity).finish()
-                }
-            } else {
-                (context as? Activity)?.finish()
-            }
+            val intent = InfoActivity.getIntentFor(context!!,
+                    getLearnMoreUrl(), getPreferenceTitle())
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
+            context.startActivity(intent)
         }
 
         val backgroundDrawableArray =
-            context.obtainStyledAttributes(intArrayOf(R.attr.selectableItemBackground))
+                context.obtainStyledAttributes(intArrayOf(R.attr.selectableItemBackground))
         val backgroundDrawable = backgroundDrawableArray.getDrawable(0)
         backgroundDrawableArray.recycle()
         learnMoreLink.background = backgroundDrawable
@@ -57,4 +57,6 @@ abstract class LearnMoreSwitchPreference(context: Context?, attrs: AttributeSet?
     open fun getDescription(): String? = null
 
     abstract fun getLearnMoreUrl(): String
+
+    abstract fun getPreferenceTitle(): String
 }

--- a/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
@@ -1,22 +1,16 @@
 package org.mozilla.focus.settings
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.graphics.Paint
+import android.util.AttributeSet
+import android.view.View
+import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceViewHolder
 import androidx.preference.SwitchPreferenceCompat
-import android.util.AttributeSet
-import android.view.ContextThemeWrapper
-import android.view.View
-import android.widget.TextView
-import androidx.core.content.ContextCompat.startActivity
-import com.facebook.stetho.inspector.elements.android.AccessibilityNodeInfoWrapper.getDescription
-import mozilla.components.browser.session.Session
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.InfoActivity
-import org.mozilla.focus.ext.components
 
 abstract class LearnMoreSwitchPreference(context: Context?, attrs: AttributeSet?) :
         SwitchPreferenceCompat(context, attrs) {

--- a/app/src/main/java/org/mozilla/focus/settings/SafeBrowsingSwitchPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/SafeBrowsingSwitchPreference.kt
@@ -6,14 +6,16 @@ package org.mozilla.focus.settings
 import android.content.Context
 import android.util.AttributeSet
 import org.mozilla.focus.utils.SupportUtils
+import org.mozilla.focus.R.string.preference_category_safe_browsing
 
 /**
  * Switch preference for enabling/disabling autocompletion for custom domains entered by the user.
  */
 class SafeBrowsingSwitchPreference(
-    context: Context?,
-    attrs: AttributeSet?
+        context: Context?,
+        attrs: AttributeSet?
 ) : LearnMoreSwitchPreference(context, attrs) {
     override fun getLearnMoreUrl() =
-        SupportUtils.getSafeBrowsingURL()
+            SupportUtils.getSafeBrowsingURL()
+    override fun getPreferenceTitle(): String = context.getString(preference_category_safe_browsing)
 }

--- a/app/src/main/java/org/mozilla/focus/widget/TelemetrySwitchPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/widget/TelemetrySwitchPreference.kt
@@ -9,6 +9,7 @@ package org.mozilla.focus.widget
 import android.content.Context
 import android.util.AttributeSet
 import org.mozilla.focus.R
+import org.mozilla.focus.R.string.preference_mozilla_telemetry2
 import org.mozilla.focus.settings.LearnMoreSwitchPreference
 import org.mozilla.focus.telemetry.CrashReporterWrapper
 import org.mozilla.focus.telemetry.TelemetryWrapper
@@ -19,7 +20,7 @@ import org.mozilla.telemetry.TelemetryHolder
  * Switch preference for enabling/disabling telemetry
  */
 internal class TelemetrySwitchPreference(context: Context?, attrs: AttributeSet?) :
-    LearnMoreSwitchPreference(context, attrs) {
+        LearnMoreSwitchPreference(context, attrs) {
 
     init {
         if (context != null) {
@@ -37,12 +38,14 @@ internal class TelemetrySwitchPreference(context: Context?, attrs: AttributeSet?
 
     override fun getDescription(): String? {
         return context.resources.getString(
-            R.string.preference_mozilla_telemetry_summary2,
-            context.resources.getString(R.string.app_name)
+                R.string.preference_mozilla_telemetry_summary2,
+                context.resources.getString(R.string.app_name)
         )
     }
 
     override fun getLearnMoreUrl(): String {
         return SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.USAGE_DATA)
     }
+
+    override fun getPreferenceTitle(): String = context.getString(preference_mozilla_telemetry2)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,6 +169,8 @@
 
     <string name="preference_category_search">Search</string>
 
+    <string name="preference_category_search_suggestions">Search Suggestions</string>
+
     <!-- Title of "switch" preference that enables/disables search suggestions -->
     <string name="preference_show_search_suggestions">Get search suggestions</string>
     <!-- Description of the preference that enables/disables search suggestions


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/focus-android/issues/4395