### PR TITLE
Avoid removing sessions we can't close

### DIFF
--- a/app/src/main/java/org/mozilla/focus/session/VisibilityLifeCycleCallback.java
+++ b/app/src/main/java/org/mozilla/focus/session/VisibilityLifeCycleCallback.java
@@ -28,6 +28,12 @@ public class VisibilityLifeCycleCallback implements Application.ActivityLifecycl
                 .finishAndRemoveTaskIfInBackground();
     }
 
+    /* package */ static boolean isInBackground(Context context) {
+        return ((FocusApplication) context.getApplicationContext())
+                .getVisibilityLifeCycleCallback()
+                .activitiesInStartedState == 0;
+    }
+
     private final Context context;
 
     /**


### PR DESCRIPTION
In some cases, closing tabs from the notification does not necessarily work correctly because we cannot get the underlying GeckoSessions. This patch handles the foregrounded & backgrounded states separately so that we rely on finishing the task to remove sessions when backgrounded and only call `removeAllAndCloseSessions` when foregrounded.