### PR TITLE
No bug - fix CoT issues for Focus releases.

### DIFF
--- a/tools/taskcluster/lib/tasks.py
+++ b/tools/taskcluster/lib/tasks.py
@@ -52,6 +52,7 @@ class TaskBuilder(object):
                     "-c",
                     command
                 ],
+                "env": {},
                 "artifacts": artifacts,
                 "deadline": taskcluster.stringDate(deadline)
             },


### PR DESCRIPTION
On our last Focus release on 7th of May, the build task was identical to the currrent one and CoT worked fine. But in the meantime, CoT was changed when https://github.com/mozilla-releng/scriptworker/pull/454 was merged, since now `check_interactive_docker_worker` runs against the chain task too, if it’s docker-worker. So that breaks the assumptions we have in-tree. 

This should provide an empty dict to make CoT happy.