### PR TITLE
Fixes issue #4480. Now the 'find in page' search bar is visible properly above the virtual keyboard.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import android.preference.PreferenceManager
 import android.util.AttributeSet
 import android.view.View
+import android.view.WindowManager
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.lib.crash.Crash
@@ -48,6 +49,7 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
 
         if (!isTaskRoot) {
             if (intent.hasCategory(Intent.CATEGORY_LAUNCHER) && Intent.ACTION_MAIN == intent.action) {

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -1318,7 +1318,7 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
 
     private fun showFindInPage() {
         findInPageView!!.visibility = View.VISIBLE
-        findInPageQuery!!.requestFocus()
+        
 
         val params = swipeRefresh!!.layoutParams as CoordinatorLayout.LayoutParams
         params.bottomMargin = findInPageViewHeight


### PR DESCRIPTION
The search bar for "find in page" was not visible for some devices. This particularly happened for devices of screen size around 6.2 inches. The problem gets solved on adding the `window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)` inside `onCreate()` in the MainActivity.

Device Used for testing: Xiaomi Redmi Note 7 Pro (Android 9)