### PR TITLE
Issue #4532: Add feature-prompts component

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -165,6 +165,7 @@ dependencies {
     implementation "org.mozilla.components:feature-customtabs:$mozilla_components_version"
     implementation "org.mozilla.components:feature-contextmenu:$mozilla_components_version"
     implementation "org.mozilla.components:feature-findinpage:$mozilla_components_version"
+    implementation "org.mozilla.components:feature-prompts:$mozilla_components_version"
     implementation "org.mozilla.components:feature-session:$mozilla_components_version"
     implementation "org.mozilla.components:feature-tabs:$mozilla_components_version"
     implementation "org.mozilla.components:lib-crash:$mozilla_components_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" /> <!-- Used by sentry. -->
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <!-- Needed to prompt the user to give permission for camera access -->
+    <uses-permission android:name="android.permission.CAMERA" />
     <!-- Needed to prompt the user to give permission to install a downloaded apk -->
     <uses-permission-sdk-23 android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 

--- a/app/src/main/java/org/mozilla/focus/utils/AppPermissionCodes.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/AppPermissionCodes.kt
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.utils
+
+object AppPermissionCodes {
+    const val REQUEST_CODE_DOWNLOAD_PERMISSIONS = 1
+    const val REQUEST_CODE_PROMPT_PERMISSIONS = 2
+    const val REQUEST_CODE_APP_PERMISSIONS = 3
+    const val REQUEST_CODE_CAMERA_PERMISSIONS = 4
+    const val REQUEST_CODE_STORAGE_PERMISSION = 5
+}


### PR DESCRIPTION
Depends on a newer a-c version that includes this fix: https://github.com/mozilla-mobile/android-components/pull/7379

We can still merge it since it isn't a breaking API and upgrade the a-c version after our next release.