### PR TITLE
Close #4143: Finish CustomTabActivity if there is no session

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/CustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/CustomTabActivity.kt
@@ -30,6 +30,13 @@ class CustomTabActivity : MainActivity() {
         customTabId = intent.getStringExtra(CUSTOM_TAB_ID)
             ?: throw IllegalAccessError("No custom tab id in intent")
 
+        // The session for this ID, no longer exists. This usually happens because we were gc-d
+        // and since we do not save custom tab sessions, the activity is re-created and we no longer
+        // have a session with us to restore. It's safer to finish the activity instead.
+        if (components.sessionManager.findSessionById(customTabId) == null) {
+            finish()
+        }
+
         super.onCreate(savedInstanceState)
     }
 


### PR DESCRIPTION
This has become a top crash that we should get into the next release if possible.

We had the same issue in r-b as well: https://github.com/mozilla-mobile/reference-browser/pull/894

To reproduce this, in the developer options, set 'Don't keep activities' and change the 'Background process limit' option to 'No background processes'. Then..

1. Open a Custom Tab.
2. Background the custom tab.
3. Open the main app from the launcher.
4. Swipe away (kill) the main app.
5. App switch to where the custom tab was previous.
5. 💥 

Bugzilla: BZ-1639900