### PR TITLE
Update to AC 48.0.0 and GV 78.0.20200625152958

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         targetSdkVersion 28
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
                        // override this with a generated versionCode at build time.
-        versionName "8.4.0"
+        versionName "8.5.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled true

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     ext.espresso_version = '3.1.0-alpha4'
     ext.kotlin_version = '1.3.61'
     ext.coroutines_version = '1.3.0'
-    ext.mozilla_components_version = '44.0.1'
-    ext.gecko_release_version = '77.0.20200602142841'
+    ext.mozilla_components_version = '48.0.0'
+    ext.gecko_release_version = '78.0.20200625152958'
 
     repositories {
         google()


### PR DESCRIPTION
Version bump to 8.5.0 as well.