### PR TITLE
Fixes issue #4583 - Correct translation in homescreen

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -829,6 +829,10 @@ class UrlInputFragment :
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        if (key == activity?.getString(R.string.pref_key_homescreen_tips)) { updateTipsLabel() }
+        if (key == activity?.getString(R.string.pref_key_locale)) {
+            updateTipsLabel()
+        } else if (key == activity?.getString(R.string.pref_key_homescreen_tips)) {
+            updateTipsLabel()
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -829,9 +829,7 @@ class UrlInputFragment :
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        if (key == activity?.getString(R.string.pref_key_locale)) {
-            updateTipsLabel()
-        } else if (key == activity?.getString(R.string.pref_key_homescreen_tips)) {
+        if (key == activity?.getString(R.string.pref_key_locale) || key == activity?.getString(R.string.pref_key_homescreen_tips)) {
             updateTipsLabel()
         }
     }


### PR DESCRIPTION
Fix issue #4583 

I found a wrong flag on refreshing the list of tips.

However, I leave it just in case.
Therefore, the condition about _R.string.pref_key_homescreen_tips_ might not be needed.

If you mind it, please tell me!