### PR TITLE
Use setPrimaryClip instead of accessing primaryClip directly

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -1308,7 +1308,7 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
             if (session.isCustomTabSession()) {
                 val clipBoard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                 val uri = Uri.parse(url)
-                clipBoard.primaryClip = ClipData.newRawUri("Uri", uri)
+                clipBoard.setPrimaryClip(ClipData.newRawUri("Uri", uri))
                 Toast.makeText(context, getString(R.string.custom_tab_copy_url_action), Toast.LENGTH_SHORT).show()
             }
         }

--- a/app/src/main/java/org/mozilla/focus/menu/context/WebContextMenu.kt
+++ b/app/src/main/java/org/mozilla/focus/menu/context/WebContextMenu.kt
@@ -271,7 +271,7 @@ object WebContextMenu {
                     }
 
                     val clip = ClipData.newUri(dialog.context.contentResolver, "URI", uri)
-                    clipboard.primaryClip = clip
+                    clipboard.setPrimaryClip(clip)
                     true
                 }
                 else -> throw IllegalArgumentException("Unhandled menu item id=" + item.itemId)


### PR DESCRIPTION
Using Android platform 30 and build-tools version 30.0.0 the build breaks with a deprecation message as the primaryClip property is set directly instead of using the setPrimaryClip method
fixes #4590 