### PR TITLE
Update to AC 49.0.1 and GV 78.0.20200708170202

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         targetSdkVersion 28
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
                        // override this with a generated versionCode at build time.
-        versionName "8.5.0"
+        versionName "8.5.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled true

--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -17,6 +17,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
+import mozilla.components.concept.engine.profiler.Profiler
 import mozilla.components.concept.engine.utils.EngineVersion
 import org.json.JSONObject
 import org.mozilla.focus.search.BingSearchEngineFilter
@@ -51,6 +52,7 @@ class Components {
  */
 private class DummyEngine : Engine {
     override val version: EngineVersion = EngineVersion(1, 0, 0)
+    override val profiler: Profiler? = null
     override val settings: Settings = DefaultSettings()
 
     override fun createSession(private: Boolean, contextId: String?): EngineSession {

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     ext.espresso_version = '3.1.0-alpha4'
     ext.kotlin_version = '1.3.61'
     ext.coroutines_version = '1.3.0'
-    ext.mozilla_components_version = '48.0.0'
-    ext.gecko_release_version = '78.0.20200625152958'
+    ext.mozilla_components_version = '49.0.1'
+    ext.gecko_release_version = '78.0.20200708170202'
 
     repositories {
         google()


### PR DESCRIPTION
Bumps version to 8.5.1 for the GV security patch upgrade.