### PR TITLE
Closes #4597: Early return after finishing CustomTabActivity

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/CustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/CustomTabActivity.kt
@@ -35,6 +35,7 @@ class CustomTabActivity : MainActivity() {
         // have a session with us to restore. It's safer to finish the activity instead.
         if (components.sessionManager.findSessionById(customTabId) == null) {
             finish()
+            return
         }
 
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
When we finished the activity, the call continued on into the parent
(MainActivity) that made the same crash point where we try to use an
intent session ID that no longer exists.

We do not need to do this in our other browsers because we handle the
Custom Tab sessions as a nullable ID, so we do not need to
short-circuit them similar to this.

In my testing, I haven't been able to find any side-effects from this
change since we do not have anything to clean up or destroy at this
early point in the lifecycle.