### PR TITLE
Closes #4587: Search bar won't accept an URL containing a colon

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -268,7 +268,7 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
         val isNewSession = previousSessionCount < components.sessionManager.sessions.count() && previousSessionCount > 0
 
         if ((currentSession.source == Session.Source.ACTION_SEND ||
-                currentSession.source == Session.Source.HOME_SCREEN) && isNewSession) {
+                currentSession.source == Session.Source.HOME_SCREEN || currentSession.source == Session.Source.ACTION_VIEW) && isNewSession) {
             browserFragment.openedFromExternalLink = true
         }
 

--- a/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
+++ b/app/src/main/java/org/mozilla/focus/utils/UrlUtils.java
@@ -10,6 +10,7 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.text.TextUtils;
+import android.util.Log;
 import android.webkit.URLUtil;
 import mozilla.components.browser.search.SearchEngine;
 import org.mozilla.focus.browser.LocalizedContent;
@@ -19,14 +20,19 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 public class UrlUtils {
+    /*
+    * getScheme for "en.wikipedia.org/wiki/Dracula:_Dead_and_Loving_It" returns "en.wikipedia.org/wiki/Dracula"
+    * Source : https://en.wikipedia.org/wiki/List_of_URI_schemes
+    * Schemes never contain capital letters and backslash
+    * */
     public static String normalize(@NonNull String input) {
         String trimmedInput = input.trim();
         Uri uri = Uri.parse(trimmedInput);
 
-        if (TextUtils.isEmpty(uri.getScheme())) {
+        String scheme = uri.getScheme();
+        if (scheme == null || TextUtils.isEmpty(scheme) || !scheme.equals(scheme.toLowerCase()) || scheme.contains("/")) {
             uri = Uri.parse("http://" + trimmedInput);
         }
-
         return uri.toString();
     }
 


### PR DESCRIPTION
Fixes #4587 @badboy @frozzare @jonalmeida 
getScheme() for "en.wikipedia.org/wiki/Dracula:_Dead_and_Loving_It" returns "en.wikipedia.org/wiki/Dracula"
Schemes never contain capital letters and slash( Source : https://en.wikipedia.org/wiki/List_of_URI_schemes)