### PR TITLE
Update to AC 53.0.0 and GV 79.0.20200720193547

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         targetSdkVersion 28
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
                        // override this with a generated versionCode at build time.
-        versionName "8.5.1"
+        versionName "8.6.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled true

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -12,6 +12,7 @@ import android.util.AttributeSet
 import android.view.View
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.state.SessionState
 import mozilla.components.lib.crash.Crash
 import mozilla.components.support.utils.SafeIntent
 import org.mozilla.focus.R
@@ -267,8 +268,8 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
         val browserFragment = BrowserFragment.createForSession(currentSession)
         val isNewSession = previousSessionCount < components.sessionManager.sessions.count() && previousSessionCount > 0
 
-        if ((currentSession.source == Session.Source.ACTION_SEND ||
-                currentSession.source == Session.Source.HOME_SCREEN) && isNewSession) {
+        if ((currentSession.source == SessionState.Source.ACTION_SEND ||
+                currentSession.source == SessionState.Source.HOME_SCREEN) && isNewSession) {
             browserFragment.openedFromExternalLink = true
         }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.state.SessionState
 import mozilla.components.concept.engine.content.blocking.Tracker
 import mozilla.components.lib.crash.Crash
 import mozilla.components.support.utils.ColorUtils
@@ -941,7 +942,7 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
             // Go back in web history
             goBack()
         } else {
-            if (session.source == Session.Source.ACTION_VIEW || session.isCustomTabSession()) {
+            if (session.source == SessionState.Source.ACTION_VIEW || session.isCustomTabSession()) {
                 TelemetryWrapper.eraseBackToAppEvent()
 
                 // This session has been started from a VIEW intent. Go back to the previous app
@@ -1140,13 +1141,13 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
             }
 
             R.id.help -> {
-                val session = Session(SupportUtils.HELP_URL, source = Session.Source.MENU)
+                val session = Session(SupportUtils.HELP_URL, source = SessionState.Source.MENU)
                 requireComponents.sessionManager.add(session, selected = true)
             }
 
             R.id.help_trackers -> {
                 val url = SupportUtils.getSumoURLForTopic(context!!, SupportUtils.SumoTopic.TRACKERS)
-                val session = Session(url, source = Session.Source.MENU)
+                val session = Session(url, source = SessionState.Source.MENU)
 
                 requireComponents.sessionManager.add(session, selected = true)
             }
@@ -1163,7 +1164,7 @@ class BrowserFragment : WebFragment(), LifecycleObserver, View.OnClickListener,
 
             R.id.report_site_issue -> {
                 val reportUrl = String.format(SupportUtils.REPORT_SITE_ISSUE_URL, url)
-                val session = Session(reportUrl, source = Session.Source.MENU)
+                val session = Session(reportUrl, source = SessionState.Source.MENU)
                 requireComponents.sessionManager.add(session, selected = true)
 
                 TelemetryWrapper.reportSiteIssueEvent()

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -36,6 +36,7 @@ import mozilla.components.browser.domains.autocomplete.CustomDomainsProvider
 import mozilla.components.browser.domains.autocomplete.DomainAutocompleteResult
 import mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.state.state.SessionState
 import mozilla.components.support.utils.ThreadUtils
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText.AutocompleteResult
@@ -430,7 +431,7 @@ class UrlInputFragment :
                 WhatsNew.userViewedWhatsNew(it)
 
                 val url = SupportUtils.getSumoURLForTopic(it, SupportUtils.SumoTopic.WHATS_NEW)
-                val session = Session(url, source = Session.Source.MENU)
+                val session = Session(url, source = SessionState.Source.MENU)
 
                 requireComponents.sessionManager.add(session, selected = true)
             }
@@ -438,7 +439,7 @@ class UrlInputFragment :
             R.id.settings -> (activity as LocaleAwareAppCompatActivity).openPreferences()
 
             R.id.help -> {
-                val session = Session(SupportUtils.HELP_URL, source = Session.Source.MENU)
+                val session = Session(SupportUtils.HELP_URL, source = SessionState.Source.MENU)
                 requireComponents.sessionManager.add(session, selected = true)
             }
 
@@ -761,7 +762,7 @@ class UrlInputFragment :
                 .remove(this)
                 .commit()
         } else {
-            val session = Session(url, source = Session.Source.USER_ENTERED)
+            val session = Session(url, source = SessionState.Source.USER_ENTERED)
             if (!searchTerms.isNullOrEmpty()) {
                 session.searchTerms = searchTerms
             }

--- a/app/src/main/java/org/mozilla/focus/menu/context/WebContextMenu.kt
+++ b/app/src/main/java/org/mozilla/focus/menu/context/WebContextMenu.kt
@@ -26,6 +26,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.state.state.SessionState
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.MainActivity
 import org.mozilla.focus.open.OpenWithFragment
@@ -185,7 +186,7 @@ object WebContextMenu {
                 }
                 R.id.menu_open_in_focus -> {
                     // Open selected link in Focus and navigate there
-                    val newSession = Session(hitTarget.linkURL, source = Session.Source.MENU)
+                    val newSession = Session(hitTarget.linkURL, source = SessionState.Source.MENU)
                     context.components.sessionManager.add(newSession, selected = true)
 
                     val intent = Intent(context, MainActivity::class.java)
@@ -197,7 +198,7 @@ object WebContextMenu {
                     true
                 }
                 R.id.menu_new_tab -> {
-                    val newSession = Session(hitTarget.linkURL, source = Session.Source.MENU)
+                    val newSession = Session(hitTarget.linkURL, source = SessionState.Source.MENU)
                     context.components.sessionManager.add(
                         newSession,
                         selected = Settings.getInstance(context).shouldOpenNewTabs()

--- a/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsFragment.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.state.state.SessionState
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.searchsuggestions.SearchSuggestionsViewModel
@@ -159,7 +160,7 @@ class SearchSuggestionsFragment : Fragment(), CoroutineScope {
             override fun onClick(textView: View) {
                 val context = textView.context
                 val url = SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.SEARCH_SUGGESTIONS)
-                val session = Session(url, source = Session.Source.MENU)
+                val session = Session(url, source = SessionState.Source.MENU)
                 context.components.sessionManager.add(session, selected = true)
             }
 

--- a/app/src/main/java/org/mozilla/focus/session/IntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/focus/session/IntentProcessor.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import android.text.TextUtils
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.state.SessionState
 import mozilla.components.feature.customtabs.createCustomTabConfigFromIntent
 import mozilla.components.feature.customtabs.isCustomTabIntent
 import mozilla.components.support.utils.SafeIntent
@@ -74,7 +75,7 @@ class IntentProcessor(
                             intent.getBooleanExtra(HomeScreen.REQUEST_DESKTOP, false)
 
                         createSession(
-                            Session.Source.HOME_SCREEN,
+                            SessionState.Source.HOME_SCREEN,
                             intent,
                             intent.dataString ?: "",
                             blockingEnabled,
@@ -82,12 +83,12 @@ class IntentProcessor(
                         )
                     }
                     intent.hasExtra(TextActionActivity.EXTRA_TEXT_SELECTION) -> createSession(
-                        Session.Source.TEXT_SELECTION,
+                        SessionState.Source.TEXT_SELECTION,
                         intent,
                         intent.dataString ?: ""
                     )
                     else -> createSession(
-                        Session.Source.ACTION_VIEW,
+                        SessionState.Source.ACTION_VIEW,
                         intent,
                         intent.dataString ?: ""
                     )
@@ -103,15 +104,15 @@ class IntentProcessor(
                 return if (!UrlUtils.isUrl(dataString)) {
                     val bestURL = WebURLFinder(dataString).bestWebURL()
                     if (!TextUtils.isEmpty(bestURL)) {
-                        createSession(Session.Source.ACTION_SEND, bestURL ?: "")
+                        createSession(SessionState.Source.ACTION_SEND, bestURL ?: "")
                     } else {
                         createSearchSession(
-                            Session.Source.ACTION_SEND,
+                            SessionState.Source.ACTION_SEND,
                             UrlUtils.createSearchUrl(context, dataString),
                             dataString ?: "")
                     }
                 } else {
-                    createSession(Session.Source.ACTION_SEND, dataString ?: "")
+                    createSession(SessionState.Source.ACTION_SEND, dataString ?: "")
                 }
             }
 
@@ -119,22 +120,22 @@ class IntentProcessor(
         }
     }
 
-    private fun createSession(source: Session.Source, url: String): Session {
+    private fun createSession(source: SessionState.Source, url: String): Session {
         return Session(url, source = source).apply {
             sessionManager.add(this, selected = true)
         }
     }
 
-    private fun createSearchSession(source: Session.Source, url: String, searchTerms: String): Session {
+    private fun createSearchSession(source: SessionState.Source, url: String, searchTerms: String): Session {
         return Session(url, source = source).apply {
             this.searchTerms = searchTerms
             sessionManager.add(this, selected = true)
         }
     }
 
-    private fun createSession(source: Session.Source, intent: SafeIntent, url: String): Session {
+    private fun createSession(source: SessionState.Source, intent: SafeIntent, url: String): Session {
         return if (isCustomTabIntent(intent.unsafe)) {
-            Session(url, source = Session.Source.CUSTOM_TAB).apply {
+            Session(url, source = SessionState.Source.CUSTOM_TAB).apply {
                 customTabConfig = createCustomTabConfigFromIntent(intent.unsafe, context.resources)
                 sessionManager.add(this, selected = false)
             }
@@ -146,14 +147,14 @@ class IntentProcessor(
     }
 
     private fun createSession(
-        source: Session.Source,
+        source: SessionState.Source,
         intent: SafeIntent,
         url: String,
         blockingEnabled: Boolean,
         requestDesktop: Boolean
     ): Session {
         val session = if (isCustomTabIntent(intent)) {
-            Session(url, source = Session.Source.CUSTOM_TAB).apply {
+            Session(url, source = SessionState.Source.CUSTOM_TAB).apply {
                 customTabConfig = createCustomTabConfigFromIntent(intent.unsafe, context.resources)
             }
         } else {

--- a/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
@@ -11,6 +11,7 @@ import android.view.ContextThemeWrapper
 import android.view.View
 import android.widget.TextView
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.state.state.SessionState
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
 
@@ -36,7 +37,7 @@ abstract class LearnMoreSwitchPreference(context: Context?, attrs: AttributeSet?
         learnMoreLink.setOnClickListener {
             // This is a hardcoded link: if we ever end up needing more of these links, we should
             // move the link into an xml parameter, but there's no advantage to making it configurable now.
-            val session = Session(getLearnMoreUrl(), source = Session.Source.MENU)
+            val session = Session(getLearnMoreUrl(), source = SessionState.Source.MENU)
             context.components.sessionManager.add(session, selected = true)
             if (context is ContextThemeWrapper) {
                 if ((context as ContextThemeWrapper).baseContext is Activity) {

--- a/app/src/main/java/org/mozilla/focus/settings/MozillaSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/MozillaSettingsFragment.kt
@@ -8,6 +8,7 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.preference.Preference
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.state.state.SessionState
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.InfoActivity
 import org.mozilla.focus.ext.components
@@ -55,7 +56,7 @@ class MozillaSettingsFragment : BaseSettingsFragment(),
                 startActivity(intent)
             }
             resources.getString(R.string.pref_key_help) -> run {
-                val session = Session(SupportUtils.HELP_URL, source = Session.Source.MENU)
+                val session = Session(SupportUtils.HELP_URL, source = SessionState.Source.MENU)
                 activity.components.sessionManager.add(session, true)
                 activity.finish()
             }
@@ -69,7 +70,7 @@ class MozillaSettingsFragment : BaseSettingsFragment(),
                 else
                     SupportUtils.PRIVACY_NOTICE_URL
 
-                val session = Session(url, source = Session.Source.MENU)
+                val session = Session(url, source = SessionState.Source.MENU)
                 activity.components.sessionManager.add(session, true)
                 activity.finish()
             }

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetrySessionObserver.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetrySessionObserver.kt
@@ -7,15 +7,16 @@ package org.mozilla.focus.telemetry
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.state.CustomTabConfig
+import mozilla.components.browser.state.state.SessionState
 
 class TelemetrySessionObserver : SessionManager.Observer {
     override fun onSessionAdded(session: Session) {
         when (session.source) {
-            Session.Source.ACTION_VIEW -> TelemetryWrapper.browseIntentEvent()
-            Session.Source.ACTION_SEND -> TelemetryWrapper.shareIntentEvent(session.searchTerms.isNotEmpty())
-            Session.Source.TEXT_SELECTION -> TelemetryWrapper.textSelectionIntentEvent()
-            Session.Source.HOME_SCREEN -> TelemetryWrapper.openHomescreenShortcutEvent()
-            Session.Source.CUSTOM_TAB -> TelemetryWrapper.customTabsIntentEvent(
+            SessionState.Source.ACTION_VIEW -> TelemetryWrapper.browseIntentEvent()
+            SessionState.Source.ACTION_SEND -> TelemetryWrapper.shareIntentEvent(session.searchTerms.isNotEmpty())
+            SessionState.Source.TEXT_SELECTION -> TelemetryWrapper.textSelectionIntentEvent()
+            SessionState.Source.HOME_SCREEN -> TelemetryWrapper.openHomescreenShortcutEvent()
+            SessionState.Source.CUSTOM_TAB -> TelemetryWrapper.customTabsIntentEvent(
                     generateOptions(session.customTabConfig!!))
             else -> {
                 // For other session types we create events at the place where we create the sessions.

--- a/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
+++ b/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.state.state.SessionState
 import org.mozilla.focus.R.string.app_name
 import org.mozilla.focus.R.string.tip_add_to_homescreen
 import org.mozilla.focus.R.string.tip_autocomplete_url
@@ -44,7 +45,7 @@ class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val d
             val url = SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.ALLOWLIST)
 
             val deepLink = {
-                val session = Session(url, source = Session.Source.MENU)
+                val session = Session(url, source = SessionState.Source.MENU)
                 context.components.sessionManager.add(session, selected = true)
                 TelemetryWrapper.pressTipEvent(id)
             }
@@ -76,7 +77,7 @@ class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val d
                     "https://support.mozilla.org/en-US/kb/add-web-page-shortcuts-your-home-screen"
 
             val deepLinkAddToHomescreen = {
-                val session = Session(homescreenURL, source = Session.Source.MENU)
+                val session = Session(homescreenURL, source = SessionState.Source.MENU)
                 context.components.sessionManager.add(session, selected = true)
                 TelemetryWrapper.pressTipEvent(id)
             }
@@ -123,7 +124,7 @@ class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val d
             }
 
             val deepLinkAutocompleteUrl = {
-                val session = Session(autocompleteURL, source = Session.Source.MENU)
+                val session = Session(autocompleteURL, source = SessionState.Source.MENU)
                 context.components.sessionManager.add(session, selected = true)
                 TelemetryWrapper.pressTipEvent(id)
             }
@@ -142,7 +143,7 @@ class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val d
             }
 
             val deepLinkOpenInNewTab = {
-                val session = Session(newTabURL, source = Session.Source.MENU)
+                val session = Session(newTabURL, source = SessionState.Source.MENU)
                 context.components.sessionManager.add(session, selected = true)
                 TelemetryWrapper.pressTipEvent(id)
             }
@@ -161,7 +162,7 @@ class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val d
             }
 
             val deepLinkRequestDesktop = {
-                val session = Session(requestDesktopURL, source = Session.Source.MENU)
+                val session = Session(requestDesktopURL, source = SessionState.Source.MENU)
                 context.components.sessionManager.add(session, selected = true)
                 TelemetryWrapper.pressTipEvent(id)
             }

--- a/app/src/main/java/org/mozilla/focus/utils/SupportUtils.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/SupportUtils.kt
@@ -15,6 +15,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.provider.Settings
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.state.state.SessionState
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.locale.Locales
 import java.io.UnsupportedEncodingException
@@ -80,7 +81,7 @@ object SupportUtils {
     }
 
     fun openDefaultBrowserSumoPage(context: Context) {
-        val session = Session(SupportUtils.DEFAULT_BROWSER_URL, source = Session.Source.MENU)
+        val session = Session(SupportUtils.DEFAULT_BROWSER_URL, source = SessionState.Source.MENU)
         context.components.sessionManager.add(session, selected = true)
 
         if (context is Activity) {

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     ext.espresso_version = '3.1.0-alpha4'
     ext.kotlin_version = '1.3.61'
     ext.coroutines_version = '1.3.0'
-    ext.mozilla_components_version = '49.0.1'
-    ext.gecko_release_version = '78.0.20200708170202'
+    ext.mozilla_components_version = '53.0.0'
+    ext.gecko_release_version = '79.0.20200720193547'
 
     repositories {
         google()


### PR DESCRIPTION
 - Removed GV telemetry API which is no longer available.
 - `Session.Source` -> `SessionState.Source`