### PR TITLE
Close #4602: Move Custom Tab session ID check to MainActivity

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/CustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/CustomTabActivity.kt
@@ -30,14 +30,6 @@ class CustomTabActivity : MainActivity() {
         customTabId = intent.getStringExtra(CUSTOM_TAB_ID)
             ?: throw IllegalAccessError("No custom tab id in intent")
 
-        // The session for this ID, no longer exists. This usually happens because we were gc-d
-        // and since we do not save custom tab sessions, the activity is re-created and we no longer
-        // have a session with us to restore. It's safer to finish the activity instead.
-        if (components.sessionManager.findSessionById(customTabId) == null) {
-            finish()
-            return
-        }
-
         super.onCreate(savedInstanceState)
     }
 

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -16,6 +16,7 @@ import mozilla.components.browser.state.state.SessionState
 import mozilla.components.lib.crash.Crash
 import mozilla.components.support.utils.SafeIntent
 import org.mozilla.focus.R
+import org.mozilla.focus.activity.CustomTabActivity.Companion.CUSTOM_TAB_ID
 import org.mozilla.focus.biometrics.Biometrics
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.fragment.BrowserFragment
@@ -49,6 +50,16 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val customTabId = intent.getStringExtra(CUSTOM_TAB_ID)
+
+        // The session for this ID, no longer exists. This usually happens because we were gc-d
+        // and since we do not save custom tab sessions, the activity is re-created and we no longer
+        // have a session with us to restore. It's safer to finish the activity instead.
+        if (customTabId != null && components.sessionManager.findSessionById(customTabId) == null) {
+            finish()
+            return
+        }
 
         if (!isTaskRoot) {
             if (intent.hasCategory(Intent.CATEGORY_LAUNCHER) && Intent.ACTION_MAIN == intent.action) {


### PR DESCRIPTION
The check that we originally added would usually have been enough, but
we made a mistake in on caling super. The problem gets complicated
there, because we want to call super for the `AppCompatActivity` and not
the `MainActivity` which is where the crash happens when we use a
session ID in the MainActivity for observing session changes that are
happening on a non-existent Custom Tab.

The fix here is to move the check we had in the `CustomTabActivity` to
the `MainActivity`. This is by no means ideal in term of
separation-of-concerns, but for a patch fix, it allows us to gracefully
exit.