### PR TITLE
Update to AC 57.0.6 and GV 81.0.20200917005511

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         targetSdkVersion 28
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
                        // override this with a generated versionCode at build time.
-        versionName "8.7.2"
+        versionName "8.8.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled true

--- a/app/src/main/java/org/mozilla/focus/web/GeckoWebViewProvider.kt
+++ b/app/src/main/java/org/mozilla/focus/web/GeckoWebViewProvider.kt
@@ -410,6 +410,13 @@ class GeckoWebViewProvider : IWebViewProvider {
                     geckoSession.loadUri(currentUrl)
                 }
 
+                override fun onKill(session: GeckoSession) {
+                    // Ensure the session that was killed is the same session we act on.
+                    geckoSession = session
+                    geckoSession.open(geckoRuntime!!)
+                    geckoSession.loadUri(currentUrl)
+                }
+
                 override fun onFocusRequest(geckoSession: GeckoSession) {}
 
                 override fun onCloseRequest(geckoSession: GeckoSession) {

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     ext.espresso_version = '3.1.0-alpha4'
     ext.kotlin_version = '1.3.61'
     ext.coroutines_version = '1.3.0'
-    ext.mozilla_components_version = '54.0.5'
-    ext.gecko_release_version = '80.0.20200827204751'
+    ext.mozilla_components_version = '57.0.6'
+    ext.gecko_release_version = '81.0.20200917005511'
 
     repositories {
         google()


### PR DESCRIPTION
 - Fixes a bug where the session is killed and we were not able to recover from it.
 - Bumps version to 8.8.0.