### PR TITLE
Remove unnecessary logging of URLs (fixes #4630)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -151,3 +151,13 @@
 -dontwarn java.beans.BeanInfo
 -dontwarn java.beans.IntrospectionException
 -dontwarn java.beans.FeatureDescriptor
+
+####################################################################################################
+# REMOVE all Log messages except warnings and errors
+####################################################################################################
+-assumenosideeffects class android.util.Log {
+    public static boolean isLoggable(java.lang.String, int);
+    public static int v(...);
+    public static int i(...);
+    public static int d(...);
+}

--- a/app/src/main/java/org/mozilla/focus/observer/LoadTimeObserver.kt
+++ b/app/src/main/java/org/mozilla/focus/observer/LoadTimeObserver.kt
@@ -25,7 +25,7 @@ object LoadTimeObserver {
             override fun onUrlChanged(session: Session, url: String) {
                 if ((urlLoading != null && urlLoading != url) || urlLoading == null) {
                     startLoadTime = SystemClock.elapsedRealtime()
-                    Log.i(LOG_TAG, "zerdatime $startLoadTime - url changed to $url, new page load start")
+                    Log.i(LOG_TAG, "zerdatime $startLoadTime - url changed, new page load start")
                     urlLoading = url
                 }
             }

--- a/app/src/main/java/org/mozilla/focus/web/GeckoWebViewProvider.kt
+++ b/app/src/main/java/org/mozilla/focus/web/GeckoWebViewProvider.kt
@@ -94,6 +94,7 @@ class GeckoWebViewProvider : IWebViewProvider {
             }
             runtimeSettingsBuilder.contentBlocking(contentBlockingBuilder.build())
             runtimeSettingsBuilder.crashHandler(CrashHandlerService::class.java)
+            runtimeSettingsBuilder.consoleOutput(false)
 
             geckoRuntime =
                     GeckoRuntime.create(context.applicationContext, runtimeSettingsBuilder.build())


### PR DESCRIPTION
This strips out non-dire logging from release builds using proguard rules, disables logging of console output, and removes one instance where LoadTimeObserver could potentially include a URL in logging. Fixes #4630 