### PR TITLE
Disable GeckoView's debug logging.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/web/GeckoWebViewProvider.kt
+++ b/app/src/main/java/org/mozilla/focus/web/GeckoWebViewProvider.kt
@@ -95,6 +95,7 @@ class GeckoWebViewProvider : IWebViewProvider {
             runtimeSettingsBuilder.contentBlocking(contentBlockingBuilder.build())
             runtimeSettingsBuilder.crashHandler(CrashHandlerService::class.java)
             runtimeSettingsBuilder.consoleOutput(false)
+            runtimeSettingsBuilder.debugLogging(false)
 
             geckoRuntime =
                     GeckoRuntime.create(context.applicationContext, runtimeSettingsBuilder.build())


### PR DESCRIPTION
Removes some unnecessary/unwanted logging.