### PR TITLE
Update to Android Components 63.0.0 and GeckoView 82

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -164,7 +164,7 @@ dependencies {
     implementation "org.mozilla.components:feature-customtabs:$mozilla_components_version"
     implementation "org.mozilla.components:lib-crash:$mozilla_components_version"
     implementation "org.mozilla.components:lib-fetch-httpurlconnection:$mozilla_components_version"
-    implementation "org.mozilla.components:service-telemetry:$mozilla_components_version"
+    implementation "org.mozilla.components:service-telemetry:$mozilla_components_version_telemetry"
     implementation "org.mozilla.components:service-fretboard:$mozilla_components_version", {
         exclude group: 'android.arch.work', module: 'work-runtime'
     }

--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -11,13 +11,13 @@ import mozilla.components.browser.search.provider.AssetsSearchEngineProvider
 import mozilla.components.browser.search.provider.localization.LocaleSearchLocalizationProvider
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.base.profiler.Profiler
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
-import mozilla.components.concept.engine.profiler.Profiler
 import mozilla.components.concept.engine.utils.EngineVersion
 import org.json.JSONObject
 import org.mozilla.focus.search.BingSearchEngineFilter

--- a/app/src/main/java/org/mozilla/focus/ext/Session.kt
+++ b/app/src/main/java/org/mozilla/focus/ext/Session.kt
@@ -6,6 +6,7 @@ package org.mozilla.focus.ext
 
 import android.os.Bundle
 import mozilla.components.browser.session.Session
+import org.mozilla.geckoview.GeckoSession
 import java.util.WeakHashMap
 
 // Extension methods on the Session class. This is used for additional session data that is not part
@@ -25,9 +26,23 @@ private fun getOrPutExtension(session: Session): SessionExtension {
 }
 
 private class SessionExtension {
+    var savedGeckoSession: GeckoSession? = null
     var savedWebViewState: Bundle? = null
     var shouldRequestDesktopSite: Boolean = false
 }
+
+/**
+ * Saving the Gecko Session attached to the component session. We need this now because we can no
+ * longer serialize a gecko session into a [Bundle] as we did before.
+ *
+ * Temporary solution until we can use the browser-engine component.
+ *
+ * Component upstream issue:
+ * https://github.com/mozilla-mobile/android-components/issues/408
+ */
+var Session.savedGeckoSession: GeckoSession?
+    get() = getOrPutExtension(this).savedGeckoSession
+    set(value) { getOrPutExtension(this).savedGeckoSession = value }
 
 /**
  * Saving the state attached ot a session.

--- a/app/src/main/java/org/mozilla/focus/fragment/WebFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/WebFragment.kt
@@ -14,6 +14,7 @@ import android.webkit.WebView
 import mozilla.components.browser.session.Session
 
 import org.mozilla.focus.R
+import org.mozilla.focus.ext.savedGeckoSession
 import org.mozilla.focus.ext.savedWebViewState
 import org.mozilla.focus.ext.shouldRequestDesktopSite
 import org.mozilla.focus.locale.LocaleAwareFragment
@@ -136,7 +137,9 @@ abstract class WebFragment : LocaleAwareFragment() {
 
     private fun loadInitialUrl() {
         val session = session
-        if (session == null || session.savedWebViewState == null) {
+        if (session == null ||
+            session.savedWebViewState == null ||
+            session.savedGeckoSession == null) {
             val url = initialUrl
             if (!TextUtils.isEmpty(url)) {
                 webViewInstance!!.loadUrl(url)
@@ -146,7 +149,9 @@ abstract class WebFragment : LocaleAwareFragment() {
 
     private fun restoreStateOrLoadUrl() {
         val session = session
-        if (session == null || session.savedWebViewState == null) {
+        if (session == null ||
+            session.savedWebViewState == null ||
+            session.savedGeckoSession == null) {
             val url = initialUrl
             if (!TextUtils.isEmpty(url)) {
                 webViewInstance!!.loadUrl(url)

--- a/app/src/main/java/org/mozilla/focus/session/SessionCallbackProxy.kt
+++ b/app/src/main/java/org/mozilla/focus/session/SessionCallbackProxy.kt
@@ -37,7 +37,7 @@ class SessionCallbackProxy(private val session: Session, private val delegate: I
     override fun onPageFinished(isSecure: Boolean) {
         session.progress = MAXIMUM_PROGRESS
         session.loading = false
-        if (!isDownload || !AppConstants.isGeckoBuild) {
+        if (!isDownload && !AppConstants.isGeckoBuild) {
             session.securityInfo = Session.SecurityInfo(
                 isSecure,
                 session.securityInfo.host,

--- a/app/src/main/java/org/mozilla/focus/session/SessionManagerExtension.kt
+++ b/app/src/main/java/org/mozilla/focus/session/SessionManagerExtension.kt
@@ -6,15 +6,12 @@ package org.mozilla.focus.session
 
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
-import org.mozilla.focus.ext.savedWebViewState
+import org.mozilla.focus.ext.savedGeckoSession
 import org.mozilla.focus.utils.AppConstants
-import org.mozilla.focus.web.GeckoWebViewProvider
-import org.mozilla.geckoview.GeckoSession
 
 fun SessionManager.removeAndCloseSession(session: Session) {
     if (AppConstants.isGeckoBuild) {
-        val geckoSession =
-            session.savedWebViewState?.getParcelable<GeckoSession>(GeckoWebViewProvider.GECKO_SESSION)
+        val geckoSession = session.savedGeckoSession
         if (geckoSession != null && geckoSession.isOpen) {
             geckoSession.close()
         }
@@ -25,8 +22,7 @@ fun SessionManager.removeAndCloseSession(session: Session) {
 fun SessionManager.removeAndCloseAllSessions() {
     if (AppConstants.isGeckoBuild) {
         sessions.forEach { session ->
-            val geckoSession =
-                session.savedWebViewState?.getParcelable<GeckoSession>(GeckoWebViewProvider.GECKO_SESSION)
+            val geckoSession = session.savedGeckoSession
             if (geckoSession != null && geckoSession.isOpen) {
                 geckoSession.close()
             }
@@ -38,8 +34,7 @@ fun SessionManager.removeAndCloseAllSessions() {
 fun SessionManager.removeAllAndCloseAllSessions() {
     if (AppConstants.isGeckoBuild) {
         all.forEach { session ->
-            val geckoSession =
-                session.savedWebViewState?.getParcelable<GeckoSession>(GeckoWebViewProvider.GECKO_SESSION)
+            val geckoSession = session.savedGeckoSession
             if (geckoSession != null && geckoSession.isOpen) {
                 geckoSession.close()
             }

--- a/app/src/main/java/org/mozilla/focus/web/GeckoWebViewProvider.kt
+++ b/app/src/main/java/org/mozilla/focus/web/GeckoWebViewProvider.kt
@@ -622,9 +622,10 @@ class GeckoWebViewProvider : IWebViewProvider {
                     geckoSession.open(geckoRuntime!!)
                 }
                 setSession(geckoSession)
-            } else {
+            } else if (restored) {
                 // App was backgrounded and restored;
-                // GV restored the GeckoSession itself, but we need to restore our variables
+                geckoSession = savedSession
+                setSession(geckoSession)
                 canGoBack = stateData.getBoolean(CAN_GO_BACK, false)
                 canGoForward = stateData.getBoolean(CAN_GO_FORWARD, false)
                 isSecure = stateData.getBoolean(IS_SECURE, false)
@@ -644,7 +645,6 @@ class GeckoWebViewProvider : IWebViewProvider {
         }
 
         override fun saveWebViewState(session: Session) {
-            session.savedGeckoSession = geckoSession
             val sessionBundle = Bundle()
             sessionBundle.putBoolean(CAN_GO_BACK, canGoBack)
             sessionBundle.putBoolean(CAN_GO_FORWARD, canGoForward)
@@ -652,6 +652,7 @@ class GeckoWebViewProvider : IWebViewProvider {
             sessionBundle.putString(WEBVIEW_TITLE, webViewTitle)
             sessionBundle.putString(CURRENT_URL, currentUrl)
             session.savedWebViewState = sessionBundle
+            session.savedGeckoSession = geckoSession
         }
 
         override fun getTitle(): String? {

--- a/app/src/test/java/org/mozilla/focus/telemetry/HistogramTest.kt
+++ b/app/src/test/java/org/mozilla/focus/telemetry/HistogramTest.kt
@@ -14,6 +14,7 @@ import org.junit.Assert.assertTrue
 class HistogramTest {
 
     @Test
+    @Suppress("Deprecation")
     fun testAddLoadToHistogram() {
         TelemetryWrapper.addLoadToHistogram("https://www.mozilla.org", 99L)
         TelemetryWrapper.addLoadToHistogram("https://www.mozilla.org/en-US/MPL/", 199L)

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,11 @@ buildscript {
     ext.espresso_version = '3.1.0-alpha4'
     ext.kotlin_version = '1.3.61'
     ext.coroutines_version = '1.3.0'
-    ext.mozilla_components_version = '57.0.9'
-    ext.gecko_release_version = '81.0.20201108175212'
+    ext.gecko_release_version = '82.0.20201014125134'
+    ext.mozilla_components_version = '63.0.0'
+    // Pinning the last working version of the service-telemetry component until we decide
+    // what we want to do with telemetry in the app.
+    ext.mozilla_components_version_telemetry = '57.0.9'
 
     repositories {
         google()


### PR DESCRIPTION
 - The `service-telemetry` component is now removed so we pin the
 version to the last released version. I opted for pinning instead of
 removing the component until we know what we want to remove/replace it
 with in the future. We have already disabled the GV integration as well
 and pinning just makes the diff smaller.
 - Added the GeckoSession to the `SessionExtensions` hashmap now that
 GeckoSession is no longer Parcelable and Focus relies on holding the
 in-memory instance of the session when using the 'open-in' feature.

The questionable part here is holding a weak ref to the GeckoSession which we were previously putting into the `Bundle` and ignoring the `about:blank` loading in the `GeckoWebViewProvider`.