### PR TITLE
Fixed issue #4645

### DIFF
--- a/app/src/main/res/xml/privacy_security_settings.xml
+++ b/app/src/main/res/xml/privacy_security_settings.xml
@@ -72,6 +72,7 @@
         android:layout="@layout/focus_preference_category"
         android:title="@string/preference_category_cookies">
         <org.mozilla.focus.widget.CookiesPreference
+            android:defaultValue="@string/preference_privacy_should_block_cookies_third_party_tracker_cookies_option"
             android:entries="@array/preference_privacy_cookies_options"
             android:entryValues="@array/preference_privacy_cookies_options"
             android:key="@string/pref_key_performance_enable_cookies"


### PR DESCRIPTION
… 3rd-party tracker cookies only".

This makes sense as the condition at PrivacySecuritySettingsFragment.kt line 43 ( if (!AppConstants.isGeckoBuild)) is never satisfied because AppConstants.kt defines isGeckoBuild to always be true.

This resolves the issue #4645

