### PR TITLE
Closes #4669: Fix UI Test Task

### DIFF
--- a/tools/taskcluster/schedule-master-build.py
+++ b/tools/taskcluster/schedule-master-build.py
@@ -83,8 +83,8 @@ def generate_ui_test_task(dependencies, engine="Klar", device="arm"):
 
     task_name = "(Focus for Android) UI tests - {0} {1}".format(engine, device)
     task_description = "Run UI tests for {0} build for Android.".format(engine, device)
-    build_dir = "assemble{0}Debug".format(assemble_engine, device.capitalize())
-    build_dir_test = "assemble{0}DebugAndroidTest".format(assemble_engine, device.capitalize())
+    build_dir = "assemble{0}{1}Debug".format(assemble_engine, device.capitalize())
+    build_dir_test = "assemble{0}{1}DebugAndroidTest".format(assemble_engine, device.capitalize())
     print('BUILD_DIR: {0}'.format(build_dir))
     print('BUILD_DIR_TEST: {0}'.format(build_dir_test))
     device = device.lower()


### PR DESCRIPTION
Fixes build_dir / build_dir_test pathing for Gradle command

assembleFocusArmDebug
assembleFocusArmDebugAndroidTest