### PR TITLE
Version 8.11.3 with GV 84.0.20210105180113

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         targetSdkVersion 29
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
                        // override this with a generated versionCode at build time.
-        versionName "8.11.2"
+        versionName "8.11.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled true

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     ext.espresso_version = '3.1.0-alpha4'
     ext.kotlin_version = '1.3.61'
     ext.coroutines_version = '1.3.0'
-    ext.gecko_release_version = '84.0.20201223151259'
-    ext.mozilla_components_version = '70.0.5'
+    ext.gecko_release_version = '84.0.20210105180113'
+    ext.mozilla_components_version = '70.0.7'
     // Pinning the last working version of the service-telemetry component until we decide
     // what we want to do with telemetry in the app.
     ext.mozilla_components_version_telemetry = '57.0.9'


### PR DESCRIPTION
This patch updates GV to 84.0.20210105180113 through A-C 70.0.7. It also sets the Focus version to 8.11.3.