### PR TITLE
Update to AC 70.0.15 and GeckoView 85.0.20210118153634

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         targetSdkVersion 29
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
                        // override this with a generated versionCode at build time.
-        versionName "8.11.3"
+        versionName "8.11.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled true

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     ext.espresso_version = '3.1.0-alpha4'
     ext.kotlin_version = '1.3.61'
     ext.coroutines_version = '1.3.0'
-    ext.gecko_release_version = '84.0.20210105180113'
-    ext.mozilla_components_version = '70.0.7'
+    ext.gecko_release_version = '85.0.20210118153634'
+    ext.mozilla_components_version = '70.0.15'
     // Pinning the last working version of the service-telemetry component until we decide
     // what we want to do with telemetry in the app.
     ext.mozilla_components_version_telemetry = '57.0.9'


### PR DESCRIPTION
Will restart build when the AC release is published.