### PR TITLE
Close #4699: Remove ExperimentsSyncService registering in AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -135,11 +135,6 @@
         <service android:name=".session.SessionNotificationService"
             android:exported="false" />
 
-        <service
-            android:name=".utils.ExperimentsSyncService"
-            android:exported="false"
-            android:permission="android.permission.BIND_JOB_SERVICE" />
-
         <meta-data android:name="android.webkit.WebView.MetricsOptOut"
                    android:value="true" />
     </application>


### PR DESCRIPTION
One more reference of Fretboard to remove for https://github.com/mozilla-mobile/focus-android/pull/4693