### PR TITLE
Update to GeckoView 86.0.20210222142601

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         targetSdkVersion 29
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
                        // override this with a generated versionCode at build time.
-        versionName "8.13.0"
+        versionName "8.13.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled true

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.espresso_version = '3.1.0-alpha4'
     ext.kotlin_version = '1.3.61'
     ext.coroutines_version = '1.3.0'
-    ext.gecko_release_version = '86.0.20210217195321'
+    ext.gecko_release_version = '86.0.20210222142601'
     ext.mozilla_components_version = '72.0.15'
     // Pinning the last working version of the service-telemetry component until we decide
     // what we want to do with telemetry in the app.


### PR DESCRIPTION
Not bumping A-C here since it isn't explicitly needed and this will allow us to get the next release out sooner with the crash fix that already landed.