### PR TITLE
Close #4527: Add share image context menu support

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -51,6 +51,7 @@ import mozilla.components.feature.contextmenu.ContextMenuFeature
 import mozilla.components.feature.downloads.AbstractFetchDownloadService
 import mozilla.components.feature.downloads.DownloadsFeature
 import mozilla.components.feature.downloads.manager.FetchDownloadManager
+import mozilla.components.feature.downloads.share.ShareDownloadFeature
 import mozilla.components.feature.findinpage.view.FindInPageBar
 import mozilla.components.feature.prompts.PromptFeature
 import mozilla.components.feature.session.FullScreenFeature
@@ -127,6 +128,7 @@ class BrowserFragment :
     private val promptFeature = ViewBoundFeatureWrapper<PromptFeature>()
     private val contextMenuFeature = ViewBoundFeatureWrapper<ContextMenuFeature>()
     private val downloadsFeature = ViewBoundFeatureWrapper<DownloadsFeature>()
+    private val shareDownloadFeature = ViewBoundFeatureWrapper<ShareDownloadFeature>()
 
     private val urlBinding = ViewBoundFeatureWrapper<UrlBinding>()
     private val securityInfoBinding = ViewBoundFeatureWrapper<SecurityInfoBinding>()
@@ -278,6 +280,13 @@ class BrowserFragment :
                 onDownloadStopped = { state, _, status ->
                     showDownloadSnackbar(state, status)
                 }
+        ), this, view)
+
+        shareDownloadFeature.set(ShareDownloadFeature(
+            context = requireContext().applicationContext,
+            httpClient = components.client,
+            store = components.store,
+            tabId = session.id
         ), this, view)
 
         urlBinding.set(

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.espresso_version = '3.1.0-alpha4'
     ext.kotlin_version = '1.3.61'
     ext.coroutines_version = '1.3.0'
-    ext.mozilla_components_version = '72.0.15'
+    ext.mozilla_components_version = '73.0.8'
     // Pinning the last working version of the service-telemetry component until we decide
     // what we want to do with telemetry in the app.
     ext.mozilla_components_version_telemetry = '57.0.9'


### PR DESCRIPTION
Adds the `ShareDownloadFeature` to support the "Share Image" context menu which fixes #4527:

<img width="510" alt="Screen Shot 2021-03-12 at 6 45 52 PM" src="https://user-images.githubusercontent.com/1370580/110955982-29e10a80-8318-11eb-8ceb-4f8ce877ad6c.png">

