### PR TITLE
BrowserFragment: Start to replace Session usage with browser-state

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/binding/MenuBinding.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/binding/MenuBinding.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
+import org.mozilla.focus.ext.ifCustomTab
 import org.mozilla.focus.fragment.BrowserFragment
 import org.mozilla.focus.menu.browser.BrowserMenu
 import java.lang.ref.WeakReference
@@ -54,7 +55,7 @@ class MenuBinding(
     }
 
     override fun onClick(view: View) {
-        val menu = BrowserMenu(fragment.requireContext(), fragment, fragment.session.customTabConfig)
+        val menu = BrowserMenu(fragment.requireContext(), fragment, fragment.tab.ifCustomTab()?.config)
         menu.show(menuView)
 
         menuReference = WeakReference(menu)

--- a/app/src/main/java/org/mozilla/focus/ext/SessionState.kt
+++ b/app/src/main/java/org/mozilla/focus/ext/SessionState.kt
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.ext
+
+import mozilla.components.browser.state.state.CustomTabSessionState
+import mozilla.components.browser.state.state.SessionState
+
+/**
+ * Returns this [SessionState] cast to [CustomTabSessionState] if possible. Otherwise returns `null`.
+ */
+fun SessionState.ifCustomTab(): CustomTabSessionState? {
+    if (this is CustomTabSessionState) {
+        return this
+    }
+    return null
+}
+
+/**
+ * Returns `true` if this [SessionState] is a custom tab (an instance of [CustomTabSessionState]).
+ */
+fun SessionState.isCustomTab(): Boolean {
+    return this is CustomTabSessionState
+}

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -111,10 +111,10 @@ class UrlInputFragment :
         }
 
         @JvmStatic
-        fun createWithSession(session: Session, urlView: View): UrlInputFragment {
+        fun createWithTab(tabId: String, urlView: View): UrlInputFragment {
             val arguments = Bundle()
 
-            arguments.putString(ARGUMENT_SESSION_UUID, session.id)
+            arguments.putString(ARGUMENT_SESSION_UUID, tabId)
             arguments.putString(ARGUMENT_ANIMATION, ANIMATION_BROWSER_SCREEN)
 
             val screenLocation = IntArray(2)
@@ -357,7 +357,7 @@ class UrlInputFragment :
                     ?.beginTransaction()
                     ?.replace(
                             R.id.container,
-                            UrlInputFragment.createWithSession(session!!, urlView),
+                            UrlInputFragment.createWithTab(session!!.id, urlView),
                             UrlInputFragment.FRAGMENT_TAG)
                     ?.commit()
         } else {

--- a/app/src/main/java/org/mozilla/focus/menu/browser/RequestDesktopCheckItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/focus/menu/browser/RequestDesktopCheckItemViewHolder.kt
@@ -7,16 +7,12 @@ package org.mozilla.focus.menu.browser
 import android.view.View
 import android.widget.CheckBox
 import android.widget.CompoundButton
-import mozilla.components.browser.state.selector.findTabOrCustomTab
-
+import mozilla.components.support.utils.ThreadUtils
 import org.mozilla.focus.R
+import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.fragment.BrowserFragment
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.UrlUtils
-
-import mozilla.components.support.utils.ThreadUtils
-import org.mozilla.focus.ext.components
-import org.mozilla.focus.ext.requireComponents
 
 internal class RequestDesktopCheckItemViewHolder/* package */(
     itemView: View,
@@ -25,8 +21,7 @@ internal class RequestDesktopCheckItemViewHolder/* package */(
     private val checkbox: CheckBox = itemView.findViewById(R.id.check_menu_item_checkbox)
 
     init {
-        val tab = itemView.context.components.store.state.findTabOrCustomTab(fragment.session.id)
-        checkbox.isChecked = tab?.content?.desktopMode ?: false
+        checkbox.isChecked = fragment.tab.content.desktopMode
         checkbox.setOnCheckedChangeListener(this)
     }
 


### PR DESCRIPTION
Slowly starting to replace `Session` and `SessionManager` usage in Focus.