### PR TITLE
Close #4528: Remove HttpUrlConnection and OkHttp usages

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -206,7 +206,7 @@ dependencies {
 
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
-    testImplementation "org.mozilla.components:lib-fetch-httpurlconnection:$mozilla_components_version"
+    testImplementation "org.mozilla.components:lib-fetch-okhttp:$mozilla_components_version"
 
     androidTestImplementation "tools.fastlane:screengrab:2.0.0", {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -174,14 +174,11 @@ dependencies {
     implementation "org.mozilla.components:feature-session:$mozilla_components_version"
     implementation "org.mozilla.components:feature-tabs:$mozilla_components_version"
     implementation "org.mozilla.components:lib-crash:$mozilla_components_version"
-    implementation "org.mozilla.components:lib-fetch-httpurlconnection:$mozilla_components_version"
     implementation "org.mozilla.components:service-telemetry:$mozilla_components_version_telemetry"
     implementation "org.mozilla.components:support-ktx:$mozilla_components_version"
     implementation "org.mozilla.components:support-utils:$mozilla_components_version"
     implementation "org.mozilla.components:ui-autocomplete:$mozilla_components_version"
     implementation "org.mozilla.components:ui-colors:$mozilla_components_version"
-
-    implementation 'com.squareup.okhttp3:okhttp:3.14.1'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
@@ -209,6 +206,7 @@ dependencies {
 
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
+    testImplementation "org.mozilla.components:lib-fetch-httpurlconnection:$mozilla_components_version"
 
     androidTestImplementation "tools.fastlane:screengrab:2.0.0", {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -38,7 +38,8 @@ import org.mozilla.focus.utils.Settings
  */
 class Components(
     context: Context,
-    private val engineOverride: Engine? = null
+    private val engineOverride: Engine? = null,
+    private val clientOverride: Client? = null
 ) {
     val engineDefaultSettings by lazy {
         val settings = Settings.getInstance(context)
@@ -58,7 +59,9 @@ class Components(
         }
     }
 
-    val client: Client by lazy { EngineProvider.createClient(context) }
+    val client: Client by lazy {
+        clientOverride ?: EngineProvider.createClient(context)
+    }
 
     val trackingProtectionUseCases by lazy { TrackingProtectionUseCases(store, engine) }
 

--- a/app/src/main/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsViewModel.kt
+++ b/app/src/main/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsViewModel.kt
@@ -13,6 +13,7 @@ import android.graphics.Typeface
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.style.StyleSpan
+import org.mozilla.focus.ext.components
 
 sealed class State {
     data class Disabled(val givePrompt: Boolean) : State()
@@ -38,7 +39,10 @@ class SearchSuggestionsViewModel(application: Application) : AndroidViewModel(ap
         private set
 
     init {
-        fetcher = SearchSuggestionsFetcher(preferences.getSearchEngine())
+        fetcher = SearchSuggestionsFetcher(
+            preferences.getSearchEngine(),
+            application.applicationContext.components.client
+        )
 
         suggestions = map(fetcher.results) { result ->
             val style = StyleSpan(Typeface.BOLD)

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -17,7 +17,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.preference.PreferenceManager
 import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.state.selector.privateTabs
-import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 import org.json.JSONObject
 import org.mozilla.focus.BuildConfig
@@ -265,7 +264,7 @@ object TelemetryWrapper {
 
             val serializer = JSONPingSerializer()
             val storage = FileTelemetryStorage(configuration, serializer)
-            val client = TelemetryClient(HttpURLConnectionClient())
+            val client = TelemetryClient(context.components.client)
             val scheduler = JobSchedulerTelemetryScheduler()
 
             TelemetryHolder.set(Telemetry(configuration, storage, client, scheduler)

--- a/app/src/test/java/org/mozilla/focus/TestFocusApplication.kt
+++ b/app/src/test/java/org/mozilla/focus/TestFocusApplication.kt
@@ -16,6 +16,9 @@ import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.engine.utils.EngineVersion
+import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.fetch.Request
+import mozilla.components.concept.fetch.Response
 import org.json.JSONObject
 
 /**
@@ -24,7 +27,7 @@ import org.json.JSONObject
  */
 class TestFocusApplication : FocusApplication() {
     override val components: Components by lazy {
-        Components(this, engineOverride = FakeEngine())
+        Components(this, engineOverride = FakeEngine(), clientOverride = FakeClient())
     }
 }
 
@@ -65,5 +68,11 @@ class FakeEngineSessionState : EngineSessionState {
     override fun writeTo(writer: JsonWriter) {
         writer.beginObject()
         writer.endObject()
+    }
+}
+
+class FakeClient : Client() {
+    override fun fetch(request: Request): Response {
+        throw UnsupportedOperationException()
     }
 }

--- a/app/src/test/java/org/mozilla/focus/settings/SearchEngineValidationTest.kt
+++ b/app/src/test/java/org/mozilla/focus/settings/SearchEngineValidationTest.kt
@@ -4,10 +4,13 @@
 
 package org.mozilla.focus.settings
 
+import mozilla.components.concept.fetch.Client
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.settings.ManualAddSearchEngineSettingsFragment.Companion.isValidSearchQueryURL
@@ -17,31 +20,39 @@ import org.robolectric.RobolectricTestRunner
 // This unit test is not running on an Android device. Allow me to use spaces in function names.
 @Suppress("IllegalIdentifier")
 class SearchEngineValidationTest {
+
+    lateinit var client: Client
+
+    @Before
+    fun setup() {
+        client = HttpURLConnectionClient()
+    }
+
     @Test
     fun `URL returning 200 OK is valid`() = withMockWebServer(responseWithStatus(200)) {
-        assertTrue(isValidSearchQueryURL(it.rootUrl()))
+        assertTrue(isValidSearchQueryURL(client, it.rootUrl()))
     }
 
     @Test
     fun `URL using HTTP redirect is invalid`() = withMockWebServer(responseWithStatus(301)) {
         // We now follow redirects(Issue #1976). This test now asserts false.
-        assertFalse(isValidSearchQueryURL(it.rootUrl()))
+        assertFalse(isValidSearchQueryURL(client, it.rootUrl()))
     }
 
     @Test
     fun `URL returning 404 NOT FOUND is not valid`() = withMockWebServer(responseWithStatus(404)) {
-        assertFalse(isValidSearchQueryURL(it.rootUrl()))
+        assertFalse(isValidSearchQueryURL(client, it.rootUrl()))
     }
 
     @Test
     fun `URL returning server error is not valid`() = withMockWebServer(responseWithStatus(500)) {
-        assertFalse(isValidSearchQueryURL(it.rootUrl()))
+        assertFalse(isValidSearchQueryURL(client, it.rootUrl()))
     }
 
     @Test
     fun `URL timing out is not valid`() = withMockWebServer {
         // Without queuing a response MockWebServer will not return anything and keep the connection open
-        assertFalse(isValidSearchQueryURL(it.rootUrl()))
+        assertFalse(isValidSearchQueryURL(client, it.rootUrl()))
     }
 }
 

--- a/app/src/test/java/org/mozilla/focus/settings/SearchEngineValidationTest.kt
+++ b/app/src/test/java/org/mozilla/focus/settings/SearchEngineValidationTest.kt
@@ -5,7 +5,7 @@
 package org.mozilla.focus.settings
 
 import mozilla.components.concept.fetch.Client
-import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
+import mozilla.components.lib.fetch.okhttp.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertFalse
@@ -25,7 +25,7 @@ class SearchEngineValidationTest {
 
     @Before
     fun setup() {
-        client = HttpURLConnectionClient()
+        client = OkHttpClient()
     }
 
     @Test


### PR DESCRIPTION
The `SearchSuggestionsFetcher` can be removed in the future when we decide to use the awesomebar feature, for now, this removes all the other client usages from production code.

Haven't been able to run tests on the patch because of some local gradle errors:

<details>

```
[Robolectric] org.mozilla.focus.settings.SearchEngineValidationTest.URL timing out is not valid: sdk=28; resources=BINARY
Downloading from maven 
Downloading: org/robolectric/android-all/Q-robolectric-5415296/android-all-Q-robolectric-5415296.pom from repository sonatype at https://oss.sonatype.org/content/groups/public/
Error transferring file: java.security.NoSuchAlgorithmException: Error constructing implementation (algorithm: Default, provider: SunJSSE, class: sun.security.ssl.SSLContextImpl$DefaultSSLContext)
[WARNING] Unable to get resource 'org.robolectric:android-all:pom:Q-robolectric-5415296' from repository sonatype (https://oss.sonatype.org/content/groups/public/): Error transferring file: java.security.NoSuchAlgorithmException: Error constructing implementation (algorithm: Default, provider: SunJSSE, class: sun.security.ssl.SSLContextImpl$DefaultSSLContext)
Downloading: org/robolectric/android-all/Q-robolectric-5415296/android-all-Q-robolectric-5415296.pom from repository central at http://repo1.maven.org/maven2
Error transferring file: Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/org/robolectric/android-all/Q-robolectric-5415296/android-all-Q-robolectric-5415296.pom
[WARNING] Unable to get resource 'org.robolectric:android-all:pom:Q-robolectric-5415296' from repository central (http://repo1.maven.org/maven2): Error transferring file: Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/org/robolectric/android-all/Q-robolectric-5415296/android-all-Q-robolectric-5415296.pom
Downloading: org/robolectric/android-all/Q-robolectric-5415296/android-all-Q-robolectric-5415296.jar from repository sonatype at https://oss.sonatype.org/content/groups/public/
Error transferring file: java.security.NoSuchAlgorithmException: Error constructing implementation (algorithm: Default, provider: SunJSSE, class: sun.security.ssl.SSLContextImpl$DefaultSSLContext)
[WARNING] Unable to get resource 'org.robolectric:android-all:jar:Q-robolectric-5415296' from repository sonatype (https://oss.sonatype.org/content/groups/public/): Error transferring file: java.security.NoSuchAlgorithmException: Error constructing implementation (algorithm: Default, provider: SunJSSE, class: sun.security.ssl.SSLContextImpl$DefaultSSLContext)
Downloading: org/robolectric/android-all/Q-robolectric-5415296/android-all-Q-robolectric-5415296.jar from repository central at http://repo1.maven.org/maven2
Error transferring file: Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/org/robolectric/android-all/Q-robolectric-5415296/android-all-Q-robolectric-5415296.jar
[WARNING] Unable to get resource 'org.robolectric:android-all:jar:Q-robolectric-5415296' from repository central (http://repo1.maven.org/maven2): Error transferring file: Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/org/robolectric/android-all/Q-robolectric-5415296/android-all-Q-robolectric-5415296.jar

Unable to resolve artifact: Missing:
----------
1) org.robolectric:android-all:jar:Q-robolectric-5415296

  Try downloading the file manually from the project website.

  Then, install it using the command: 
      mvn install:install-file -DgroupId=org.robolectric -DartifactId=android-all -Dversion=Q-robolectric-5415296 -Dpackaging=jar -Dfile=/path/to/file

  Alternatively, if you host your own repository you can deploy the file there: 
      mvn deploy:deploy-file -DgroupId=org.robolectric -DartifactId=android-all -Dversion=Q-robolectric-5415296 -Dpackaging=jar -Dfile=/path/to/file -Durl=[url] -DrepositoryId=[id]

  Path to dependency: 
  	1) org.apache.maven:super-pom:pom:2.0
  	2) org.robolectric:android-all:jar:Q-robolectric-5415296

```

</details>