### PR TITLE
Closed #4718: Re-add Google Cloud SDK to Dockerfile

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -70,3 +70,10 @@ RUN ./gradlew assembleFocusAarch64Debug \
 # to schedule the rest of the Taskcluster tasks. Please upgrade to taskcluster>=5 once
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1460015 is fixed
 RUN pip install 'taskcluster>=4,<5'
+
+# Install Google Cloud SDK for using Firebase Test Lab
+RUN cd /opt && curl --location --retry 5 --output gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-331.0.0-linux-x86_64.tar.gz \
+  && tar -xvf /opt/gcloud.tar.gz \
+  && rm -f gcloud.tar.gz \
+  && /opt/google-cloud-sdk/install.sh --quiet \
+  && /opt/google-cloud-sdk/bin/gcloud --quiet components update


### PR DESCRIPTION
Google SDK is needed for Firebase Test Lab for UI tests.

Originally removed in https://github.com/mozilla-mobile/focus-android/commit/a9f8f8dce58b867548d9a3d98df3ca1af2593f21 

I don't know if the removed from the above commit (at the bottom of the file) is still needed or a thing

> Needed for verifying cyclic redundancy check (CRC) headers (Google Cloud SDK)

 `python-dev` `gcc` `python-setuptools` or `crcmod` 