### PR TITLE
Update Robolectric to 4.4 and remove Jetifier

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -195,7 +195,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.3.1"
     testImplementation "junit:junit:4.12"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.3.1"
-    testImplementation "org.robolectric:robolectric:4.3" // required to support api level 28
+    testImplementation "org.robolectric:robolectric:4.4" // required to support api level 28
     testImplementation 'org.mockito:mockito-core:2.24.5'
     testImplementation "androidx.arch.core:core-testing:${architecture_components_version}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,6 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xms1g -Xmx4g
 android.enableR8=true


### PR DESCRIPTION
This has been plaguing me off late in Focus and AC.

The previous version of Robolectric still hits HTTP-only endpoints that
run into SSL exceptions when trying to upgrade. This is fixed in 4.4.

Jetifier is also no longer needed as well and we need to remove it when
upgrading Robolectric.

Related issue: https://github.com/robolectric/robolectric/issues/5456