### PR TITLE
For issue #4540: Update tracking protection policy when cookie setting change

### DIFF
--- a/app/src/main/java/org/mozilla/focus/engine/EngineSharedPreferencesListener.kt
+++ b/app/src/main/java/org/mozilla/focus/engine/EngineSharedPreferencesListener.kt
@@ -21,7 +21,8 @@ class EngineSharedPreferencesListener(
             context.getString(R.string.pref_key_privacy_block_social),
             context.getString(R.string.pref_key_privacy_block_ads),
             context.getString(R.string.pref_key_privacy_block_analytics),
-            context.getString(R.string.pref_key_privacy_block_other) ->
+            context.getString(R.string.pref_key_privacy_block_other),
+            context.getString(R.string.pref_key_performance_enable_cookies) ->
                 updateTrackingProtectionPolicy()
 
             context.getString(R.string.pref_key_safe_browsing) ->


### PR DESCRIPTION
When we change the cookie setting, users are not able to see changes applied until they restart the app, with this fix every time users change the cookie setting they will be reflected instantly.

