### PR TITLE
Resolves #4785: Explicitly set extractNativeLibs=true in app manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
     
     <application
         android:allowBackup="false"
+        android:extractNativeLibs="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"


### PR DESCRIPTION
This is a speculative GV crash fix, identical to what was landed in Fenix.