### PR TITLE
Re-enabled the SwitchContextTest.kt UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/EraseBrowsingDataTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/EraseBrowsingDataTest.kt
@@ -66,6 +66,11 @@ class EraseBrowsingDataTest {
         } catch (e: IOException) {
             throw AssertionError("Could not start web server", e)
         }
+
+        notificationTray {
+            mDevice.openNotification()
+            clearNotifications()
+        }
     }
 
     @After
@@ -108,23 +113,6 @@ class EraseBrowsingDataTest {
         }.clickEraseAndOpenNotificationButton {
             verifySnackBarText(getStringResource(R.string.feedback_erase))
             verifyEmptySearchBar()
-        }
-    }
-
-    @Test
-    fun notificationOpenButtonTest() {
-        // Open a webpage
-        searchScreen {
-        }.loadPage(webServer.url("").toString()) { }
-        // Send app to background
-        pressHomeKey()
-        // Pull down system bar and select Open
-        mDevice.openNotification()
-        notificationTray {
-            verifySystemNotificationExists(getStringResource(R.string.notification_erase_text))
-            expandEraseBrowsingNotification()
-        }.clickNotificationOpenButton {
-            verifyBrowserView()
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ImageSelectTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ImageSelectTest.kt
@@ -23,8 +23,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
 import org.mozilla.focus.helpers.TestHelper
-import org.mozilla.focus.helpers.TestHelper.appName
 import org.mozilla.focus.helpers.TestHelper.mDevice
+import org.mozilla.focus.helpers.TestHelper.packageName
 import org.mozilla.focus.helpers.TestHelper.pressBackKey
 import org.mozilla.focus.helpers.TestHelper.pressEnterKey
 import org.mozilla.focus.helpers.TestHelper.readTestAsset
@@ -39,7 +39,7 @@ class ImageSelectTest {
     private var rabbitImage: UiObject? = null
     private val imageMenuTitle = TestHelper.mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/topPanel")
+            .resourceId(packageName + ":id/topPanel")
             .enabled(true)
     )
     private val imageMenuTitleText = TestHelper.mDevice.findObject(
@@ -50,25 +50,25 @@ class ImageSelectTest {
     )
     private val shareMenu = TestHelper.mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/design_menu_item_text")
+            .resourceId(packageName + ":id/design_menu_item_text")
             .text("Share image")
             .enabled(true)
     )
     private val copyMenu = TestHelper.mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/design_menu_item_text")
+            .resourceId(packageName + ":id/design_menu_item_text")
             .text("Copy image address")
             .enabled(true)
     )
     private val saveMenu = TestHelper.mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/design_menu_item_text")
+            .resourceId(packageName + ":id/design_menu_item_text")
             .text("Save image")
             .enabled(true)
     )
     private val warning = TestHelper.mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/warning")
+            .resourceId(packageName + ":id/warning")
             .text("Saved and shared images will not be deleted when you erase Firefox Focus history.")
             .enabled(true)
     )

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MultitaskingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MultitaskingTest.kt
@@ -35,8 +35,8 @@ import org.mozilla.focus.helpers.EspressoHelper.onFloatingTabsButton
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
 import org.mozilla.focus.helpers.SessionLoadedIdlingResource
 import org.mozilla.focus.helpers.TestHelper
-import org.mozilla.focus.helpers.TestHelper.appName
 import org.mozilla.focus.helpers.TestHelper.createMockResponseFromAsset
+import org.mozilla.focus.helpers.TestHelper.packageName
 
 /**
  * Open multiple sessions and verify that the UI looks like it should.
@@ -199,12 +199,12 @@ class MultitaskingTest {
     private fun checkNewTabPopup() {
         TestHelper.mDevice.wait(
             Until.findObject(
-                By.res(appName, "snackbar_text")
+                By.res(packageName, "snackbar_text")
             ), 5000
         )
         TestHelper.mDevice.wait(
             Until.gone(
-                By.res(appName, "snackbar_text")
+                By.res(packageName, "snackbar_text")
             ), 5000
         )
     }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/OpenInExternalBrowserDialogueTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/OpenInExternalBrowserDialogueTest.kt
@@ -16,7 +16,7 @@ import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
 import org.mozilla.focus.helpers.TestHelper
-import org.mozilla.focus.helpers.TestHelper.appName
+import org.mozilla.focus.helpers.TestHelper.packageName
 import org.mozilla.focus.helpers.TestHelper.pressBackKey
 import org.mozilla.focus.helpers.TestHelper.pressEnterKey
 import org.mozilla.focus.helpers.TestHelper.readTestAsset
@@ -62,7 +62,7 @@ class OpenInExternalBrowserDialogueTest {
     init {
         val openWithBtn = TestHelper.mDevice.findObject(
             UiSelector()
-                .resourceId(appName + ":id/open_select_browser")
+                .resourceId(packageName + ":id/open_select_browser")
                 .enabled(true)
         )
         val openWithTitle = TestHelper.mDevice.findObject(
@@ -73,7 +73,7 @@ class OpenInExternalBrowserDialogueTest {
         )
         val openWithList = TestHelper.mDevice.findObject(
             UiSelector()
-                .resourceId(appName + ":id/apps")
+                .resourceId(packageName + ":id/apps")
                 .enabled(true)
         )
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SettingsBlockToggleTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SettingsBlockToggleTest.kt
@@ -19,7 +19,7 @@ import org.junit.runner.RunWith
 import org.mozilla.focus.helpers.EspressoHelper.openSettings
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
 import org.mozilla.focus.helpers.TestHelper
-import org.mozilla.focus.helpers.TestHelper.appName
+import org.mozilla.focus.helpers.TestHelper.packageName
 import org.mozilla.focus.helpers.TestHelper.pressBackKey
 import org.mozilla.focus.helpers.TestHelper.pressEnterKey
 import org.mozilla.focus.helpers.TestHelper.readTestAsset
@@ -80,7 +80,7 @@ class SettingsBlockToggleTest {
         )
         val blockAdTrackerSwitch = blockAdTrackerEntry.getChild(
             UiSelector()
-                .resourceId(appName + ":id/switchWidget")
+                .resourceId(packageName + ":id/switchWidget")
         )
         val blockAnalyticTrackerEntry = TestHelper.settingsMenu.getChild(
             UiSelector()
@@ -89,7 +89,7 @@ class SettingsBlockToggleTest {
         )
         val blockAnalyticTrackerSwitch = blockAnalyticTrackerEntry.getChild(
             UiSelector()
-                .resourceId(appName + ":id/switchWidget")
+                .resourceId(packageName + ":id/switchWidget")
         )
         val blockSocialTrackerEntry = TestHelper.settingsMenu.getChild(
             UiSelector()
@@ -98,7 +98,7 @@ class SettingsBlockToggleTest {
         )
         val blockSocialTrackerSwitch = blockSocialTrackerEntry.getChild(
             UiSelector()
-                .resourceId(appName + ":id/switchWidget")
+                .resourceId(packageName + ":id/switchWidget")
         )
 
         // Let's go to an actual URL which is http://

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ShareWebsiteTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ShareWebsiteTest.kt
@@ -17,7 +17,7 @@ import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
 import org.mozilla.focus.helpers.TestHelper
-import org.mozilla.focus.helpers.TestHelper.appName
+import org.mozilla.focus.helpers.TestHelper.packageName
 import org.mozilla.focus.helpers.TestHelper.pressBackKey
 import org.mozilla.focus.helpers.TestHelper.pressEnterKey
 import org.mozilla.focus.helpers.TestHelper.readTestAsset
@@ -70,7 +70,7 @@ class ShareWebsiteTest {
     init {
         val shareBtn = TestHelper.mDevice.findObject(
             UiSelector()
-                .resourceId(appName + ":id/share")
+                .resourceId(packageName + ":id/share")
                 .enabled(true)
         )
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SwitchContextTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SwitchContextTest.kt
@@ -1,5 +1,4 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 20; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.focus.activity
@@ -7,36 +6,33 @@ package org.mozilla.focus.activity
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
-import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.hamcrest.core.IsNull
 import org.junit.After
-import org.junit.Assert
+import org.junit.Assert.assertThat
+import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.focus.R
+import org.mozilla.focus.activity.robots.notificationTray
+import org.mozilla.focus.activity.robots.searchScreen
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
-import org.mozilla.focus.helpers.TestHelper
-import org.mozilla.focus.helpers.TestHelper.expandNotification
-import org.mozilla.focus.helpers.TestHelper.openNotification
-import org.mozilla.focus.helpers.TestHelper.pressEnterKey
+import org.mozilla.focus.helpers.TestHelper.getStringResource
+import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.pressHomeKey
 import org.mozilla.focus.helpers.TestHelper.readTestAsset
-import org.mozilla.focus.helpers.TestHelper.waitForIdle
-import org.mozilla.focus.helpers.TestHelper.waitForWebSiteTitleLoad
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 import java.io.IOException
 
-// This test opens enters and invalid URL, and Focus should provide an appropriate error message
+// This test switches out of Focus and opens it from the private browsing notification
 @RunWith(AndroidJUnit4ClassRunner::class)
-@Ignore("This test was written specifically for WebView and needs to be adapted for GeckoView")
 class SwitchContextTest {
-    private var webServer: MockWebServer? = null
+    private lateinit var webServer: MockWebServer
 
     @get: Rule
     var mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
@@ -45,7 +41,7 @@ class SwitchContextTest {
     fun setUp() {
         webServer = MockWebServer()
         try {
-            webServer!!.enqueue(
+            webServer.enqueue(
                 MockResponse()
                     .setBody(readTestAsset("image_test.html"))
                     .addHeader(
@@ -53,151 +49,93 @@ class SwitchContextTest {
                         "sphere=battery; Expires=Wed, 21 Oct 2035 07:28:00 GMT;"
                     )
             )
-            webServer!!.enqueue(
+            webServer.enqueue(
                 MockResponse()
                     .setBody(readTestAsset("rabbit.jpg"))
             )
-            webServer!!.enqueue(
+            webServer.enqueue(
                 MockResponse()
                     .setBody(readTestAsset("download.jpg"))
             )
-            webServer!!.start()
+            webServer.start()
         } catch (e: IOException) {
             throw AssertionError("Could not start web server", e)
+        }
+
+        notificationTray {
+            mDevice.openNotification()
+            clearNotifications()
         }
     }
 
     @After
     fun tearDown() {
-        mActivityTestRule.activity.finishAndRemoveTask()
         try {
-            webServer!!.close()
-            webServer!!.shutdown()
+            webServer.close()
+            webServer.shutdown()
         } catch (e: IOException) {
             throw AssertionError("Could not stop web server", e)
         }
     }
 
     @Test
-    @Throws(UiObjectNotFoundException::class)
-    fun ForegroundTest() {
-
+    fun notificationOpenButtonTest() {
         // Open a webpage
-        TestHelper.inlineAutocompleteEditText.waitForExists(waitingTime)
-        Assert.assertTrue(TestHelper.inlineAutocompleteEditText.exists())
-        TestHelper.inlineAutocompleteEditText.clearTextField()
-        TestHelper.inlineAutocompleteEditText.text =
-            webServer!!.url(TEST_PATH).toString()
-        TestHelper.hint.waitForExists(waitingTime)
-        pressEnterKey()
-
-        // Assert website is loaded
-        waitForWebSiteTitleLoad()
-
-        // Switch out of Focus, pull down system bar and select open action
+        searchScreen {
+        }.loadPage(webServer.url("").toString()) { }
+        // Send app to background
         pressHomeKey()
-        openNotification()
-        waitForIdle()
-        // If simulator has more recent message, the options need to be expanded
-        expandNotification()
-        TestHelper.notificationOpenItem.click()
-
-        // Verify that it's on the main view, showing the previous browsing session
-        TestHelper.browserURLbar.waitForExists(waitingTime)
-        Assert.assertTrue(TestHelper.browserURLbar.exists())
-        waitForWebSiteTitleLoad()
+        // Pull down system bar and select Open
+        mDevice.openNotification()
+        notificationTray {
+            verifySystemNotificationExists(getStringResource(R.string.notification_erase_text))
+            expandEraseBrowsingNotification()
+        }.clickNotificationOpenButton {
+            verifyBrowserView()
+        }
     }
 
     @Test
-    @Throws(UiObjectNotFoundException::class)
-    fun eraseAndOpenTest() {
-
-        // Open a webpage
-        TestHelper.inlineAutocompleteEditText.waitForExists(waitingTime)
-        Assert.assertTrue(TestHelper.inlineAutocompleteEditText.exists())
-        TestHelper.inlineAutocompleteEditText.clearTextField()
-        TestHelper.inlineAutocompleteEditText.text =
-            webServer!!.url(TEST_PATH).toString()
-        TestHelper.hint.waitForExists(waitingTime)
-        pressEnterKey()
-
-        // Assert website is loaded
-        waitForWebSiteTitleLoad()
-
-        // Switch out of Focus, pull down system bar and select open action
-        pressHomeKey()
-        openNotification()
-
-        // If simulator has more recent message, the options need to be expanded
-        expandNotification()
-        TestHelper.notificationEraseOpenItem.click()
-
-        // Verify that it's on the main view, showing the initial view
-        TestHelper.erasedMsg.waitForExists(waitingTime)
-        Assert.assertTrue(TestHelper.erasedMsg.exists())
-        Assert.assertTrue(TestHelper.inlineAutocompleteEditText.exists())
-        Assert.assertTrue(TestHelper.initialView.exists())
-    }
-
-    @Suppress("LongMethod")
-    @Test
-    @Throws(UiObjectNotFoundException::class)
-    fun settingsToFocus() {
-
+    fun switchFromSettingsToFocusTest() {
         // Initialize UiDevice instance
         val LAUNCH_TIMEOUT = 5000
         val SETTINGS_APP = "com.android.settings"
-        val settings = TestHelper.mDevice.findObject(
+        val settingsApp = mDevice.findObject(
             UiSelector()
                 .packageName(SETTINGS_APP)
                 .enabled(true)
         )
+        val launcherPackage = mDevice.launcherPackageName
+        val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        val intent = context.packageManager
+            .getLaunchIntentForPackage(SETTINGS_APP)
 
         // Open a webpage
-        TestHelper.inlineAutocompleteEditText.waitForExists(waitingTime)
-        TestHelper.inlineAutocompleteEditText.clearTextField()
-        TestHelper.inlineAutocompleteEditText.text = webServer!!.url(TEST_PATH).toString()
-        TestHelper.hint.waitForExists(waitingTime)
-        pressEnterKey()
-
-        // Assert website is loaded
-        waitForWebSiteTitleLoad()
+        searchScreen {
+        }.loadPage(webServer.url("").toString()) { }
 
         // Switch out of Focus, open settings app
         pressHomeKey()
 
         // Wait for launcher
-        val launcherPackage = TestHelper.mDevice.launcherPackageName
-        Assert.assertThat(launcherPackage, IsNull.notNullValue())
-        TestHelper.mDevice.wait(
+        assertThat(launcherPackage, IsNull.notNullValue())
+        mDevice.wait(
             Until.hasObject(By.pkg(launcherPackage).depth(0)),
             LAUNCH_TIMEOUT.toLong()
         )
 
         // Launch the app
-        val context = InstrumentationRegistry.getInstrumentation()
-            .targetContext
-            .applicationContext
-        val intent = context.packageManager
-            .getLaunchIntentForPackage(SETTINGS_APP)
         context.startActivity(intent)
+        settingsApp.waitForExists(waitingTime)
+        assertTrue(settingsApp.exists())
 
         // switch to Focus
-        settings.waitForExists(waitingTime)
-        Assert.assertTrue(settings.exists())
-        openNotification()
-
-        // If simulator has more recent message, the options need to be expanded
-        expandNotification()
-        TestHelper.notificationOpenItem.click()
-
-        // Verify that it's on the main view, showing the previous browsing session
-        TestHelper.browserURLbar.waitForExists(waitingTime)
-        Assert.assertTrue(TestHelper.browserURLbar.exists())
-        waitForWebSiteTitleLoad()
-    }
-
-    companion object {
-        private const val TEST_PATH = "/"
+        mDevice.openNotification()
+        notificationTray {
+            verifySystemNotificationExists(getStringResource(R.string.notification_erase_text))
+            expandEraseBrowsingNotification()
+        }.clickNotificationOpenButton {
+            verifyBrowserView()
+        }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
@@ -15,26 +15,26 @@ import org.hamcrest.Matchers.allOf
 import org.junit.Assert.assertTrue
 import org.mozilla.focus.R
 import org.mozilla.focus.helpers.SessionLoadedIdlingResource
-import org.mozilla.focus.helpers.TestHelper.appName
 import org.mozilla.focus.helpers.TestHelper.mDevice
+import org.mozilla.focus.helpers.TestHelper.packageName
 import org.mozilla.focus.helpers.TestHelper.webPageLoadwaitingTime
 
 class BrowserRobot {
 
     val progressBar =
         mDevice.findObject(
-            UiSelector().resourceId("$appName:id/progress")
+            UiSelector().resourceId("$packageName:id/progress")
         )
 
     fun verifyBrowserView() =
-        assertTrue(mDevice.findObject(UiSelector().resourceId("$appName:id/webview"))
+        assertTrue(mDevice.findObject(UiSelector().resourceId("$packageName:id/webview"))
             .waitForExists(webPageLoadwaitingTime)
         )
 
     fun verifyPageContent(expectedText: String) {
         val sessionLoadedIdlingResource = SessionLoadedIdlingResource()
 
-        mDevice.findObject(UiSelector().resourceId("$appName:id/webview"))
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/webview"))
             .waitForExists(webPageLoadwaitingTime)
 
         runWithIdleRes(sessionLoadedIdlingResource) {
@@ -50,7 +50,7 @@ class BrowserRobot {
 
         browserURLbar.waitForExists(webPageLoadwaitingTime)
 
-        mDevice.findObject(UiSelector().resourceId("$appName:id/webview"))
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/webview"))
             .waitForExists(webPageLoadwaitingTime)
 
         runWithIdleRes(sessionLoadedIdlingResource) {
@@ -92,6 +92,6 @@ inline fun runWithIdleRes(ir: IdlingResource?, pendingCheck: () -> Unit) {
     }
 }
 
-private val browserURLbar = mDevice.findObject(UiSelector().resourceId("$appName:id/display_url"))
+private val browserURLbar = mDevice.findObject(UiSelector().resourceId("$packageName:id/display_url"))
 
 private val floatingEraseButton = onView(allOf(withId(R.id.erase), isDisplayed()))

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/DownloadRobot.kt
@@ -12,10 +12,10 @@ import androidx.test.uiautomator.UiSelector
 import org.junit.Assert.assertTrue
 import org.mozilla.focus.R
 import org.mozilla.focus.helpers.SessionLoadedIdlingResource
-import org.mozilla.focus.helpers.TestHelper.appName
 import org.mozilla.focus.helpers.TestHelper.getStringResource
 import org.mozilla.focus.helpers.TestHelper.isPackageInstalled
 import org.mozilla.focus.helpers.TestHelper.mDevice
+import org.mozilla.focus.helpers.TestHelper.packageName
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 import org.mozilla.focus.helpers.TestHelper.webPageLoadwaitingTime
 
@@ -52,7 +52,7 @@ class DownloadRobot {
     }
 
     fun openDownloadedFile() {
-        val snackBarButton = mDevice.findObject(UiSelector().resourceId("$appName:id/snackbar_action"))
+        val snackBarButton = mDevice.findObject(UiSelector().resourceId("$packageName:id/snackbar_action"))
         snackBarButton.waitForExists(waitingTime)
         snackBarButton.clickAndWaitForNewWindow(webPageLoadwaitingTime)
     }
@@ -72,22 +72,22 @@ val downloadIconAsset: UiObject = mDevice.findObject(
 
 private val downloadDialogTitle = mDevice.findObject(
     UiSelector()
-        .resourceId("$appName:id/title")
+        .resourceId("$packageName:id/title")
 )
 
 private val downloadFileName = mDevice.findObject(
     UiSelector()
-        .resourceId("$appName:id/filename")
+        .resourceId("$packageName:id/filename")
 )
 
 private val downloadCancelBtn = mDevice.findObject(
     UiSelector()
-        .resourceId("$appName:id/close_button")
+        .resourceId("$packageName:id/close_button")
 )
 
 private val downloadBtn = mDevice.findObject(
     UiSelector()
-        .resourceId("$appName:id/download_button")
+        .resourceId("$packageName:id/download_button")
 )
 
 private val downloadNotificationText = getStringResource(R.string.mozac_feature_downloads_completed_notification_text2)

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/HomeScreenRobot.kt
@@ -12,9 +12,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.uiautomator.UiSelector
 import org.junit.Assert.assertTrue
 import org.mozilla.focus.R
-import org.mozilla.focus.helpers.TestHelper.appName
 import org.mozilla.focus.helpers.TestHelper.getStringResource
 import org.mozilla.focus.helpers.TestHelper.mDevice
+import org.mozilla.focus.helpers.TestHelper.packageName
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 
 class HomeScreenRobot {
@@ -42,6 +42,6 @@ fun homeScreen(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition
     return HomeScreenRobot.Transition()
 }
 
-private val searchBar = mDevice.findObject(UiSelector().resourceId("$appName:id/urlView"))
+private val searchBar = mDevice.findObject(UiSelector().resourceId("$packageName:id/urlView"))
 
 private val mainMenu = onView(withId(R.id.menuView))

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/NotificationRobot.kt
@@ -1,70 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.activity.robots
 
 import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import org.junit.Assert.assertTrue
 import org.mozilla.focus.R
 import org.mozilla.focus.helpers.TestHelper
+import org.mozilla.focus.helpers.TestHelper.getStringResource
 import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 
 class NotificationRobot {
 
+    fun clearNotifications() {
+        if (clearButton.exists()) {
+            clearButton.click()
+        } else {
+            notificationTray.flingToEnd(3)
+            if (clearButton.exists()) {
+                clearButton.click()
+            } else if (notificationTray.exists()) {
+                mDevice.pressBack()
+            }
+        }
+    }
+
     fun expandEraseBrowsingNotification() {
         val PINCH_PERCENT = 50
         val PINCH_STEPS = 5
 
-        val notificationExpandSwitch = mDevice.findObject(
-            UiSelector()
-                .resourceId("android:id/expand_button")
-                .textContains("Firefox Focus")
-        )
         if (!notificationEraseAndOpenButton.waitForExists(waitingTime)) {
-            if (!notificationExpandSwitch.exists()) {
+            if (!notificationTray.ensureFullyVisible(notificationHeader)) {
                 eraseBrowsingNotification.pinchOut(
                     PINCH_PERCENT,
                     PINCH_STEPS
                 )
             } else {
-                notificationExpandSwitch.click()
+                notificationHeader.click()
             }
+            notificationTray.ensureFullyVisible(notificationEraseAndOpenButton)
             assertTrue(notificationEraseAndOpenButton.exists())
         }
     }
 
     fun verifySystemNotificationExists(notificationMessage: String) {
-        var notificationTray =
-            mDevice.findObject(
-                UiSelector().resourceId("com.android.systemui:id/notification_stack_scroller")
-            )
+        var notificationFound = false
 
-        if (notificationTray.isScrollable) {
-            notificationTray = UiScrollable(
-                UiSelector().resourceId("com.android.systemui:id/notification_stack_scroller")
-            )
-
-            var notificationFound = false
-
-            do {
-                try {
-                    notificationFound = notificationTray.getChildByText(
-                        UiSelector().text(notificationMessage), notificationMessage, true
-                    ).waitForExists(TestHelper.waitingTime)
-                    assertTrue(notificationFound)
-                } catch (e: UiObjectNotFoundException) {
-                    Log.d("TestLog", e.message.toString())
-                    // scrolls down the notifications until it reaches the end, then it will close
-                    notificationTray.scrollForward()
-                    mDevice.waitForIdle()
-                }
-            } while (!notificationFound)
-        } else {
-            val notificationFound =
-                notificationTray.getChild(UiSelector().textContains(notificationMessage)).exists()
-            assertTrue(notificationFound)
-        }
+        do {
+            try {
+                notificationFound = notificationTray.getChildByText(
+                    UiSelector().text(notificationMessage), notificationMessage, true
+                ).waitForExists(waitingTime)
+                assertTrue(notificationFound)
+            } catch (e: UiObjectNotFoundException) {
+                Log.d("TestLog", e.message.toString())
+                // scrolls down the notifications until it reaches the end, then it will close
+                notificationTray.scrollForward()
+                mDevice.waitForIdle()
+            }
+        } while (!notificationFound)
     }
 
     class Transition {
@@ -93,14 +93,28 @@ fun notificationTray(interact: NotificationRobot.() -> Unit): NotificationRobot.
 
 private val eraseBrowsingNotification =
     mDevice.findObject(
-        UiSelector().text(TestHelper.getStringResource(R.string.notification_erase_text))
+        UiSelector().text(getStringResource(R.string.notification_erase_text))
     )
 
 private val notificationEraseAndOpenButton =
     mDevice.findObject(
-        UiSelector().description(TestHelper.getStringResource(R.string.notification_action_erase_and_open))
+        UiSelector().description(getStringResource(R.string.notification_action_erase_and_open))
     )
 
 private val notificationOpenButton = mDevice.findObject(
-    UiSelector().description(TestHelper.getStringResource(R.string.notification_action_open))
+    UiSelector().description(getStringResource(R.string.notification_action_open))
 )
+
+private val notificationTray = UiScrollable(
+    UiSelector().resourceId("com.android.systemui:id/notification_stack_scroller")
+).setAsVerticalList()
+
+private val appName = InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.app_name)
+
+private val notificationHeader = mDevice.findObject(
+    UiSelector()
+        .resourceId("android:id/app_name_text")
+        .textContains(appName)
+)
+
+private val clearButton = mDevice.findObject(UiSelector().resourceId("com.android.systemui:id/dismiss_text"))

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/NotificationRobot.kt
@@ -5,13 +5,13 @@
 package org.mozilla.focus.activity.robots
 
 import android.util.Log
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import org.junit.Assert.assertTrue
 import org.mozilla.focus.R
 import org.mozilla.focus.helpers.TestHelper
+import org.mozilla.focus.helpers.TestHelper.appName
 import org.mozilla.focus.helpers.TestHelper.getStringResource
 import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.waitingTime
@@ -108,8 +108,6 @@ private val notificationOpenButton = mDevice.findObject(
 private val notificationTray = UiScrollable(
     UiSelector().resourceId("com.android.systemui:id/notification_stack_scroller")
 ).setAsVerticalList()
-
-private val appName = InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.app_name)
 
 private val notificationHeader = mDevice.findObject(
     UiSelector()

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SearchRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SearchRobot.kt
@@ -13,8 +13,8 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.focus.R
 import org.mozilla.focus.helpers.SessionLoadedIdlingResource
-import org.mozilla.focus.helpers.TestHelper.appName
 import org.mozilla.focus.helpers.TestHelper.mDevice
+import org.mozilla.focus.helpers.TestHelper.packageName
 import org.mozilla.focus.helpers.TestHelper.pressEnterKey
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 import org.mozilla.focus.helpers.TestHelper.webPageLoadwaitingTime
@@ -71,7 +71,7 @@ class SearchRobot {
                     BrowserRobot().progressBar.waitUntilGone(webPageLoadwaitingTime)
                 )
                 assertTrue(
-                    mDevice.findObject(UiSelector().resourceId("$appName:id/webview"))
+                    mDevice.findObject(UiSelector().resourceId("$packageName:id/webview"))
                         .waitForExists(webPageLoadwaitingTime)
                 )
             }
@@ -88,29 +88,29 @@ fun searchScreen(interact: SearchRobot.() -> Unit): SearchRobot.Transition {
 }
 
 private val searchBar =
-    mDevice.findObject(UiSelector().resourceId("$appName:id/urlView"))
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/urlView"))
 
 private val searchHint = mDevice.findObject(
     UiSelector()
-        .resourceId("$appName:id/searchView")
+        .resourceId("$packageName:id/searchView")
         .clickable(true)
 )
 
 private val searchSuggestionsTitle = mDevice.findObject(
     UiSelector()
-        .resourceId("$appName:id/enable_search_suggestions_title")
+        .resourceId("$packageName:id/enable_search_suggestions_title")
         .enabled(true)
 )
 
 private val searchSuggestionsButtonYes = mDevice.findObject(
     UiSelector()
-        .resourceId("$appName:id/enable_search_suggestions_button")
+        .resourceId("$packageName:id/enable_search_suggestions_button")
         .enabled(true)
 )
 
 private val suggestionsList = mDevice.findObject(
     UiSelector()
-        .resourceId("$appName:id/suggestionList")
+        .resourceId("$packageName:id/suggestionList")
 )
 
 private val clearSearchButton = onView(withId(R.id.clearView))

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsAdvancedMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsAdvancedMenuRobot.kt
@@ -10,7 +10,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
-import org.mozilla.focus.helpers.TestHelper.appName
+import org.mozilla.focus.helpers.TestHelper.packageName
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 
 class SettingsAdvancedMenuRobot {
@@ -23,6 +23,6 @@ class SettingsAdvancedMenuRobot {
 }
 
 private val advancedSettingsList =
-    UiScrollable(UiSelector().resourceId("$appName:id/recycler_view"))
+    UiScrollable(UiSelector().resourceId("$packageName:id/recycler_view"))
 
 private val remoteDebuggingSwitch = onView(ViewMatchers.withText("Remote debugging via USB/Wi-Fi"))

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsMozillaMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsMozillaMenuRobot.kt
@@ -27,7 +27,7 @@ class SettingsMozillaMenuRobot {
 }
 
 private val mozillaSettingsList =
-    UiScrollable(UiSelector().resourceId("${TestHelper.appName}:id/recycler_view"))
+    UiScrollable(UiSelector().resourceId("${TestHelper.packageName}:id/recycler_view"))
 
 private val showTipsSwitch = onView(withText("Show home screen tips"))
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsPrivacyMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsPrivacyMenuRobot.kt
@@ -12,7 +12,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
-import org.mozilla.focus.helpers.TestHelper.appName
+import org.mozilla.focus.helpers.TestHelper.packageName
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 
 class SettingsPrivacyMenuRobot {
@@ -36,7 +36,7 @@ class SettingsPrivacyMenuRobot {
 }
 
 private val privacySettingsList =
-    UiScrollable(UiSelector().resourceId("$appName:id/recycler_view"))
+    UiScrollable(UiSelector().resourceId("$packageName:id/recycler_view"))
 
 private fun adTrackersBlockSwitch(): ViewInteraction {
     privacySettingsList

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsRobot.kt
@@ -7,7 +7,7 @@ package org.mozilla.focus.activity.robots
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import org.junit.Assert.assertTrue
-import org.mozilla.focus.helpers.TestHelper.appName
+import org.mozilla.focus.helpers.TestHelper.packageName
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 
 class SettingsRobot {
@@ -72,7 +72,7 @@ class SettingsRobot {
     }
 }
 
-private val settingsMenuList = UiScrollable(UiSelector().resourceId("$appName:id/recycler_view"))
+private val settingsMenuList = UiScrollable(UiSelector().resourceId("$packageName:id/recycler_view"))
 
 private val generalSettingsMenu = settingsMenuList.getChild(
     UiSelector()

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsSearchMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsSearchMenuRobot.kt
@@ -8,8 +8,8 @@ import androidx.test.uiautomator.UiObject
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import org.junit.Assert.assertTrue
-import org.mozilla.focus.helpers.TestHelper.appName
 import org.mozilla.focus.helpers.TestHelper.mDevice
+import org.mozilla.focus.helpers.TestHelper.packageName
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 
 class SearchSettingsRobot {
@@ -41,20 +41,20 @@ class SearchSettingsRobot {
 }
 
 private val searchEngineSubMenu =
-    UiScrollable(UiSelector().resourceId("$appName:id/recycler_view"))
+    UiScrollable(UiSelector().resourceId("$packageName:id/recycler_view"))
         .getChild(UiSelector().text("Search engine"))
 
 private val searchEngineList = UiScrollable(
     UiSelector()
-        .resourceId("$appName:id/search_engine_group").enabled(true)
+        .resourceId("$packageName:id/search_engine_group").enabled(true)
 )
 
 private val searchSuggestionsSwitch: UiObject =
     mDevice.findObject(
         UiSelector()
-            .resourceId("$appName:id/switchWidget")
+            .resourceId("$packageName:id/switchWidget")
     )
 
 private val urlAutocompleteSubMenu =
-    UiScrollable(UiSelector().resourceId("$appName:id/recycler_view"))
+    UiScrollable(UiSelector().resourceId("$packageName:id/recycler_view"))
         .getChild(UiSelector().text("URL Autocomplete"))

--- a/app/src/androidTest/java/org/mozilla/focus/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/TestHelper.kt
@@ -42,18 +42,26 @@ object TestHelper {
     const val webPageLoadwaitingTime = DateUtils.SECOND_IN_MILLIS * 15
 
     @JvmStatic
-    val appName: String
+    val packageName: String
         get() = InstrumentationRegistry.getInstrumentation()
-            .targetContext.packageName
+            .targetContext
+            .packageName
 
     @JvmStatic
-    val appContext: Context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+    val appName: String = InstrumentationRegistry.getInstrumentation()
+        .targetContext
+        .getString(R.string.app_name)
+
+    @JvmStatic
+    val appContext: Context = InstrumentationRegistry.getInstrumentation()
+        .targetContext
+        .applicationContext
 
     fun getStringResource(id: Int) = appContext.getString(id)
 
     fun verifySnackBarText(text: String) {
         val snackbarText = mDevice.findObject(
-            UiSelector().resourceId("$appName:id/snackbar_text")
+            UiSelector().resourceId("$packageName:id/snackbar_text")
         )
         snackbarText.waitForExists(waitingTime)
         assertTrue(snackbarText.text.contains(text))
@@ -115,21 +123,21 @@ object TestHelper {
     @JvmField
     var nextBtn = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/next")
+            .resourceId(packageName + ":id/next")
             .enabled(true)
     )
 
     @JvmField
     var finishBtn = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/finish")
+            .resourceId(packageName + ":id/finish")
             .enabled(true)
     )
 
     @JvmField
     var initialView = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/backgroundView")
+            .resourceId(packageName + ":id/backgroundView")
             .enabled(true)
     )
 
@@ -146,7 +154,7 @@ object TestHelper {
     @JvmField
     var browserURLbar = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/display_url")
+            .resourceId(packageName + ":id/display_url")
             .clickable(true)
     )
 
@@ -160,7 +168,7 @@ object TestHelper {
     @JvmField
     var inlineAutocompleteEditText = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/urlView")
+            .resourceId(packageName + ":id/urlView")
             .focused(true)
             .enabled(true)
     )
@@ -168,39 +176,39 @@ object TestHelper {
     @JvmField
     var searchSuggestionsTitle = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/enable_search_suggestions_title")
+            .resourceId(packageName + ":id/enable_search_suggestions_title")
             .enabled(true)
     )
 
     @JvmField
     var searchSuggestionsButtonYes = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/enable_search_suggestions_button")
+            .resourceId(packageName + ":id/enable_search_suggestions_button")
             .enabled(true)
     )
 
     @JvmField
     var cleartextField = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/clearView")
+            .resourceId(packageName + ":id/clearView")
             .enabled(true)
     )
 
     @JvmField
     var hint = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/searchView")
+            .resourceId(packageName + ":id/searchView")
             .clickable(true)
     )
 
     @JvmField
     var suggestionList = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/suggestionList")
+            .resourceId(packageName + ":id/suggestionList")
     )
     var suggestion = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/suggestion")
+            .resourceId(packageName + ":id/suggestion")
     )
 
     @JvmField
@@ -211,14 +219,14 @@ object TestHelper {
     )
     var geckoView = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/webview")
+            .resourceId(packageName + ":id/webview")
             .enabled(true)
     )
 
     @JvmField
     var progressBar = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/progress")
+            .resourceId(packageName + ":id/progress")
             .enabled(true)
     )
     var tryAgainBtn = mDevice.findObject(
@@ -233,7 +241,7 @@ object TestHelper {
     )
     var browserViewSettingsMenuItem = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/settings")
+            .resourceId(packageName + ":id/settings")
             .clickable(true)
     )
 
@@ -241,14 +249,14 @@ object TestHelper {
     var erasedMsg = mDevice.findObject(
         UiSelector()
             .text("Your browsing history has been erased.")
-            .resourceId(appName + ":id/snackbar_text")
+            .resourceId(packageName + ":id/snackbar_text")
             .enabled(true)
     )
 
     @JvmField
     var lockIcon = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/lock")
+            .resourceId(packageName + ":id/lock")
             .description("Secure connection")
     )
 
@@ -262,7 +270,7 @@ object TestHelper {
     var notificationExpandSwitch = mDevice.findObject(
         UiSelector()
             .resourceId("android:id/expand_button")
-            .packageName(appName + "")
+            .packageName(packageName + "")
             .enabled(true)
     )
 
@@ -283,28 +291,28 @@ object TestHelper {
     )
     var blockOffIcon = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/block")
+            .resourceId(packageName + ":id/block")
             .enabled(true)
     )
 
     @JvmField
     var AddtoHSmenuItem = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/add_to_homescreen")
+            .resourceId(packageName + ":id/add_to_homescreen")
             .enabled(true)
     )
 
     @JvmField
     var AddtoHSCancelBtn = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/addtohomescreen_dialog_cancel")
+            .resourceId(packageName + ":id/addtohomescreen_dialog_cancel")
             .enabled(true)
     )
 
     @JvmField
     var AddtoHSOKBtn = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/addtohomescreen_dialog_add")
+            .resourceId(packageName + ":id/addtohomescreen_dialog_add")
             .enabled(true)
     )
 
@@ -319,7 +327,7 @@ object TestHelper {
     @JvmField
     var shortcutTitle = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/edit_title")
+            .resourceId(packageName + ":id/edit_title")
             .enabled(true)
     )
 
@@ -334,62 +342,62 @@ object TestHelper {
     @JvmField
     var securityInfoIcon = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/security_info")
+            .resourceId(packageName + ":id/security_info")
             .enabled(true)
     )
 
     @JvmField
     var identityState = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/site_identity_state")
+            .resourceId(packageName + ":id/site_identity_state")
             .enabled(true)
     )
 
     @JvmField
     var downloadTitle = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/title_template")
+            .resourceId(packageName + ":id/title_template")
             .enabled(true)
     )
 
     @JvmField
     var downloadBtn = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/download_dialog_download")
+            .resourceId(packageName + ":id/download_dialog_download")
             .enabled(true)
     )
 
     /********* Main View Menu Item Locators  */
     var whatsNewItem = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/whats_new")
+            .resourceId(packageName + ":id/whats_new")
             .enabled(true)
     )
 
     @JvmField
     var HelpItem = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/help")
+            .resourceId(packageName + ":id/help")
             .enabled(true)
     )
 
     @JvmField
     var settingsMenuItem = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/settings")
+            .resourceId(packageName + ":id/settings")
             .enabled(true)
     )
 
     @JvmField
     var blockCounterItem = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/trackers_count")
+            .resourceId(packageName + ":id/trackers_count")
     )
 
     @JvmField
     var menulist = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/list")
+            .resourceId(packageName + ":id/list")
             .enabled(true)
     )
 
@@ -419,13 +427,13 @@ object TestHelper {
     @JvmField
     var settingsMenu = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/recycler_view")
+            .resourceId(packageName + ":id/recycler_view")
     )
 
     @JvmField
     var settingsHeading = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/toolbar")
+            .resourceId(packageName + ":id/toolbar")
             .enabled(true)
     )
     var navigateUp = mDevice.findObject(
@@ -439,7 +447,7 @@ object TestHelper {
     )
     var refreshBtn = mDevice.findObject(
         UiSelector()
-            .resourceId(appName + ":id/refresh")
+            .resourceId(packageName + ":id/refresh")
             .enabled(true)
     )
 


### PR DESCRIPTION
Fixed and re-enabled the tests, moved over the notificationOpenButtonTest from EraseBrowsingDataTest.kt to keep the same structure. 
Made some new small tweaks to the Notification robot methods because of test flakiness. Will keep an eye on them to see if they are still flaky.