### PR TITLE
Remove old survey code.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -177,9 +177,6 @@ object TelemetryWrapper {
         val AUTOCOMPLETE_URL_TIP = "autocomplete_url_tip"
         val OPEN_IN_NEW_TAB_TIP = "open_in_new_tab_tip"
         val DISABLE_TIPS_TIP = "disable_tips_tip"
-        val SURVEY_TIP = "survey_tip"
-        val SURVEY_TIP_ES = "survey_tip_es"
-        val SURVEY_TIP_FR = "survey_tip_fr"
         val CLOSE_TAB = "close_tab"
     }
 
@@ -948,9 +945,6 @@ object TelemetryWrapper {
             R.string.tip_set_default_browser -> Value.DEFAULT_BROWSER_TIP
             R.string.tip_autocomplete_url -> Value.AUTOCOMPLETE_URL_TIP
             R.string.tip_disable_tips2 -> Value.DISABLE_TIPS_TIP
-            R.string.tip_take_survey -> Value.SURVEY_TIP
-            R.string.tip_take_survey_es -> Value.SURVEY_TIP_ES
-            R.string.tip_take_survey_fr -> Value.SURVEY_TIP_FR
             else -> {
                 // Unknown tip, fail silently rather than crashing.
                 return
@@ -969,9 +963,6 @@ object TelemetryWrapper {
             R.string.tip_set_default_browser -> Value.DEFAULT_BROWSER_TIP
             R.string.tip_autocomplete_url -> Value.AUTOCOMPLETE_URL_TIP
             R.string.tip_disable_tips2 -> Value.DISABLE_TIPS_TIP
-            R.string.tip_take_survey -> Value.SURVEY_TIP
-            R.string.tip_take_survey_es -> Value.SURVEY_TIP_ES
-            R.string.tip_take_survey_fr -> Value.SURVEY_TIP_FR
             else -> {
                 // Unknown tip, fail silently rather than crashing.
                 return

--- a/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
+++ b/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
@@ -251,14 +251,6 @@ object TipManager {
             return null
         }
 
-        // Show the survey tip first
-        for (tip in listOfTips) {
-            if (tip.id == R.string.tip_take_survey && tip.shouldDisplay()) {
-                listOfTips.remove(tip)
-                return tip
-            }
-        }
-
         // Always show the disable tip if it's ready to be displayed
         for (tip in listOfTips) {
             if (tip.id == R.string.tip_disable_tips2 && tip.shouldDisplay()) {

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -215,9 +215,6 @@ class Settings private constructor(
         getPreferenceKey(R.string.has_requested_desktop),
         false)
 
-    fun hasTakenSurvey() = preferences.getBoolean(getPreferenceKey(R.string.has_taken_survey),
-            false)
-
     fun getAppLaunchCount() = preferences.getInt(
             getPreferenceKey(R.string.app_launch_count),
             0)

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -50,7 +50,6 @@
     <string name="has_opened_new_tab" translatable="false"><xliff:g id="preference_key">has_opened_new_tab</xliff:g></string>
     <string name="has_added_to_home_screen" translatable="false"><xliff:g id="preference_key">has_added_to_home_screen</xliff:g></string>
     <string name="has_requested_desktop" translatable="false"><xliff:g id="preference_key">has_requested_desktop</xliff:g></string>
-    <string name="has_taken_survey" translatable="false"><xliff:g id="preference_key">has_taken_survey</xliff:g></string>
     <string name="app_launch_count" translatable="false"><xliff:g id="preference_key">app_launch_count</xliff:g></string>
     <string name="pref_key_category_safe_browsing" translatable="false"><xliff:g id="preference_key">safe_browsing_category</xliff:g></string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -774,18 +774,6 @@ be temporary, and you can try again later.</li>
         Allowlist disables Tracking Protection for sites you know and trust.
     </string>
 
-    <!-- Tip for taking Focus survey en-->
-    <string name="tip_take_survey">Please help us by taking a short survey.\n
-         Click here.</string>
-
-    <!-- Tip for taking Focus survey es-->
-    <string name="tip_take_survey_es">Por favor ayúdanos haciendo una breve encuesta.\n
-        Haz clic aquí.</string>
-
-    <!-- Tip for taking Focus survey fr -->
-    <string name="tip_take_survey_fr">Aidez-nous à améliorer en remplissant ce court questionnaire.\n
-        Remplir le questionnaire.</string>
-
     <!-- Label for the snackbar when a user opens a new tab -->
     <string name="new_tab_opened_snackbar">New tab opened</string>
 


### PR DESCRIPTION
This came up in the first L10N export: `strings.xml` contained translated strings (`tip_take_survey_es`, ..). Since this old survey isn't shown to users anymore, this patch removes the code and the strings.