### PR TITLE
Bump version to 8.15.1.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         targetSdkVersion 29
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
                        // override this with a generated versionCode at build time.
-        versionName "8.15.0"
+        versionName "8.15.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled true


### PR DESCRIPTION
Missing this from the last PR, but it shouldn't be the case of the build failure we're seeing [here](https://firefox-ci-tc.services.mozilla.com/tasks/NjCmNAMSQUyxjCVWRoPYjQ/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FNjCmNAMSQUyxjCVWRoPYjQ%2Fruns%2F0%2Fartifacts%2Fpublic%252Flogs%252Flive.log).