### PR TITLE
Remove robolectric from service-telemetry dependencies

### DIFF
--- a/service-telemetry/build.gradle
+++ b/service-telemetry/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     testImplementation "junit:junit:4.12"
-    testImplementation "org.robolectric:robolectric:4.4" // required to support api level 28
     testImplementation 'org.mockito:mockito-core:2.24.5'
 
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'


### PR DESCRIPTION
It's causing us issues in the service-telemetry module and we don't need it.