### PR TITLE
Fixes #4825: restore network connection after noNetworkConnectionErrorPageTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
@@ -4,6 +4,7 @@
 package org.mozilla.focus.activity
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,6 +19,11 @@ import org.mozilla.focus.helpers.TestHelper.setNetworkEnabled
 class ErrorPagesTest {
     @get: Rule
     val mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
+
+    @After
+    fun tearDown() {
+        setNetworkEnabled(true)
+    }
 
     @Test
     fun badURLCheckTest() {


### PR DESCRIPTION
SearchTest#enableSearchSuggestionOnFirstRunTest was failing because there was no network connection available to pull the search suggestions. That was due to omitting to re-enable it after noNetworkConnectionErrorPageTest.