### PR TITLE
Issue #4820: generate_build_task(): Do not try to run removed check_translations.py

### DIFF
--- a/tools/taskcluster/schedule-main-build.py
+++ b/tools/taskcluster/schedule-main-build.py
@@ -28,7 +28,6 @@ def generate_build_task():
         name="(Focus for Android) Build",
         description="Build Focus/Klar for Android from source code.",
         command=('echo "--" > .adjust_token'
-                 ' && python tools/l10n/check_translations.py'
                  ' && ./gradlew --no-daemon clean assemble'))
 
 


### PR DESCRIPTION
This fixes a build error on `main` after we merged the related changes.