### PR TITLE
Issue #4781: Inject MLS token into BuildConfig.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -261,7 +261,23 @@ android.applicationVariants.all { variant ->
 }
 
 // -------------------------------------------------------------------------------------------------
-// Adjust: Read token from locale file if it exists (Only release builds)
+// MLS: Read token from local file if it exists (Only release builds)
+// -------------------------------------------------------------------------------------------------
+
+android.applicationVariants.all {
+    print("MLS token: ")
+    try {
+        def token = new File("${rootDir}/.mls_token").text.trim()
+        buildConfigField 'String', 'MLS_TOKEN', '"' + token + '"'
+        println "(Added from .mls_token file)"
+    } catch (FileNotFoundException ignored) {
+        buildConfigField 'String', 'MLS_TOKEN', '""'
+        println("X_X")
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Adjust: Read token from local file if it exists (Only release builds)
 // -------------------------------------------------------------------------------------------------
 
 android.applicationVariants.all { variant ->
@@ -285,7 +301,7 @@ android.applicationVariants.all { variant ->
 }
 
 // -------------------------------------------------------------------------------------------------
-// Sentry: Read token from locale file if it exists (Only release builds)
+// Sentry: Read token from local file if it exists (Only release builds)
 // -------------------------------------------------------------------------------------------------
 
 android.applicationVariants.all {

--- a/tools/taskcluster/get-mls-token.py
+++ b/tools/taskcluster/get-mls-token.py
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+This script talks to the taskcluster secrets service to obtain the
+Adjust token and write it to the .adjust_token file in the root
+directory.
+"""
+
+import os
+import taskcluster
+
+# Get JSON data from taskcluster secrets service
+secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
+data = secrets.get('project/focus/tokens')
+
+token_file_path = os.path.join(os.path.dirname(__file__), '../../.mls_token')
+with open(token_file_path, 'w') as token_file:
+	token_file.write(data['secret']['mls'])
+
+print("Imported MLS token from secrets service")

--- a/tools/taskcluster/release.py
+++ b/tools/taskcluster/release.py
@@ -54,6 +54,7 @@ def generate_build_task(apks, tag):
         command=(checkout +
                  ' && python tools/taskcluster/get-adjust-token.py'
                  ' && python tools/taskcluster/get-sentry-token.py'
+                 ' && python tools/taskcluster/get-mls-token.py'
                  ' && ./gradlew --no-daemon clean test ' + assemble_task),
         features = {
             "chainOfTrust": True


### PR DESCRIPTION
Release Engineering helped me get the token into the taskcluster secrets service. With this patch we inject it into `BuildConfig` for release builds.

With this patch we do not use MLS yet. There's still more coordination needed until we can make this change.