### PR TITLE
For #4839: Disable noNetworkConnectionErrorPageTest causing failures …

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
@@ -4,7 +4,7 @@
 package org.mozilla.focus.activity
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
-import org.junit.After
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,11 +20,6 @@ class ErrorPagesTest {
     @get: Rule
     val mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
 
-    @After
-    fun tearDown() {
-        setNetworkEnabled(true)
-    }
-
     @Test
     fun badURLCheckTest() {
         val badURl = "bad.url"
@@ -36,6 +31,8 @@ class ErrorPagesTest {
         }
     }
 
+    @Ignore("Failing on API 29, working on API 28," +
+            "needs investigation: https://github.com/mozilla-mobile/focus-android/issues/4839")
     @Test
     fun noNetworkConnectionErrorPageTest() {
         val pageUrl = "mozilla.org"
@@ -45,6 +42,7 @@ class ErrorPagesTest {
         }.loadPage(pageUrl) {
             verifyPageContent(getStringResource(R.string.mozac_browser_errorpages_unknown_host_title))
             verifyPageContent("Try Again")
+            setNetworkEnabled(true)
         }
     }
 }


### PR DESCRIPTION
…on master

This test fails to setup the network connection back on, causing other failures. Works only on API 28, not 29.