### PR TITLE
BlockingThemeBinding: Transition immediately if not load was observed.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/animation/TransitionDrawableGroup.kt
+++ b/app/src/main/java/org/mozilla/focus/animation/TransitionDrawableGroup.kt
@@ -23,4 +23,10 @@ class TransitionDrawableGroup(private vararg val transitionDrawables: Transition
             transitionDrawable.resetTransition()
         }
     }
+
+    fun transitionImmediately() {
+        for (transitionDrawable in transitionDrawables) {
+            transitionDrawable.startTransition(0)
+        }
+    }
 }

--- a/app/src/main/java/org/mozilla/focus/browser/binding/BlockingThemeBinding.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/binding/BlockingThemeBinding.kt
@@ -51,9 +51,11 @@ class BlockingThemeBinding(
         if (tab.content.loading) {
             backgroundTransitionGroup?.resetTransition()
         } else {
-            // We start a transition only if a page was just loading before allowing to avoid issue #1179
+            // We start a transition animation only if a page was just loading before, avoiding issue #1179
             if (hasLoadedOnce) {
                 backgroundTransitionGroup?.startTransition(ANIMATION_DURATION)
+            } else {
+                backgroundTransitionGroup?.transitionImmediately()
             }
             hasLoadedOnce = true
         }


### PR DESCRIPTION
When switching tab then the blocking background does not update and it looks as if tracking protection is disabled in this tab. We also do not want to play the "page loaded" animation, instead we just skip the animation and then this will show the correct state immediately.