### PR TITLE
Closes #4849: MozillaSettingsFragment: Switch to browser when opening links.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/MozillaSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/MozillaSettingsFragment.kt
@@ -11,6 +11,8 @@ import mozilla.components.browser.state.state.SessionState
 import org.mozilla.focus.R
 import org.mozilla.focus.browser.LocalizedContent
 import org.mozilla.focus.ext.components
+import org.mozilla.focus.ext.requireComponents
+import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.AppConstants
 import org.mozilla.focus.utils.SupportUtils
@@ -42,28 +44,28 @@ class MozillaSettingsFragment : BaseSettingsFragment(),
 
         when (preference.key) {
             resources.getString(R.string.pref_key_about) -> run {
-                activity.components.tabsUseCases.addPrivateTab(
+                val tabId = activity.components.tabsUseCases.addPrivateTab(
                     LocalizedContent.URL_ABOUT,
                     source = SessionState.Source.MENU,
                     selectTab = true
                 )
-                activity.finish()
+                requireComponents.appStore.dispatch(AppAction.OpenTab(tabId))
             }
             resources.getString(R.string.pref_key_help) -> run {
-                activity.components.tabsUseCases.addPrivateTab(
+                val tabId = activity.components.tabsUseCases.addPrivateTab(
                     SupportUtils.HELP_URL,
                     source = SessionState.Source.MENU,
                     selectTab = true
                 )
-                activity.finish()
+                requireComponents.appStore.dispatch(AppAction.OpenTab(tabId))
             }
             resources.getString(R.string.pref_key_rights) -> run {
-                activity.components.tabsUseCases.addPrivateTab(
+                val tabId = activity.components.tabsUseCases.addPrivateTab(
                     LocalizedContent.URL_RIGHTS,
                     source = SessionState.Source.MENU,
                     selectTab = true
                 )
-                activity.finish()
+                requireComponents.appStore.dispatch(AppAction.OpenTab(tabId))
             }
             resources.getString(R.string.pref_key_privacy_notice) -> {
                 val url = if (AppConstants.isKlarBuild)
@@ -71,12 +73,12 @@ class MozillaSettingsFragment : BaseSettingsFragment(),
                 else
                     SupportUtils.PRIVACY_NOTICE_URL
 
-                activity.components.tabsUseCases.addPrivateTab(
+                val tabId = activity.components.tabsUseCases.addPrivateTab(
                     url,
                     source = SessionState.Source.MENU,
                     selectTab = true
                 )
-                activity.finish()
+                requireComponents.appStore.dispatch(AppAction.OpenTab(tabId))
             }
         }
         return super.onPreferenceTreeClick(preference)

--- a/app/src/main/java/org/mozilla/focus/state/AppAction.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppAction.kt
@@ -73,4 +73,9 @@ sealed class AppAction : Action {
      * Forces showing the first run screen (for tests).
      */
     internal object ShowFirstRun : AppAction()
+
+    /**
+     * Opens the tab with the given [tabId] and actively switches to the browser screen if needed.
+     */
+    data class OpenTab(val tabId: String) : AppAction()
 }

--- a/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
@@ -26,6 +26,7 @@ object AppReducer : Reducer<AppState, AppAction> {
             is AppAction.Unlock -> unlock(state, action)
             is AppAction.OpenSettings -> openSettings(state, action)
             is AppAction.NavigateUp -> navigateUp(state, action)
+            is AppAction.OpenTab -> openTab(state, action)
         }
     }
 }
@@ -143,6 +144,12 @@ private fun unlock(state: AppState, action: AppAction.Unlock): AppState {
 private fun openSettings(state: AppState, action: AppAction.OpenSettings): AppState {
     return state.copy(
         screen = Screen.Settings(page = action.page)
+    )
+}
+
+private fun openTab(state: AppState, action: AppAction.OpenTab): AppState {
+    return state.copy(
+        screen = Screen.Browser(tabId = action.tabId, showTabs = false)
     )
 }
 


### PR DESCRIPTION
Previously we just finished the settings activity. But now that settings are inside MainActivity this just closes the app :D. Instead we need to actively switch to the browser screen.