### PR TITLE
Closes #4850: Replace popBackStack with dispatching navigation action.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteAddFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteAddFragment.kt
@@ -21,7 +21,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import mozilla.components.browser.domains.CustomDomains
 import org.mozilla.focus.R
+import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.settings.BaseSettingsLikeFragment
+import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.ViewUtils
 import kotlin.coroutines.CoroutineContext
@@ -106,7 +108,8 @@ class AutocompleteAddFragment : BaseSettingsLikeFragment(), CoroutineScope {
 
         ViewUtils.showBrandedSnackbar(view, R.string.preference_autocomplete_add_confirmation, 0)
 
-        @Suppress("DEPRECATION")
-        fragmentManager?.popBackStack()
+        requireComponents.appStore.dispatch(AppAction.NavigateUp(
+            requireComponents.store.state.selectedTabId
+        ))
     }
 }

--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteRemoveFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteRemoveFragment.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import mozilla.components.browser.domains.CustomDomains
 import org.mozilla.focus.R
+import org.mozilla.focus.ext.requireComponents
+import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import kotlin.coroutines.CoroutineContext
 
@@ -47,8 +49,9 @@ class AutocompleteRemoveFragment : AutocompleteListFragment(), CoroutineScope {
                     TelemetryWrapper.removeAutocompleteDomainsEvent(domains.size)
                 }.await()
 
-                @Suppress("DEPRECATION")
-                requireFragmentManager().popBackStack()
+                requireComponents.appStore.dispatch(
+                    AppAction.NavigateUp(requireComponents.store.state.selectedTabId)
+                )
             }
         }
     }

--- a/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsListFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsListFragment.kt
@@ -138,8 +138,9 @@ open class ExceptionsListFragment : BaseSettingsLikeFragment(), CoroutineScope {
 
         (exceptionList.adapter as DomainListAdapter).refresh(requireActivity()) {
             if ((exceptionList.adapter as DomainListAdapter).itemCount == 0) {
-                @Suppress("DEPRECATION")
-                requireFragmentManager().popBackStack()
+                requireComponents.appStore.dispatch(
+                    AppAction.NavigateUp(requireComponents.store.state.selectedTabId)
+                )
             }
             activity?.invalidateOptionsMenu()
         }

--- a/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsRemoveFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsRemoveFragment.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.launch
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
+import org.mozilla.focus.ext.requireComponents
+import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.telemetry.TelemetryWrapper
 
 class ExceptionsRemoveFragment : ExceptionsListFragment() {
@@ -38,8 +40,9 @@ class ExceptionsRemoveFragment : ExceptionsListFragment() {
                     context.components.trackingProtectionUseCases.removeException(exception)
                 }
 
-                @Suppress("DEPRECATION")
-                requireFragmentManager().popBackStack()
+                requireComponents.appStore.dispatch(
+                    AppAction.NavigateUp(requireComponents.store.state.selectedTabId)
+                )
             }
         }
     }

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
@@ -24,6 +24,7 @@ import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.search.ManualAddSearchEnginePreference
 import org.mozilla.focus.shortcut.IconGenerator
+import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.Settings
 import org.mozilla.focus.utils.SupportUtils
@@ -247,8 +248,10 @@ class ManualAddSearchEngineSettingsFragment : BaseSettingsFragment() {
 
                 Snackbar.make(fragment.requireView(), R.string.search_add_confirmation, Snackbar.LENGTH_SHORT).show()
                 Settings.getInstance(fragment.requireActivity()).setDefaultSearchEngineByName(engineName)
-                @Suppress("DEPRECATION")
-                fragment.requireFragmentManager().popBackStack()
+
+                fragment.requireComponents.appStore.dispatch(
+                    AppAction.NavigateUp(fragment.requireComponents.store.state.selectedTabId)
+                )
             } else {
                 showServerError(fragment)
             }

--- a/app/src/main/java/org/mozilla/focus/settings/RemoveSearchEnginesSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/RemoveSearchEnginesSettingsFragment.kt
@@ -12,6 +12,7 @@ import mozilla.components.browser.state.state.searchEngines
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.search.MultiselectSearchEngineListPreference
+import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.ViewUtils
 
@@ -66,8 +67,9 @@ class RemoveSearchEnginesSettingsFragment : BaseSettingsFragment() {
                     requireComponents.searchUseCases.removeSearchEngine(searchEngine)
                 }
 
-                @Suppress("DEPRECATION")
-                requireFragmentManager().popBackStack()
+                requireComponents.appStore.dispatch(
+                    AppAction.NavigateUp(requireComponents.store.state.selectedTabId)
+                )
                 true
             }
             else -> super.onOptionsItemSelected(item)


### PR DESCRIPTION
There were some places in settings where we didn't do a fragment transaction, but instead did pop the backstack. Those we have to replace with dispatching an action for navigation now.