### PR TITLE
Complete browser-state migration and remove browser-session dependency.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -141,7 +141,6 @@ dependencies {
     implementation "org.mozilla.components:browser-engine-gecko:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:browser-domains:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:browser-errorpages:${AndroidComponents.VERSION}"
-    implementation "org.mozilla.components:browser-session:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:browser-state:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:concept-engine:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:concept-fetch:${AndroidComponents.VERSION}"

--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -7,9 +7,7 @@ package org.mozilla.focus
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import mozilla.components.browser.session.Session
-import mozilla.components.browser.session.SessionManager
-import mozilla.components.browser.session.engine.EngineMiddleware
+import mozilla.components.browser.state.engine.EngineMiddleware
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
@@ -114,13 +112,8 @@ class Components(
                 SearchMiddleware(context, migration = SearchMigration(context)),
                 SearchFilterMiddleware(),
                 PromptMiddleware()
-            ) + EngineMiddleware.create(engine, ::findSessionById)
+            ) + EngineMiddleware.create(engine)
         )
-    }
-
-    @Suppress("DEPRECATION")
-    private fun findSessionById(tabId: String): Session? {
-        return sessionManager.findSessionById(tabId)
     }
 
     /**
@@ -129,10 +122,10 @@ class Components(
     val customTabsStore by lazy { CustomTabsServiceStore() }
 
     @Suppress("DEPRECATION")
-    val sessionUseCases: SessionUseCases by lazy { SessionUseCases(store, sessionManager) }
+    val sessionUseCases: SessionUseCases by lazy { SessionUseCases(store) }
 
     @Suppress("DEPRECATION")
-    val tabsUseCases: TabsUseCases by lazy { TabsUseCases(store, sessionManager) }
+    val tabsUseCases: TabsUseCases by lazy { TabsUseCases(store) }
 
     val searchUseCases: SearchUseCases by lazy {
         SearchUseCases(store, tabsUseCases)
@@ -145,14 +138,9 @@ class Components(
     val appLinksUseCases: AppLinksUseCases by lazy { AppLinksUseCases(context.applicationContext) }
 
     @Suppress("DEPRECATION")
-    val customTabsUseCases: CustomTabsUseCases by lazy { CustomTabsUseCases(sessionManager, sessionUseCases.loadUrl) }
+    val customTabsUseCases: CustomTabsUseCases by lazy { CustomTabsUseCases(store, sessionUseCases.loadUrl) }
 
     val crashReporter: CrashReporter by lazy { createCrashReporter(context) }
-
-    @Deprecated("Use BrowserStore instead")
-    private val sessionManager by lazy {
-        SessionManager(engine, store)
-    }
 }
 
 private fun determineInitialScreen(context: Context): Screen {

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -808,19 +808,21 @@ class BrowserFragment :
             }
 
             R.id.help -> {
-                requireComponents.tabsUseCases.addPrivateTab(
+                requireComponents.tabsUseCases.addTab(
                     SupportUtils.HELP_URL,
                     source = SessionState.Source.MENU,
-                    selectTab = true
+                    selectTab = true,
+                    private = true
                 )
             }
 
             R.id.help_trackers -> {
                 val url = SupportUtils.getSumoURLForTopic(requireContext(), SupportUtils.SumoTopic.TRACKERS)
-                requireComponents.tabsUseCases.addPrivateTab(
+                requireComponents.tabsUseCases.addTab(
                     url,
                     source = SessionState.Source.MENU,
-                    selectTab = true
+                    selectTab = true,
+                    private = true
                 )
             }
 
@@ -832,10 +834,11 @@ class BrowserFragment :
 
             R.id.report_site_issue -> {
                 val reportUrl = String.format(SupportUtils.REPORT_SITE_ISSUE_URL, tab.content.url)
-                requireComponents.tabsUseCases.addPrivateTab(
+                requireComponents.tabsUseCases.addTab(
                     reportUrl,
                     source = SessionState.Source.MENU,
-                    selectTab = true
+                    selectTab = true,
+                    private = true
                 )
 
                 TelemetryWrapper.reportSiteIssueEvent()

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -441,7 +441,7 @@ class UrlInputFragment :
                 WhatsNew.userViewedWhatsNew(it)
 
                 val url = SupportUtils.getSumoURLForTopic(it, SupportUtils.SumoTopic.WHATS_NEW)
-                requireComponents.tabsUseCases.addPrivateTab(url, source = SessionState.Source.MENU)
+                requireComponents.tabsUseCases.addTab(url, source = SessionState.Source.MENU, private = true)
             }
 
             R.id.settings -> {
@@ -451,9 +451,10 @@ class UrlInputFragment :
             }
 
             R.id.help -> {
-                requireComponents.tabsUseCases.addPrivateTab(
+                requireComponents.tabsUseCases.addTab(
                     SupportUtils.HELP_URL,
-                    source = SessionState.Source.MENU
+                    source = SessionState.Source.MENU,
+                    private = true
                 )
             }
 
@@ -768,10 +769,11 @@ class UrlInputFragment :
 
             requireComponents.appStore.dispatch(AppAction.FinishEdit(tab.id))
         } else {
-            val tabId = requireComponents.tabsUseCases.addPrivateTab(
+            val tabId = requireComponents.tabsUseCases.addTab(
                 url,
                 source = SessionState.Source.USER_ENTERED,
-                selectTab = true
+                selectTab = true,
+                private = true
             )
 
             if (!searchTerms.isNullOrEmpty()) {

--- a/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsFragment.kt
@@ -161,10 +161,11 @@ class SearchSuggestionsFragment : Fragment(), CoroutineScope {
                 val context = textView.context
                 val url = SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.SEARCH_SUGGESTIONS)
 
-                requireComponents.tabsUseCases.addPrivateTab(
+                requireComponents.tabsUseCases.addTab(
                     url,
                     source = SessionState.Source.MENU,
-                    selectTab = true
+                    selectTab = true,
+                    private = true
                 )
             }
 

--- a/app/src/main/java/org/mozilla/focus/session/IntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/focus/session/IntentProcessor.kt
@@ -129,18 +129,20 @@ class IntentProcessor(
     }
 
     private fun createSession(source: SessionState.Source, url: String): Result {
-        return Result.Tab(tabsUseCases.addPrivateTab(
+        return Result.Tab(tabsUseCases.addTab(
             url,
             source = source,
-            selectTab = true
+            selectTab = true,
+            private = true
         ))
     }
 
     private fun createSearchSession(source: SessionState.Source, url: String, searchTerms: String): Result {
-        return Result.Tab(tabsUseCases.addPrivateTab(
+        return Result.Tab(tabsUseCases.addTab(
             url,
             source = source,
-            searchTerms = searchTerms
+            searchTerms = searchTerms,
+            private = true
         ))
     }
 
@@ -152,10 +154,11 @@ class IntentProcessor(
                 private = true
             ))
         } else {
-            Result.Tab(tabsUseCases.addPrivateTab(
+            Result.Tab(tabsUseCases.addTab(
                 url,
                 source = source,
-                selectTab = true
+                selectTab = true,
+                private = true
             ))
         }
     }
@@ -174,9 +177,10 @@ class IntentProcessor(
             )
             Pair(Result.CustomTab(tabId), tabId)
         } else {
-            val tabId = tabsUseCases.addPrivateTab(
+            val tabId = tabsUseCases.addTab(
                 url,
-                source = source
+                source = source,
+                private = true
             )
             Pair(Result.Tab(tabId), tabId)
         }

--- a/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
@@ -33,10 +33,11 @@ abstract class LearnMoreSwitchPreference(context: Context?, attrs: AttributeSet?
         learnMoreLink.paintFlags = learnMoreLink.paintFlags or Paint.UNDERLINE_TEXT_FLAG
         learnMoreLink.setTextColor(ContextCompat.getColor(context, R.color.colorAction))
         learnMoreLink.setOnClickListener {
-            val tabId = context.components.tabsUseCases.addPrivateTab(
+            val tabId = context.components.tabsUseCases.addTab(
                 getLearnMoreUrl(),
                 source = SessionState.Source.MENU,
-                selectTab = true
+                selectTab = true,
+                private = true
             )
 
             context.components.appStore.dispatch(

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
@@ -82,9 +82,10 @@ class ManualAddSearchEngineSettingsFragment : BaseSettingsFragment() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         val openLearnMore = {
-            val tabId = requireComponents.tabsUseCases.addPrivateTab(
+            val tabId = requireComponents.tabsUseCases.addTab(
                 SupportUtils.getSumoURLForTopic(requireContext(), SupportUtils.SumoTopic.ADD_SEARCH_ENGINE),
-                selectTab = true
+                selectTab = true,
+                private = true
             )
 
             TelemetryWrapper.addSearchEngineLearnMoreEvent()

--- a/app/src/main/java/org/mozilla/focus/settings/MozillaSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/MozillaSettingsFragment.kt
@@ -44,26 +44,29 @@ class MozillaSettingsFragment : BaseSettingsFragment(),
 
         when (preference.key) {
             resources.getString(R.string.pref_key_about) -> run {
-                val tabId = activity.components.tabsUseCases.addPrivateTab(
+                val tabId = activity.components.tabsUseCases.addTab(
                     LocalizedContent.URL_ABOUT,
                     source = SessionState.Source.MENU,
-                    selectTab = true
+                    selectTab = true,
+                    private = true
                 )
                 requireComponents.appStore.dispatch(AppAction.OpenTab(tabId))
             }
             resources.getString(R.string.pref_key_help) -> run {
-                val tabId = activity.components.tabsUseCases.addPrivateTab(
+                val tabId = activity.components.tabsUseCases.addTab(
                     SupportUtils.HELP_URL,
                     source = SessionState.Source.MENU,
-                    selectTab = true
+                    selectTab = true,
+                    private = true
                 )
                 requireComponents.appStore.dispatch(AppAction.OpenTab(tabId))
             }
             resources.getString(R.string.pref_key_rights) -> run {
-                val tabId = activity.components.tabsUseCases.addPrivateTab(
+                val tabId = activity.components.tabsUseCases.addTab(
                     LocalizedContent.URL_RIGHTS,
                     source = SessionState.Source.MENU,
-                    selectTab = true
+                    selectTab = true,
+                    private = true
                 )
                 requireComponents.appStore.dispatch(AppAction.OpenTab(tabId))
             }
@@ -73,10 +76,11 @@ class MozillaSettingsFragment : BaseSettingsFragment(),
                 else
                     SupportUtils.PRIVACY_NOTICE_URL
 
-                val tabId = activity.components.tabsUseCases.addPrivateTab(
+                val tabId = activity.components.tabsUseCases.addTab(
                     url,
                     source = SessionState.Source.MENU,
-                    selectTab = true
+                    selectTab = true,
+                    private = true
                 )
                 requireComponents.appStore.dispatch(AppAction.OpenTab(tabId))
             }

--- a/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
+++ b/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
@@ -32,10 +32,11 @@ class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val d
             val url = SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.ALLOWLIST)
 
             val deepLink = {
-                context.components.tabsUseCases.addPrivateTab(
+                context.components.tabsUseCases.addTab(
                     url,
                     source = SessionState.Source.MENU,
-                    selectTab = true
+                    selectTab = true,
+                    private = true
                 )
 
                 TelemetryWrapper.pressTipEvent(id)
@@ -75,10 +76,11 @@ class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val d
                     "https://support.mozilla.org/kb/add-web-page-shortcuts-your-home-screen"
 
             val deepLinkAddToHomescreen = {
-                context.components.tabsUseCases.addPrivateTab(
+                context.components.tabsUseCases.addTab(
                     homescreenURL,
                     source = SessionState.Source.MENU,
-                    selectTab = true
+                    selectTab = true,
+                    private = true
                 )
 
                 TelemetryWrapper.pressTipEvent(id)
@@ -126,10 +128,11 @@ class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val d
             }
 
             val deepLinkAutocompleteUrl = {
-                context.components.tabsUseCases.addPrivateTab(
+                context.components.tabsUseCases.addTab(
                     autocompleteURL,
                     source = SessionState.Source.MENU,
-                    selectTab = true
+                    selectTab = true,
+                    private = true
                 )
 
                 TelemetryWrapper.pressTipEvent(id)
@@ -149,10 +152,11 @@ class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val d
             }
 
             val deepLinkOpenInNewTab = {
-                context.components.tabsUseCases.addPrivateTab(
+                context.components.tabsUseCases.addTab(
                     newTabURL,
                     source = SessionState.Source.MENU,
-                    selectTab = true
+                    selectTab = true,
+                    private = true
                 )
 
                 TelemetryWrapper.pressTipEvent(id)
@@ -172,10 +176,11 @@ class Tip(val id: Int, val text: String, val shouldDisplay: () -> Boolean, val d
             }
 
             val deepLinkRequestDesktop = {
-                context.components.tabsUseCases.addPrivateTab(
+                context.components.tabsUseCases.addTab(
                     requestDesktopURL,
                     source = SessionState.Source.MENU,
-                    selectTab = true
+                    selectTab = true,
+                    private = true
                 )
                 TelemetryWrapper.pressTipEvent(id)
             }

--- a/app/src/main/java/org/mozilla/focus/utils/SupportUtils.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/SupportUtils.kt
@@ -79,10 +79,11 @@ object SupportUtils {
     }
 
     fun openDefaultBrowserSumoPage(context: Context) {
-        val tabId = context.components.tabsUseCases.addPrivateTab(
-                DEFAULT_BROWSER_URL,
-                source = SessionState.Source.MENU,
-                selectTab = true
+        val tabId = context.components.tabsUseCases.addTab(
+            DEFAULT_BROWSER_URL,
+            source = SessionState.Source.MENU,
+            selectTab = true,
+            private = true
         )
 
         context.components.appStore.dispatch(

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "90.0.20210525143110"
+    const val VERSION = "91.0.20210613190144"
 }


### PR DESCRIPTION
This is the matching branch for the changes in A-C: https://github.com/mozilla-mobile/android-components/pull/10212

With that Focus will no longer depend on `browser-session` and will only use `browser-state`.

The change in A-C will not land until the beginning of a new Fenix Nightly cycle.