### PR TITLE
For #4864 and #4872 activate content blocking by default

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -195,7 +195,7 @@ class Settings private constructor(
     fun shouldBlockOtherTrackers() =
             preferences.getBoolean(
                     getPreferenceKey(R.string.pref_key_privacy_block_other),
-                    false)
+                    true)
 
     fun userHasToggledSearchSuggestions(): Boolean =
             preferences.getBoolean(SearchSuggestionsPreferences.TOGGLED_SUGGESTIONS_PREF, false)

--- a/app/src/main/res/xml/privacy_security_settings.xml
+++ b/app/src/main/res/xml/privacy_security_settings.xml
@@ -33,7 +33,7 @@
             android:title="@string/preference_privacy_block_social" />
 
         <androidx.preference.SwitchPreferenceCompat
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:key="@string/pref_key_privacy_block_other"
             android:layout="@layout/focus_preference_no_icon"
             android:summary="@string/preference_privacy_block_content_summary2"


### PR DESCRIPTION
Following the QA expected behavior, we have to activate the content blocking setting by default as without it, we are only blocking cookies on the categories specified on the `TrackingProtectionPolicy`, not content from loading.