### PR TITLE
Closes #4858: fix back button behaviour from Manage sites page

### DIFF
--- a/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
@@ -179,7 +179,7 @@ private fun navigateUp(state: AppState, action: AppAction.NavigateUp): AppState 
         Screen.Settings.Page.SearchRemove -> Screen.Settings(page = Screen.Settings.Page.SearchList)
         Screen.Settings.Page.SearchAdd -> Screen.Settings(page = Screen.Settings.Page.SearchList)
         Screen.Settings.Page.SearchAutocomplete -> Screen.Settings(page = Screen.Settings.Page.Search)
-        Screen.Settings.Page.SearchAutocompleteList -> Screen.Settings(page = Screen.Settings.Page.Search)
+        Screen.Settings.Page.SearchAutocompleteList -> Screen.Settings(page = Screen.Settings.Page.SearchAutocomplete)
 
         Screen.Settings.Page.SearchAutocompleteAdd -> Screen.Settings(
             page = Screen.Settings.Page.SearchAutocompleteList


### PR DESCRIPTION
`navigateUp` currently sends back button presses (both system and app toolbar) from the `SearchAutocompleteList` (manage sites) page back to the Search settings page, skipping URL autocomplete settings.

This commit changes the `page` parameter in `navigateUp` to `SearchAutocomplete`, causing the back button to go from the Manage sites page to URL autocomplete settings as expected.