### PR TITLE
Closes #4916: restore Manage sites page background colours

### DIFF
--- a/app/src/main/res/layout/fragment_autocomplete_add_domain.xml
+++ b/app/src/main/res/layout/fragment_autocomplete_add_domain.xml
@@ -13,12 +13,14 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:background="@color/photonInk90" />
 
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/photonInk80"
         android:padding="8dp">
 
         <TextView

--- a/app/src/main/res/layout/fragment_autocomplete_customdomains.xml
+++ b/app/src/main/res/layout/fragment_autocomplete_customdomains.xml
@@ -15,12 +15,14 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:background="@color/photonInk90" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/domainList"
         android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:background="@color/photonInk80" />
 
 </LinearLayout>


### PR DESCRIPTION
The background colours in the autocomplete custom domains and add domain fragments seem to have been lost at some point. This PR restores them to photonInk90 (toolbar) and photonInk80, matching the rest of the app.