### PR TITLE
For #4859: Re-enable disableAutocompleteForCustomSiteTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/URLAutocompleteTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/URLAutocompleteTest.kt
@@ -4,7 +4,6 @@
 package org.mozilla.focus.activity
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -97,7 +96,6 @@ class URLAutocompleteTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/focus-android/issues/4859")
     @Test
     // Add custom autocompletion site, then disable autocomplete
     fun disableAutocompleteForCustomSiteTest() {


### PR DESCRIPTION
The blocking bug #4858 was fixed. Re-enabling the test again.