### PR TITLE
Update custom tab icons color according to app theme

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -159,13 +159,6 @@ class BrowserFragment :
         val blockIcon = view.findViewById<View>(R.id.block_image) as ImageView
         blockIcon.setImageResource(R.drawable.ic_tracking_protection_disabled)
 
-        val customTabConfig = tab.ifCustomTab()?.config
-        if (customTabConfig != null) {
-            initialiseCustomTabUi(view, customTabConfig)
-        } else {
-            initialiseNormalBrowserUi(view)
-        }
-
         return view
     }
 
@@ -342,6 +335,13 @@ class BrowserFragment :
             stopButton.setOnClickListener(this)
             forwardButton.setOnClickListener(this)
             backButton.setOnClickListener(this)
+        }
+
+        val customTabConfig = tab.ifCustomTab()?.config
+        if (customTabConfig != null) {
+            initialiseCustomTabUi(view, customTabConfig)
+        } else {
+            initialiseNormalBrowserUi(view)
         }
     }
 


### PR DESCRIPTION
Fix #4877 

Lock and dots menu icons remains white colored on light theme because
securityInfoBinding and menuBinding aren't initialized when tab customization
is started

### Screenshots 

#### Light Theme
<img src="https://user-images.githubusercontent.com/11731652/120660281-d81bcc80-c48f-11eb-8fd5-67f95796ac07.png" width="33%">

#### Dark Theme
<img src="https://user-images.githubusercontent.com/11731652/120660286-da7e2680-c48f-11eb-8a56-0ee4146c1f4c.png" width="33%">
