### PR TITLE
Update alert dialog style in AppTheme

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,6 +14,8 @@
 
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="preferenceTheme">@style/PreferenceTheme</item>
+        <item name="alertDialogStyle">@style/DialogStyle</item>
+        <item name="alertDialogTheme">@style/DialogStyle</item>
     </style>
 
     <style name="PreferenceTheme" parent="PreferenceThemeOverlay.v14.Material">


### PR DESCRIPTION
For #4880 

A custom alert dialog style was already implemented but wasn't set in AppTheme

### Video


https://user-images.githubusercontent.com/11731652/121487472-c9c33880-c9da-11eb-9588-e447bbd5e131.mp4

