### PR TITLE
Update splash screen alerts design

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/EraseBrowsingDataTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/EraseBrowsingDataTest.kt
@@ -35,6 +35,7 @@ import org.mozilla.focus.helpers.TestHelper.restartApp
 import org.mozilla.focus.helpers.TestHelper.verifySnackBarText
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 import org.mozilla.focus.helpers.TestHelper.webPageLoadwaitingTime
+import org.mozilla.focus.utils.FeatureFlags
 import java.io.IOException
 
 // This test erases browsing data and checks for message
@@ -79,13 +80,19 @@ class EraseBrowsingDataTest {
 
     @Test
     fun trashButtonTest() {
+        // Establish feedback message id
+        val feedbackEraseId = if (FeatureFlags.isMvp)
+            R.string.feedback_erase2
+        else
+            R.string.feedback_erase
+
         // Open a webpage
         searchScreen {
         }.loadPage(webServer.url("").toString()) {
             verifyPageContent("focus test page")
             // Press erase button, and check for message and return to the main page
         }.clearBrowsingData {
-            verifySnackBarText(getStringResource(R.string.feedback_erase))
+            verifySnackBarText(getStringResource(feedbackEraseId))
             verifyEmptySearchBar()
         }
     }
@@ -98,6 +105,12 @@ class EraseBrowsingDataTest {
             clearNotifications()
         }
 
+        // Establish feedback message id
+        val feedbackEraseId = if (FeatureFlags.isMvp)
+            R.string.feedback_erase2
+        else
+            R.string.feedback_erase
+
         // Open a webpage
         searchScreen {
         }.loadPage(webServer.url("").toString()) { }
@@ -109,7 +122,7 @@ class EraseBrowsingDataTest {
             verifySystemNotificationExists(getStringResource(R.string.notification_erase_text))
             expandEraseBrowsingNotification()
         }.clickEraseAndOpenNotificationButton {
-            verifySnackBarText(getStringResource(R.string.feedback_erase))
+            verifySnackBarText(getStringResource(feedbackEraseId))
             verifyEmptySearchBar()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MultitaskingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MultitaskingTest.kt
@@ -23,6 +23,7 @@ import org.mozilla.focus.helpers.TestHelper.clickSnackBarActionButton
 import org.mozilla.focus.helpers.TestHelper.createMockResponseFromAsset
 import org.mozilla.focus.helpers.TestHelper.getStringResource
 import org.mozilla.focus.helpers.TestHelper.verifySnackBarText
+import org.mozilla.focus.utils.FeatureFlags
 
 /**
  * Open multiple sessions and verify that the trash icon changes to a tabs counter
@@ -62,6 +63,12 @@ class MultitaskingTest {
         val secondPageTitle = webServer.hostName + "/tab2.html"
         val eraseBrowsingButtonText = getStringResource(R.string.tabs_tray_action_erase)
 
+        // Establish feedback message id
+        val feedbackEraseId = if (FeatureFlags.isMvp)
+            R.string.feedback_erase2
+        else
+            R.string.feedback_erase
+
         // Load website: Erase button visible, Tabs button not
         searchScreen {
         }.loadPage(firstPageUrl) {
@@ -85,7 +92,7 @@ class MultitaskingTest {
 
         // Remove all tabs via the tabs tray
         }.eraseBrowsingHistoryFromTabsTray {
-            verifySnackBarText(getStringResource(R.string.feedback_erase))
+            verifySnackBarText(getStringResource(feedbackEraseId))
             TestCase.assertTrue(store.state.privateTabs.isEmpty())
         }
     }

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import android.util.AttributeSet
 import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceManager
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.lib.crash.Crash
@@ -28,6 +29,7 @@ import org.mozilla.focus.shortcut.HomeScreen
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
 import org.mozilla.focus.telemetry.TelemetryWrapper
+import org.mozilla.focus.utils.FeatureFlags
 import org.mozilla.focus.utils.Settings
 import org.mozilla.focus.utils.SupportUtils
 
@@ -41,6 +43,10 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (FeatureFlags.isMvp) {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+        }
 
         if (!isTaskRoot) {
             if (intent.hasCategory(Intent.CATEGORY_LAUNCHER) && Intent.ACTION_MAIN == intent.action) {

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -71,6 +71,7 @@ import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.AppPermissionCodes.REQUEST_CODE_DOWNLOAD_PERMISSIONS
 import org.mozilla.focus.utils.AppPermissionCodes.REQUEST_CODE_PROMPT_PERMISSIONS
 import org.mozilla.focus.utils.Browsers
+import org.mozilla.focus.utils.FeatureFlags
 import org.mozilla.focus.utils.StatusBarUtils
 import org.mozilla.focus.utils.SupportUtils
 import org.mozilla.focus.widget.FloatingEraseButton
@@ -489,12 +490,16 @@ class BrowserFragment :
         // Notify the user their session has been erased if Talk Back is enabled:
         if (context != null) {
             val manager = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+            val feedbackEraseId = if (FeatureFlags.isMvp)
+                R.string.feedback_erase2
+            else
+                R.string.feedback_erase
             if (manager.isEnabled) {
                 val event = AccessibilityEvent.obtain()
                 event.eventType = AccessibilityEvent.TYPE_ANNOUNCEMENT
                 event.className = javaClass.name
                 event.packageName = requireContext().packageName
-                event.text.add(getString(R.string.feedback_erase))
+                event.text.add(getString(feedbackEraseId))
             }
         }
 

--- a/app/src/main/java/org/mozilla/focus/navigation/MainActivityNavigation.kt
+++ b/app/src/main/java/org/mozilla/focus/navigation/MainActivityNavigation.kt
@@ -27,6 +27,7 @@ import org.mozilla.focus.settings.RemoveSearchEnginesSettingsFragment
 import org.mozilla.focus.settings.SearchSettingsFragment
 import org.mozilla.focus.settings.SettingsFragment
 import org.mozilla.focus.state.Screen
+import org.mozilla.focus.utils.FeatureFlags
 import org.mozilla.focus.utils.ViewUtils
 
 /**
@@ -47,8 +48,12 @@ class MainActivityNavigation(
         val crashReporterIsVisible = browserFragment?.crashReporterIsVisible() ?: false
 
         if (isShowingBrowser && !crashReporterIsVisible) {
+            val feedbackEraseId = if (FeatureFlags.isMvp)
+                R.string.feedback_erase2
+            else
+                R.string.feedback_erase
             ViewUtils.showBrandedSnackbar(activity.findViewById(android.R.id.content),
-                R.string.feedback_erase,
+                feedbackEraseId,
                 activity.resources.getInteger(R.integer.erase_snackbar_delay))
         }
 

--- a/app/src/main/java/org/mozilla/focus/utils/ViewUtils.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/ViewUtils.kt
@@ -9,11 +9,11 @@ import android.app.Activity
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import android.view.Gravity
 import androidx.annotation.StringRes
 import com.google.android.material.snackbar.Snackbar
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
-import android.view.Gravity
 import android.view.MenuItem
 import android.view.View
 import android.view.inputmethod.InputMethodManager
@@ -95,12 +95,15 @@ object ViewUtils {
         val snackbar = Snackbar.make(view, resId, Snackbar.LENGTH_LONG)
 
         val snackbarView = snackbar.view
-        snackbarView.setBackgroundColor(ContextCompat.getColor(context, R.color.snackbarBackground))
-
         val snackbarTextView = snackbarView.findViewById<View>(R.id.snackbar_text) as TextView
         snackbarTextView.setTextColor(ContextCompat.getColor(context, R.color.snackbarTextColor))
-        snackbarTextView.gravity = Gravity.CENTER
-        snackbarTextView.textAlignment = View.TEXT_ALIGNMENT_CENTER
+        if (FeatureFlags.isMvp) {
+            snackbarView.setBackgroundResource(R.drawable.background_snackbar)
+        } else {
+            snackbarView.setBackgroundColor(ContextCompat.getColor(context, R.color.snackbarBackground))
+            snackbarTextView.gravity = Gravity.CENTER
+            snackbarTextView.textAlignment = View.TEXT_ALIGNMENT_CENTER
+        }
 
         view.postDelayed({ snackbar.show() }, delayMillis.toLong())
     }

--- a/app/src/main/res/drawable/background_snackbar.xml
+++ b/app/src/main/res/drawable/background_snackbar.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:bottom="16dp"
+        android:left="16dp"
+        android:right="16dp">
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@color/snackbarBackground" />
+            <padding
+                android:bottom="16dp"
+                android:left="30dp"
+                android:right="16dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/focus_preference.xml
+++ b/app/src/main/res/layout/focus_preference.xml
@@ -60,6 +60,7 @@
             android:layout_below="@android:id/title"
             android:layout_alignStart="@android:id/title"
             android:textAppearance="?android:attr/textAppearanceListItemSecondary"
+            android:textColor="?android:attr/textColorSecondary"
             android:maxLines="10" />
 
     </RelativeLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <color name="snackbarBackground">#2E255D</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
 
     <!-- "Snackbar" shown after the user has pressed the 'erase' button at the end of a browsing session -->
     <string name="feedback_erase">Your browsing history has been erased.</string>
+    <string name="feedback_erase2">Browsing history cleared</string>
 
     <!-- "Snackbar" shown after the user has pressed the 'erase' button at the end of a custom tab browsing session -->
     <string name="feedback_erase_custom_tab">Tab’s browsing history has been erased.</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -7,6 +7,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+
         <item name="android:windowContentTransitions">true</item>
         <item name="popupMenuStyle">@style/PopupMenu</item>
 


### PR DESCRIPTION
For #4928

Update splash screen alerts design
Update app theme
Create a new colors file resource for dark theme
Create a mvp feature flag
Apply mvp changes only when the feature flag is enabled, otherwise keep the old behavior

Because the app theme was changed to DayNight it automatically load dark colors for some attributes when the app is in light mode but for now we don't want that.
Those attributes will be updated at light theme implementation
