### PR TITLE
Remove OkHttp dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -190,7 +190,6 @@ dependencies {
     implementation "org.mozilla.components:ui-autocomplete:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:ui-colors:${AndroidComponents.VERSION}"
 
-    implementation 'com.squareup.okhttp3:okhttp:3.14.1'
     implementation project(':service-telemetry')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"


### PR DESCRIPTION
We already have okhttp via lib-fetch-okhttp for tests, so maybe we can remove this dependency entirely instead of adding it as a `testImplementation`.

Lets see if CI is happy..