### PR TITLE
Hide floating buttons when the keyboard is shown

### DIFF
--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -22,7 +22,7 @@
             android:background="@drawable/animated_background" />
 
         <org.mozilla.focus.widget.ResizableKeyboardCoordinatorLayout
-            app:viewToHideWhenActivated="@+id/erase"
+            app:viewsToHideWhenActivated="@array/viewsToHide"
             android:layout_marginTop="0dp"
             android:id="@+id/main_content"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <array name="viewsToHide">
+        <item>@id/erase</item>
+        <item>@id/tabs</item>
+    </array>
+</resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -4,7 +4,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
    <declare-styleable name="ResizableKeyboardViewDelegate">
-       <attr name="viewToHideWhenActivated" format="reference" />
+       <attr name="viewsToHideWhenActivated" format="reference" />
        <attr name="animate" format="boolean" />
    </declare-styleable>
 


### PR DESCRIPTION
For #4617 

This functionality was already implemented but for a single view and because
we are having two floating buttons(erase and sessions counter) I added a new
method to be able to update the visibility of multiple views

#### Video

https://user-images.githubusercontent.com/11731652/123086344-fee47780-d42b-11eb-812c-ba3fd0c15a1f.mp4

