### PR TITLE
Bring back shared preference exceptions storage.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -7,6 +7,9 @@ package org.mozilla.focus
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import mozilla.components.browser.state.engine.EngineMiddleware
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.DefaultSettings
@@ -35,7 +38,6 @@ import mozilla.components.service.location.LocationService
 import mozilla.components.service.location.MozillaLocationService
 import org.mozilla.focus.activity.MainActivity
 import org.mozilla.focus.components.EngineProvider
-import org.mozilla.focus.telemetry.GleanMetricsService
 import org.mozilla.focus.downloads.DownloadService
 import org.mozilla.focus.engine.ClientWrapper
 import org.mozilla.focus.engine.LocalizedContentInterceptor
@@ -47,6 +49,7 @@ import org.mozilla.focus.search.SearchMigration
 import org.mozilla.focus.state.AppState
 import org.mozilla.focus.state.AppStore
 import org.mozilla.focus.state.Screen
+import org.mozilla.focus.telemetry.GleanMetricsService
 import org.mozilla.focus.telemetry.TelemetryMiddleware
 import org.mozilla.focus.utils.Settings
 import java.util.Locale
@@ -154,7 +157,10 @@ class Components(
         }
 
         val exceptionsMigrator = EngineProvider.provideTrackingProtectionMigrator(context)
-        exceptionsMigrator.start(context)
+
+        GlobalScope.launch(Dispatchers.IO) {
+            exceptionsMigrator.start(context)
+        }
     }
 }
 

--- a/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -60,8 +60,6 @@ open class FocusApplication : LocaleAwareApplication(), CoroutineScope {
             storeLink.start()
 
             ProcessLifecycleOwner.get().lifecycle.addObserver(lockObserver)
-
-            components.migrateTrackingProtectionExceptions(this@FocusApplication)
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -61,7 +61,7 @@ open class FocusApplication : LocaleAwareApplication(), CoroutineScope {
 
             ProcessLifecycleOwner.get().lifecycle.addObserver(lockObserver)
 
-            components.migrateTrackingProtectionExceptions(this)
+            components.migrateTrackingProtectionExceptions(this@FocusApplication)
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/exceptions/ExceptionDomains.kt
+++ b/app/src/main/java/org/mozilla/focus/exceptions/ExceptionDomains.kt
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.exceptions
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * Contains functionality to manage custom domains for allow-list.
+ */
+object ExceptionDomains {
+    private const val PREFERENCE_NAME = "exceptions"
+    private const val KEY_DOMAINS = "exceptions_domains"
+    private const val SEPARATOR = "@<;>@"
+
+    private var exceptions: List<String>? = null
+
+    /**
+     * Loads the previously added/saved custom domains from preferences.
+     *
+     * @param context the application context
+     * @return list of custom domains
+     */
+    fun load(context: Context): List<String> {
+        if (exceptions == null) {
+            exceptions = (preferences(context)
+                .getString(KEY_DOMAINS, "") ?: "")
+                .split(SEPARATOR)
+                .filter { !it.isEmpty() }
+        }
+
+        return exceptions ?: listOf()
+    }
+
+    /**
+     * Saves the provided domains to preferences.
+     *
+     * @param context the application context
+     * @param domains list of domains
+     */
+    fun save(context: Context, domains: List<String>) {
+        exceptions = domains
+
+        preferences(context)
+            .edit()
+            .putString(KEY_DOMAINS, domains.joinToString(separator = SEPARATOR))
+            .apply()
+    }
+
+    /**
+     * Adds the provided domain to preferences.
+     *
+     * @param context the application context
+     * @param domain the domain to add
+     */
+    fun add(context: Context, domain: String) {
+        val domains = mutableListOf<String>()
+        domains.addAll(load(context))
+        domains.add(domain)
+
+        save(context, domains)
+    }
+
+    /**
+     * Removes the provided domain from preferences.
+     *
+     * @param context the application context
+     * @param domains the domain to remove
+     */
+    fun remove(context: Context, domains: List<String>) {
+        save(context, load(context) - domains)
+    }
+
+    /**
+     * Removes all domains from preferences.
+     *
+     * @param context the application context
+     */
+    fun removeAll(context: Context) {
+        exceptions = emptyList()
+        preferences(context).edit().remove(KEY_DOMAINS).apply()
+    }
+
+    private fun preferences(context: Context): SharedPreferences =
+        context.getSharedPreferences(PREFERENCE_NAME, Context.MODE_PRIVATE)
+}

--- a/app/src/main/java/org/mozilla/focus/exceptions/ExceptionMigrationMiddleware.kt
+++ b/app/src/main/java/org/mozilla/focus/exceptions/ExceptionMigrationMiddleware.kt
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.exceptions
+
+import android.content.Context
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.state.action.BrowserAction
+import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.selector.privateTabs
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.MiddlewareContext
+import org.mozilla.focus.components.EngineProvider
+
+/**
+ * [Middleware] implementation for migrating the tracking protection exceptions: Loading the list of
+ * exceptions from SharedPreferences and passing them to GeckoView.
+ *
+ * This is a workaround until GeckoView can permanently save tracking protection exceptions for
+ * private tabs. Otherwise they get dropped once the last GeckoSession gets closed or the process
+ * shuts down.
+ */
+class ExceptionMigrationMiddleware(
+    private val context: Context
+) : Middleware<BrowserState, BrowserAction> {
+    private val migrator by lazy { EngineProvider.provideTrackingProtectionMigrator(context) }
+    private var hasTabs = false
+
+    override fun invoke(
+        context: MiddlewareContext<BrowserState, BrowserAction>,
+        next: (BrowserAction) -> Unit,
+        action: BrowserAction
+    ) {
+        next(action)
+
+        if (action is TabListAction) {
+            checkIfMigrationIsNeeded(context.state)
+        }
+    }
+
+    private fun checkIfMigrationIsNeeded(state: BrowserState) {
+        if (state.privateTabs.isEmpty() && hasTabs) {
+            // All tabs have been removed, let's remember this state, so that we can migrate the
+            // tracking protection exceptions again, once the first new tab gets added. We have to
+            // delay the migration because we do not know when the matching GeckoSession will get
+            // closed, because that happens asynchronously.
+            hasTabs = false
+        } else if (state.privateTabs.isNotEmpty() && !hasTabs) {
+            // There are tabs now, let's migrate the exceptions again.
+            migrateTrackingProtectionExceptions()
+            hasTabs = true
+        }
+    }
+
+    private fun migrateTrackingProtectionExceptions() {
+        // We migrate the tracking protection exceptions blocking the store thread, because we want
+        // to make sure this has happened before the first GeckoSession gets created.
+        runBlocking {
+            migrator.start(context)
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsListFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsListFragment.kt
@@ -119,6 +119,7 @@ open class ExceptionsListFragment : BaseSettingsLikeFragment(), CoroutineScope {
 
         removeAllExceptions.setOnClickListener {
             requireComponents.trackingProtectionUseCases.removeAllExceptions()
+            ExceptionDomains.removeAll(requireContext())
 
             val exceptions = (exceptionList.adapter as DomainListAdapter).selection()
             TelemetryWrapper.removeAllExceptionDomains(exceptions.count())

--- a/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsRemoveFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsRemoveFragment.kt
@@ -9,8 +9,11 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import kotlinx.android.synthetic.main.fragment_exceptions_domains.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.requireComponents
@@ -36,6 +39,10 @@ class ExceptionsRemoveFragment : ExceptionsListFragment() {
         TelemetryWrapper.removeExceptionDomains(exceptions.size)
         if (exceptions.isNotEmpty()) {
             launch(Main) {
+                withContext(Dispatchers.IO) {
+                    val domains = exceptions.map { it.url.tryGetHostFromUrl() }
+                    ExceptionDomains.remove(context, domains)
+                }
                 exceptions.forEach { exception ->
                     context.components.trackingProtectionUseCases.removeException(exception)
                 }

--- a/app/src/main/java/org/mozilla/focus/exceptions/GeckoExceptionsMigrator.kt
+++ b/app/src/main/java/org/mozilla/focus/exceptions/GeckoExceptionsMigrator.kt
@@ -18,6 +18,7 @@ class GeckoExceptionsMigrator(
     private val runtime: GeckoRuntime
 ) {
     private val logger = Logger("GeckoExceptionsMigrator")
+    private val storageController = runtime.storageController
 
     fun start(context: Context) {
         if (!isOver(context)) {
@@ -53,7 +54,7 @@ class GeckoExceptionsMigrator(
 
     private fun migrate(uri: String) {
         val privateMode = true
-        runtime.storageController.setPermission(
+        storageController.setPermission(
             "https://$uri",
             null,
             privateMode,

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -36,7 +36,6 @@ import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.toolbar.BrowserToolbar
-import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
 import mozilla.components.feature.contextmenu.ContextMenuFeature
@@ -500,10 +499,6 @@ class BrowserFragment :
         }
 
         requireComponents.tabsUseCases.removeTab(tab.id)
-
-        // Temporary workaround until we get https://bugzilla.mozilla.org/show_bug.cgi?id=1644156
-        // See comment in TabUtils.createTab().
-        requireComponents.engine.clearData(Engine.BrowsingData.all())
     }
 
     private fun shareCurrentUrl() {


### PR DESCRIPTION
As mentioned on https://github.com/mozilla-mobile/focus-android/pull/4899#pullrequestreview-702210325 GV is not persisting TP exceptions so after app restart, as a workaround we need to store then in the previous shared preference store and load them into GV on startup. 