### PR TITLE
Add Github Action checks for contributors

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -1,0 +1,133 @@
+name: Android build PR
+on: [pull_request]
+jobs:
+  run-build:
+    runs-on: ubuntu-20.04
+    if: github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'MickeyMoz'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: "Clean & Assemble Debug"
+        uses: eskatos/gradle-command-action@v1
+        with:
+          wrapper-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
+          arguments: clean app:assembleDebug
+
+  run-testDebugUnitTest:
+    runs-on: ubuntu-20.04
+    if: github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'MickeyMoz'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: "Test Debug Unit Tests"
+        uses: eskatos/gradle-command-action@v1
+        with:
+          wrapper-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
+          arguments: testFocusDebugUnitTest
+
+  run-detekt:
+    runs-on: ubuntu-20.04
+    if: github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'MickeyMoz'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: "Detekt"
+        uses: eskatos/gradle-command-action@v1
+        with:
+          wrapper-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
+          arguments: detekt
+      - name: Archive detekt results
+        uses: actions/upload-artifact@v2
+        with:
+          name: detekt report
+          path: build/reports/detekt.html
+
+  run-ktlint:
+    runs-on: ubuntu-20.04
+    if: github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'MickeyMoz'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: "Ktlint"
+        uses: eskatos/gradle-command-action@v1
+        with:
+          wrapper-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
+          arguments: ktlint
+
+  run-lintDebug:
+    runs-on: ubuntu-20.04
+    if: github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'MickeyMoz'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: "Lint Debug"
+        uses: eskatos/gradle-command-action@v1
+        with:
+          wrapper-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
+          arguments: lintDebug
+      - name: Archive lint results
+        uses: actions/upload-artifact@v2
+        with:
+          name: lintDebug report
+          path: app/build/reports/lint-results-debug.html
+
+  run-ui:
+    runs-on: macos-11
+    if: github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'MickeyMoz'
+
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        api-level: [28]
+        target: [google_apis]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run subset of UI Tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: pixel_3a
+          script:
+            "./gradlew connectedFocusDebugAndroidTest"
+      - name: Upload Test Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-report
+          path: app/build/reports


### PR DESCRIPTION
Akin to Fenix, let's get some checks working for forks, especially running UI tests now that there are many updated.

This runs: `clean app:assembleDebug` `testFocusDebugUnitTest` `detekt` `ktlint` `lintDebug` `connectedFocusDebugAndroidTest` on fork and if the PR is not opened by `MickeyMoz` (don't think this is used on focus-android anyways).

Might need to toggle repo settings for Github Actions which I don't have view on; as a I don't see the run in the Actions tab (or Actions are setup on this repo to run only when code is in the repo).

(@st3fan I don't have visibility into the Settings on this repo, which Action permission is currently selected on `focus-android`?)