### PR TITLE
For #4934: fixes scrolling text into view

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsPrivacyMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsPrivacyMenuRobot.kt
@@ -99,7 +99,7 @@ private fun stealthModeSwitch(): ViewInteraction {
 
 private fun safeBrowsingSwitch(): ViewInteraction {
     val safeBrowsingSwitchText = getStringResource(R.string.preference_safe_browsing_summary)
-    privacySettingsList.scrollTextIntoView(safeBrowsingSwitchText)
+    privacySettingsList.scrollTextIntoView("Data Choices")
     return onView(withText(safeBrowsingSwitchText))
 }
 


### PR DESCRIPTION
Small change to scroll into view the whole element before clicking on it.