### PR TITLE
No issue: Run UI tests on API28 for better stability on FTL

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
@@ -4,7 +4,6 @@
 package org.mozilla.focus.activity
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -31,8 +30,6 @@ class ErrorPagesTest {
         }
     }
 
-    @Ignore("Failing on API 29, working on API 28," +
-            "needs investigation: https://github.com/mozilla-mobile/focus-android/issues/4839")
     @Test
     fun noNetworkConnectionErrorPageTest() {
         val pageUrl = "mozilla.org"

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/AddToHomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/AddToHomeScreenRobot.kt
@@ -4,8 +4,6 @@
 
 package org.mozilla.focus.activity.robots
 
-import android.util.Log
-import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import org.mozilla.focus.helpers.TestHelper.mDevice
@@ -40,20 +38,14 @@ class AddToHomeScreenRobot {
             mDevice.waitForIdle(waitingTime)
             mDevice.pressHome()
 
-            fun deviceHomeScreen() =
-                UiScrollable(UiSelector().resourceId("com.google.android.apps.nexuslauncher:id/workspace"))
+            fun deviceHomeScreen() = UiScrollable(UiSelector().scrollable(true))
+            deviceHomeScreen().setAsHorizontalList()
 
-            try {
-                fun shortcut() = deviceHomeScreen().getChild(UiSelector().text(title))
-                shortcut().waitForExists(waitingTime)
-                shortcut().clickAndWaitForNewWindow()
-            } catch (e: UiObjectNotFoundException) {
-                Log.d("TestLog", "Shortcut not found ${e.message}")
-                deviceHomeScreen().setAsHorizontalList()
-                fun shortcut() =
-                    deviceHomeScreen().getChildByText(UiSelector().text(title), title, true)
-                shortcut().clickAndWaitForNewWindow()
-            }
+            fun shortcut() =
+                    deviceHomeScreen()
+                            .getChildByText(UiSelector().text(title), title, true)
+            shortcut().waitForExists(waitingTime)
+            shortcut().clickAndWaitForNewWindow()
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/ThreeDotMainMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/ThreeDotMainMenuRobot.kt
@@ -121,7 +121,7 @@ private val shareBtn = mDevice.findObject(
         .resourceId("$packageName:id/share")
 )
 
-private val threeDotMenuButton = onView(withId(R.id.menuView))
+private val threeDotMenuButton = onView(withId(R.id.mozac_browser_toolbar_menu))
 
 private val addToHSmenuItem = mDevice.findObject(
     UiSelector()

--- a/app/src/androidTest/java/org/mozilla/focus/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/TestHelper.kt
@@ -54,11 +54,8 @@ object TestHelper {
     fun getStringResource(id: Int) = appContext.resources.getString(id, appName)
 
     fun verifySnackBarText(text: String) {
-        val snackbarText = mDevice.findObject(
-            UiSelector().resourceId("$packageName:id/snackbar_text")
-        )
-        snackbarText.waitForExists(waitingTime)
-        assertTrue(snackbarText.text.contains(text))
+        val snackbarText = mDevice.findObject(UiSelector().textContains(text))
+        assertTrue(snackbarText.waitForExists(waitingTime))
     }
 
     fun clickSnackBarActionButton(action: String) {

--- a/tools/taskcluster/flank.yml
+++ b/tools/taskcluster/flank.yml
@@ -44,7 +44,7 @@ gcloud:
 
   device:
     - model: Pixel2
-      version: 29
+      version: 28
 
 flank:
   project: moz-fx-mobile-firebase-testlab


### PR DESCRIPTION
Failing tests on Firebase for no obvious reason, so I thought to give API28 a test run and it seemed to be an improvement.
 - tests failing on API 29: [link](https://firefox-ci-tc.services.mozilla.com/tasks/OJiS4g6LQdOtl2QhPnP2FA/runs/0/logs/public/logs/live.log)

- same tests on API 28: [link](https://firefox-ci-tc.services.mozilla.com/tasks/RWP2A_nCTR-OxGClqua8gQ/runs/0/logs/public/logs/live.log
)
- all tests on API 28: [link](https://firefox-ci-tc.services.mozilla.com/tasks/I5oFpQaOTR-INv0ex__wEw/runs/0/logs/public/logs/live.log)

   - +fixed failing tests in the above run: [link](https://firefox-ci-tc.services.mozilla.com/tasks/E8Di-VS5Rx68MiVuwBdVSg/runs/0/logs/public/logs/live.log)

This will also fix and re-enable https://github.com/mozilla-mobile/focus-android/issues/4839