### PR TITLE
For #4975 - Build enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ Before you attempt to make a contribution please read the [Community Participati
 **focusX86Debug** for X86
 **focusAarch64Debug** for ARM64
 
+## local.properties helpers
+You can speed up or enhance local development by setting a few helper flags available in `local.properties` which will be made easily available as gradle properties.
+
+### Automatically sign release builds
+To sign your release builds with your debug key automatically, add the following to `<proj-root>/local.properties`:
+
+```sh
+autosignReleaseWithDebugKey
+```
+
+With this line, release build variants will automatically be signed with your debug key (like debug builds), allowing them to be built and installed directly through Android Studio or the command line.
+
+This is helpful when you're building release variants frequently, for example to test feature flags and or do performance analyses.
+
 ## Pre-push hooks
 To reduce review turn-around time, we'd like all pushes to run tests locally. We'd
 recommend you use our provided pre-push hook in `quality/pre-push-recommended.sh`.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ Nightly, Beta and Release variants are getting published to Google Play and ther
 debuggable
 ```
 
+### Auto-publication workflow for android-components and application-services
+If you're making changes to these projects and want to test them in Focus, auto-publication workflow is the fastest, most reliable
+way to do that.
+
+In `local.properties`, specify a relative path to your local `android-components` and/or `application-services` checkouts. E.g.:
+- `autoPublish.android-components.dir=../android-components`
+- `autoPublish.application-services.dir=../application-services`
+
+Once these flags are set, your Focus builds will include any local modifications present in these projects.
+
+See a [demo of auto-publication workflow in action](https://www.youtube.com/watch?v=qZKlBzVvQGc).
+
 ## Pre-push hooks
 To reduce review turn-around time, we'd like all pushes to run tests locally. We'd
 recommend you use our provided pre-push hook in `quality/pre-push-recommended.sh`.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ With this line, release build variants will automatically be signed with your de
 
 This is helpful when you're building release variants frequently, for example to test feature flags and or do performance analyses.
 
+### Building debuggable release variants
+
+Nightly, Beta and Release variants are getting published to Google Play and therefore are not debuggable. To locally create debuggable builds of those variants, add the following to `<proj-root>/local.properties`:
+
+```sh
+debuggable
+```
+
 ## Pre-push hooks
 To reduce review turn-around time, we'd like all pushes to run tests locally. We'd
 recommend you use our provided pre-push hook in `quality/pre-push-recommended.sh`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,11 @@ android {
                 println ("All builds will be automatically signed with the debug key")
                 signingConfig signingConfigs.debug
             }
+
+            if (gradle.hasProperty("localProperties.debuggable")) {
+                println ("All builds will be debuggable")
+                debuggable true
+            }
         }
         debug {
             applicationIdSuffix ".debug"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,6 +52,11 @@ android {
             minifyEnabled !project.hasProperty("disableOptimization")
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             matchingFallbacks = ['release']
+
+            if (gradle.hasProperty("localProperties.autosignReleaseWithDebugKey")) {
+                println ("All builds will be automatically signed with the debug key")
+                signingConfig signingConfigs.debug
+            }
         }
         debug {
             applicationIdSuffix ".debug"
@@ -346,8 +351,13 @@ android.applicationVariants.all { variant ->
             buildConfigField 'String', 'ADJUST_TOKEN', '"' + token + '"'
             println "(Added from .adjust_token file)"
         } catch (FileNotFoundException ignored) {
-            buildConfigField 'String', 'ADJUST_TOKEN', 'null'
-            println("X_X")
+            if (gradle.hasProperty("localProperties.autosignReleaseWithDebugKey")) {
+                buildConfigField 'String', 'ADJUST_TOKEN', '"fake"'
+                println("fake - only for local development")
+            } else {
+                buildConfigField 'String', 'ADJUST_TOKEN', 'null'
+                println("X_X")
+            }
         }
     } else {
         buildConfigField 'String', 'ADJUST_TOKEN', 'null'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,8 +39,10 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled true
-            shrinkResources true
+            // We allow disabling optimization by passing `-PdisableOptimization` to gradle. This is used
+            // in automation for UI testing non-debug builds.
+            shrinkResources !project.hasProperty("disableOptimization")
+            minifyEnabled !project.hasProperty("disableOptimization")
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             matchingFallbacks = ['release']
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -502,3 +502,13 @@ if (project.hasProperty("coverage")) {
         }
     }
 }
+
+if (gradle.hasProperty('localProperties.autoPublish.android-components.dir')) {
+    ext.acSrcDir = gradle."localProperties.autoPublish.android-components.dir"
+    apply from: "../${acSrcDir}/substitute-local-ac.gradle"
+}
+
+if (gradle.hasProperty('localProperties.autoPublish.application-services.dir')) {
+    ext.appServicesSrcDir = gradle."localProperties.autoPublish.application-services.dir"
+    apply from: "../${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,13 @@ import com.android.build.OutputFile
 
 android {
     compileSdkVersion 30
+
+    if (project.hasProperty("testBuildType")) {
+        // Allowing to configure the test build type via command line flag (./gradlew -PtestBuildType=beta ..)
+        // in order to run UI tests against other build variants than debug in automation.
+        testBuildType project.property("testBuildType")
+    }
+    
     defaultConfig {
         applicationId "org.mozilla"
         minSdkVersion 21

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,3 +9,27 @@ pluginManagement {
 
 include ':app'
 include ':service-telemetry'
+
+def log(message) {
+    logger.lifecycle("[settings] ${message}")
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Local development enhancements
+//////////////////////////////////////////////////////////////////////////
+
+Properties localProperties = null
+
+if (file('local.properties').canRead()) {
+    localProperties = new Properties()
+    localProperties.load(file('local.properties').newDataInputStream())
+    log('Loaded local.properties')
+} else {
+    log('Missing local.properties; see https://github.com/mozilla-mobile/focus-android/blob/master/README.md#local-properties-helpers for instructions.')
+}
+
+if (localProperties != null) {
+    localProperties.each { prop ->
+        gradle.ext.set("localProperties.${prop.key}", prop.value)
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,7 +25,7 @@ if (file('local.properties').canRead()) {
     localProperties.load(file('local.properties').newDataInputStream())
     log('Loaded local.properties')
 } else {
-    log('Missing local.properties; see https://github.com/mozilla-mobile/focus-android/blob/master/README.md#local-properties-helpers for instructions.')
+    log('Missing local.properties; see https://github.com/mozilla-mobile/focus-android/blob/master/README.md#local.properties helpers for instructions.')
 }
 
 if (localProperties != null) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,11 +14,27 @@ def log(message) {
     logger.lifecycle("[settings] ${message}")
 }
 
+def runCmd(cmd, workingDir, successMessage, captureStdout=true) {
+    def proc = cmd.execute(null, new File(workingDir))
+    def standardOutput = captureStdout ? new ByteArrayOutputStream() : System.out
+    proc.consumeProcessOutput(standardOutput, System.err)
+    proc.waitFor()
+
+    if (proc.exitValue() != 0) {
+        throw new GradleException("Process '${cmd}' finished with non-zero exit value ${proc.exitValue()}");
+    } else {
+        log(successMessage)
+    }
+    return captureStdout ? standardOutput : null
+}
+
 //////////////////////////////////////////////////////////////////////////
 // Local development enhancements
 //////////////////////////////////////////////////////////////////////////
 
 Properties localProperties = null
+String settingAppServicesPath = "autoPublish.application-services.dir"
+String settingAndroidComponentsPath = "autoPublish.android-components.dir"
 
 if (file('local.properties').canRead()) {
     localProperties = new Properties()
@@ -32,4 +48,36 @@ if (localProperties != null) {
     localProperties.each { prop ->
         gradle.ext.set("localProperties.${prop.key}", prop.value)
     }
+
+    String appServicesLocalPath = localProperties.getProperty(settingAppServicesPath)
+
+    if (appServicesLocalPath != null) {
+        log("Enabling automatic publication of application-services from: $appServicesLocalPath")
+        // Windows can't execute .py files directly, so we assume a "manually installed" python,
+        // which comes with a "py" launcher and respects the shebang line to specify the version.
+        def publishAppServicesCmd = [];
+        if (System.properties['os.name'].toLowerCase().contains('windows')) {
+            publishAppServicesCmd << "py";
+        }
+        publishAppServicesCmd << "./automation/publish_to_maven_local_if_modified.py";
+        runCmd(publishAppServicesCmd, appServicesLocalPath, "Published application-services for local development.", false)
+    } else {
+        log("Disabled auto-publication of application-services. Enable it by settings '$settingAppServicesPath' in local.properties")
+    }
+
+    String androidComponentsLocalPath = localProperties.getProperty(settingAndroidComponentsPath)
+
+    if (androidComponentsLocalPath != null) {
+        log("Enabling automatic publication of android-components from: $androidComponentsLocalPath")
+        // As above, hacks to execute .py files on Windows.
+        def publishAcCmd = [];
+        if (System.properties['os.name'].toLowerCase().contains('windows')) {
+            publishAcCmd << "py";
+        }
+        publishAcCmd << "./automation/publish_to_maven_local_if_modified.py";
+        runCmd(publishAcCmd, androidComponentsLocalPath, "Published android-components for local development.", false)
+    } else {
+        log("Disabled auto-publication of android-components. Enable it by settings '$settingAndroidComponentsPath' in local.properties")
+    }
 }
+


### PR DESCRIPTION
Added support for :
- `disableOptimization` and `testBuildType=xx` allowing the Gradle `connectedAndroidTest` task to run instrumented tests unhindered even on nightly/beta/release builds
- `local.properties#autosignReleaseWithDebugKey`allowing to automatically sign nightly/beta/release builds with the debug key. Only to ease local development.
- `local.properties#debuggable` allowing even nightly/beta/release builds to be debugged.
- `local.properties#autoPublish.android-components.dir=xx` and `local.properties#autoPublish.application-services.dir=xx` allowing to automatically publish and use in Focus any local changes made in the AC/AS projects.