### PR TITLE
Update loading progress bar gradient

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -4,4 +4,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
     <color name="snackbarBackground">#2E255D</color>
+    <color name="colorProgressGradientStart">#FF9059FF</color>
+    <color name="colorProgressGradientCenter">#FFFF4AA2</color>
+    <color name="colorProgressGradientEnd">#FFFFBD4F</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -16,7 +16,8 @@
     <color name="colorGradientCenter">#970772</color>
     <color name="colorGradientEnd">#57076a</color>
 
-    <color name="colorProgressGradientStart">#FF9400FF</color>
+    <color name="colorProgressGradientStart">#FFFF1AD9</color>
+    <color name="colorProgressGradientCenter">#FFFF1AD9</color>
     <color name="colorProgressGradientEnd">#FFFF1AD9</color>
 
     <color name="colorInactiveGradientStart">#ff453440</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,6 +19,7 @@
         <item name="preferenceTheme">@style/PreferenceTheme</item>
         <item name="alertDialogStyle">@style/DialogStyle</item>
         <item name="alertDialogTheme">@style/DialogStyle</item>
+        <item name="android:progressBarStyleHorizontal">@style/progressBarStyleHorizontal</item>
     </style>
 
     <style name="PreferenceTheme" parent="PreferenceThemeOverlay.v14.Material">
@@ -158,5 +159,9 @@
 
     <style name="ColorHandleTheme">
         <item name="android:colorControlActivated">@color/photonBlue50</item>
+    </style>
+
+    <style name="progressBarStyleHorizontal" parent="@style/Widget.AppCompat.ProgressBar.Horizontal">
+        <item name="android:progressDrawable">@drawable/photon_progressbar</item>
     </style>
 </resources>


### PR DESCRIPTION
For #4930

Update loading progress bar gradient
New color resources added to use a different gradient for progress bar in dark theme

Because the app theme was changed to DayNight it automatically load dark colors for some attributes when the app is in light mode but for now we don't want that.
Those attributes will be updated at light theme implementation