### PR TITLE
Change profile in build-contributor-pr.yml

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -123,9 +123,10 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
-          profile: pixel_3a
+          profile: pixel_2
           script:
-            "./gradlew connectedFocusDebugAndroidTest"
+            "./gradlew connectedFocusDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=\
+            org.mozilla.focus.activity.ThreeDotMainMenuTest#browserMenuItemsTest"
       - name: Upload Test Artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Let's match a Pixel 2 (that we use on Firebase) to see if there's any difference in UI-test results(@sv-ohorvath). Let's also trial one test for now.
`org.mozilla.focus.activity.ThreeDotMainMenuTest#browserMenuItemsTest`

Reminder this action runs on forks only.