### PR TITLE
Update FeaturesFlag.isMvp

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/FeatureFlags.kt
@@ -3,9 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.focus.utils
 
+import org.mozilla.focus.BuildConfig
+
 /**
  * Feature flag for MVP
  */
 object FeatureFlags {
-    const val isMvp = false
+    val isMvp = BuildConfig.DEBUG
 }


### PR DESCRIPTION
For #5004

Update const val isMvp = false/true to var isMvp = BuildConfig.BUILD_TYPE.contains("debug")
It helps QA team to see the mvp changes without manually updating the flag