### PR TITLE
For #5011 - the GV icon was missing on the "About" page

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/LocalizedContent.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/LocalizedContent.kt
@@ -31,7 +31,8 @@ object LocalizedContent {
         val learnMoreURL = manifestoURL
         var aboutVersion = ""
         try {
-            val engineIndicator = BuildConfig.MOZ_APP_VERSION + "-" + BuildConfig.MOZ_APP_BUILDID
+            val engineIndicator = " \uD83E\uDD8E " + BuildConfig.MOZ_APP_VERSION + "-" +
+                BuildConfig.MOZ_APP_BUILDID
             val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
             @Suppress("DEPRECATION")
             aboutVersion = String.format(


### PR DESCRIPTION
For #5011 - the GV icon was missing on the "About" page

![Screenshot_20210727-214941](https://user-images.githubusercontent.com/1100614/127218527-dd143af0-f5db-4add-82d4-bb095a03b192.jpg)