### PR TITLE
Issue #5023: UrlInputFragment: Hide keyboard on pause.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -40,6 +40,7 @@ import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import mozilla.components.support.ktx.android.view.hideKeyboard
 import mozilla.components.support.utils.ThreadUtils
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.isSearch
@@ -206,6 +207,7 @@ class UrlInputFragment :
     override fun onPause() {
         job.cancel()
         super.onPause()
+        view?.hideKeyboard()
     }
 
     private fun updateTipsLabel() {


### PR DESCRIPTION
That's what Fenix seems to be doing.