### PR TITLE
Issue #5013: InputToolbarIntegration: Do not switch to display mode after invoking commit listener.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/input/InputToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/focus/input/InputToolbarIntegration.kt
@@ -42,7 +42,7 @@ class InputToolbarIntegration(
         })
         toolbar.setOnUrlCommitListener { url ->
             fragment.onCommit(url)
-            true
+            false
         }
 
         toolbar.setAutocompleteListener { text, delegate ->


### PR DESCRIPTION
`false`