### PR TITLE
Set version to 93.0.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ android {
         targetSdkVersion 30
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
                        // override this with a generated versionCode at build time.
-        versionName "8.13.1"
+        versionName "93.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
 


### PR DESCRIPTION
Starting with 91 (`releases_v91.0`) we will start aligning our version numbers with GeckoView/Fenix. `main` is expected to be 93. (92 will be branched from 91 to give the code on `main` more time).