### PR TITLE
Update to Mozilla Android Components 91.0.11

### DIFF
--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "91.0.11"
+    const val VERSION = "91.0.12"
 }

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "91.0.20210705190256"
+    const val VERSION = "91.0.11"
 }


### PR DESCRIPTION
This updates our `releases_v91.0` branch to Mozilla Android Components 91.0.11. This will update to the first RC of GeckoView 91.0 and should also include a fix for #5012.