### PR TITLE
Issue #4901: Update metrics for data review on initial metrics

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -14,12 +14,12 @@ browser:
     bugs:
       - https://github.com/mozilla-mobile/focus-android/issues/4545
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-android/issues/4901
+      - https://github.com/mozilla-mobile/focus-android/pull/5065#issuecomment-894328647
     data_sensitivity:
       - interaction
     notification_emails:
-      - jalmeida@mozilla.com
-    expires: "2022-08-01"
+      - android-probes@mozilla.com
+    expires: "2022-07-01"
   default_search_engine:
     type: string
     lifetime: application
@@ -28,12 +28,12 @@ browser:
     bugs:
       - https://github.com/mozilla-mobile/focus-android/issues/4545
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-android/issues/4901
+      - https://github.com/mozilla-mobile/focus-android/pull/5065#issuecomment-894328647
     data_sensitivity:
       - interaction
     notification_emails:
-      - jalmeida@mozilla.com
-    expires: never
+      - android-probes@mozilla.com
+    expires: "2022-07-01"
   locale_override:
     type: string
     lifetime: application
@@ -43,31 +43,12 @@ browser:
     bugs:
       - https://github.com/mozilla-mobile/focus-android/issues/4545
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-android/issues/4901
+      - https://github.com/mozilla-mobile/focus-android/pull/5065#issuecomment-894328647
     data_sensitivity:
       - technical
     notification_emails:
-      - jalmeida@mozilla.com
-    expires: never
-
-activation:
-  activation_id:
-    type: uuid
-    lifetime: user
-    description: |
-      An alternate identifier, not correlated with the client_id, generated once
-      and only sent with the activation ping.
-    send_in_pings:
-      - activation
-    bugs:
-      - https://github.com/mozilla-mobile/focus-android/issues/4545
-    data_reviews:
-      - https://github.com/mozilla-mobile/focus-android/issues/4901
-    data_sensitivity:
-      - highly_sensitive
-    notification_emails:
-      - jalmeida@mozilla.com
-    expires: never
+      - android-probes@mozilla.com
+    expires: "2022-07-01"
 
 legacy_ids:
   client_id:
@@ -82,6 +63,7 @@ legacy_ids:
       - https://github.com/mozilla-mobile/focus-android/issues/4901
     notification_emails:
       - jalmeida@mozilla.com
+      - android-probes@mozilla.com
     expires: never
 
 browser.search:

--- a/app/src/main/java/org/mozilla/focus/telemetry/ActivationPing.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/ActivationPing.kt
@@ -11,8 +11,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.support.base.log.logger.Logger
-import org.mozilla.focus.GleanMetrics.Activation
-import org.mozilla.focus.GleanMetrics.Pings
 
 /**
  * Ensures that only one activation ping is ever sent.
@@ -58,11 +56,13 @@ class ActivationPing(private val context: Context) {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun triggerPing() {
         // Generate the activation_id.
-        Activation.activationId.generateAndSet()
+        // Activation.activationId.generateAndSet()
 
         CoroutineScope(Dispatchers.IO).launch {
-            Pings.activation.submit()
-            markAsTriggered()
+            // Disabled until data-review r+
+            // See: https://github.com/mozilla-mobile/focus-android/pull/5065
+            // Pings.activation.submit()
+            // markAsTriggered()
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/telemetry/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/GleanMetricsService.kt
@@ -36,6 +36,7 @@ import java.util.UUID
  */
 class GleanMetricsService(context: Context) : MetricsService {
 
+    @Suppress("UnusedPrivateMember")
     private val activationPing = ActivationPing(context)
 
     @OptIn(DelicateCoroutinesApi::class)
@@ -77,7 +78,8 @@ class GleanMetricsService(context: Context) : MetricsService {
                     Browser.defaultSearchEngine.set(getDefaultSearchEngineIdentifierForTelemetry(context))
                 }
 
-                activationPing.checkAndSend()
+                // Disabled until data-review r+
+                // activationPing.checkAndSend()
             }
         }
     }


### PR DESCRIPTION
@travis79 I tried to separate out the data review into two requests to make it a bit easier: one for browser metrics, the other for activation and legacy IDs for deletion.