### PR TITLE
Closes #5020: Clear selected search suggetion from view model after processing.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -186,6 +186,7 @@ class UrlInputFragment :
                 } else {
                     onSearch(it, isSuggestion)
                 }
+                searchSuggestionsViewModel.clearSearchSuggestion()
             }
         })
     }

--- a/app/src/main/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsViewModel.kt
+++ b/app/src/main/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsViewModel.kt
@@ -60,6 +60,10 @@ class SearchSuggestionsViewModel(application: Application) : AndroidViewModel(ap
         _selectedSearchSuggestion.postValue(suggestion)
     }
 
+    fun clearSearchSuggestion() {
+        _selectedSearchSuggestion.postValue(null)
+    }
+
     fun setSearchQuery(query: String) {
         _searchQuery.value = query
 


### PR DESCRIPTION
The lifetime is bound to the liftime of the activity. This is already questionable,
but currently two fragments communicate via this view model. If a search suggestion
is selected this is communicated via the view model. The next time we go to the
search screen the old selected search suggestion is still in the state and gets
processed again. This quick fix will take care of clearing the search suggestion
after processing it.

**I think we should uplift this to 91.0 before releasing**