### PR TITLE
Close #5076: Use referenced colour resource in normal theme

### DIFF
--- a/app/src/main/java/org/mozilla/focus/menu/browser/CustomTabMenu.kt
+++ b/app/src/main/java/org/mozilla/focus/menu/browser/CustomTabMenu.kt
@@ -6,9 +6,7 @@ package org.mozilla.focus.menu.browser
 import android.content.Context
 import androidx.core.content.ContextCompat
 import mozilla.components.browser.menu.BrowserMenuBuilder
-import mozilla.components.browser.menu.BrowserMenuHighlight
 import mozilla.components.browser.menu.item.BrowserMenuDivider
-import mozilla.components.browser.menu.item.BrowserMenuHighlightableItem
 import mozilla.components.browser.menu.item.BrowserMenuImageSwitch
 import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
@@ -112,14 +110,10 @@ class CustomTabMenu(
             onItemTapped.invoke(ToolbarMenu.Item.AddToHomeScreen)
         }
 
-        val openInApp = BrowserMenuHighlightableItem(
+        val openInApp = BrowserMenuImageText(
             label = context.getString(R.string.menu_open_with_a_browser2),
-            startImageResource = R.drawable.ic_help,
-            textColorResource = context.theme.resolveAttribute(R.attr.primaryText),
-            highlight = BrowserMenuHighlight.HighPriority(
-                backgroundTint = ContextCompat.getColor(context, R.color.mvp_browser_menu_bg),
-                canPropagate = false
-            )
+            imageResource = R.drawable.ic_open_in,
+            textColorResource = context.theme.resolveAttribute(R.attr.primaryText)
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.OpenInApp)
         }

--- a/app/src/main/java/org/mozilla/focus/menu/browser/DefaultBrowserMenu.kt
+++ b/app/src/main/java/org/mozilla/focus/menu/browser/DefaultBrowserMenu.kt
@@ -4,11 +4,8 @@
 package org.mozilla.focus.menu.browser
 
 import android.content.Context
-import androidx.core.content.ContextCompat
-import mozilla.components.browser.menu.BrowserMenuHighlight
 import mozilla.components.browser.menu.WebExtensionBrowserMenuBuilder
 import mozilla.components.browser.menu.item.BrowserMenuDivider
-import mozilla.components.browser.menu.item.BrowserMenuHighlightableItem
 import mozilla.components.browser.menu.item.BrowserMenuImageSwitch
 import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
@@ -127,26 +124,18 @@ class DefaultBrowserMenu(
             onItemTapped.invoke(ToolbarMenu.Item.AddToHomeScreen)
         }
 
-        val openInApp = BrowserMenuHighlightableItem(
+        val openInApp = BrowserMenuImageText(
             label = context.getString(R.string.menu_open_with_a_browser2),
-            startImageResource = R.drawable.ic_help,
-            textColorResource = context.theme.resolveAttribute(R.attr.primaryText),
-            highlight = BrowserMenuHighlight.HighPriority(
-                backgroundTint = ContextCompat.getColor(context, R.color.mvp_browser_menu_bg),
-                canPropagate = false
-            )
+            imageResource = R.drawable.ic_open_in,
+            textColorResource = context.theme.resolveAttribute(R.attr.primaryText)
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.OpenInApp)
         }
 
-        val settings = BrowserMenuHighlightableItem(
+        val settings = BrowserMenuImageText(
             label = context.getString(R.string.menu_settings),
-            startImageResource = R.drawable.ic_settings2,
-            textColorResource = context.theme.resolveAttribute(R.attr.primaryText),
-            highlight = BrowserMenuHighlight.HighPriority(
-                backgroundTint = ContextCompat.getColor(context, R.color.mvp_browser_menu_bg),
-                canPropagate = false
-            )
+            imageResource = R.drawable.ic_settings2,
+            textColorResource = context.theme.resolveAttribute(R.attr.primaryText)
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.Settings)
         }

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -3,9 +3,6 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <color name="colorPoweredBy" tools:ignore="MissingDefaultResource">#271948</color>
-    <!-- Browser Menu items color palette -->
-    <color name="mvp_browser_menu_bg" tools:ignore="MissingDefaultResource">@color/photonInk80</color>
 
     <color name="colorPrimary">#ff272727</color>
     <color name="colorPrimaryDark">#6c3b6e</color>
@@ -97,13 +94,14 @@
     <color name="contextMenuSeparatorBackground">#1AF9F9FA</color>
 
     <!-- Browser Menu items color palette -->
-    <color name="browser_menu_bg">#2E255D</color>
+    <color name="browser_menu_bg">#342F6D</color>
     <color name="browser_menu_blocking_switch_bg">#1Af9f9fa</color>
     <color name="browser_menu_trackers_blocked_label">@android:color/white</color>
     <color name="browser_menu_request_desktop_separator">#1Af9f9fa</color>
     <color name="browser_menu_trackers_blocked_subtitle">@color/photonGrey10</color>
 
     <color name="images_removal_warning_background_color">#353852</color>
+    <color name="colorPoweredBy">#1D1133</color>
 
     <!-- Add to Home screen dialog color palette -->
     <color name="home_screen_dialog_bg">@color/photonInk80</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -101,6 +101,7 @@
     <color name="browser_menu_trackers_blocked_subtitle">@color/photonGrey10</color>
 
     <color name="images_removal_warning_background_color">#353852</color>
+    <color name="colorPoweredBy">@color/photonLightGrey05</color>
 
     <!-- Add to Home screen dialog color palette -->
     <color name="home_screen_dialog_bg">@color/photonInk80</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -103,7 +103,7 @@
     </style>
 
     <style name="Mozac.Browser.Menu" parent="">
-        <item name="cardBackgroundColor">@color/mvp_browser_menu_bg</item>
+        <item name="cardBackgroundColor">@color/browser_menu_bg</item>
     </style>
 
     <!-- Add new style to be able to use the same color for both themes until light theme it will be implemented -->


### PR DESCRIPTION
@sv-ohorvath this should have been the cause of the crash with the missing colour.

~Let's see how CI feels about it.~ I ran the tests and found that it needs to be updated for [the new menu designs](https://www.figma.com/file/2V6wgf9fRFdYfLaf5c3oPj/Product-UI?node-id=2133%3A282824), but that said, there seems to be a bug where the Custom Tab from the test seems to cause the UI to go odd.