### PR TITLE
Close #5084: Correct Custom Tab menu items

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -228,6 +228,7 @@ dependencies {
     implementation "org.mozilla.components:ui-autocomplete:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:ui-colors:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:ui-icons:${AndroidComponents.VERSION}"
+    implementation "org.mozilla.components:feature-webcompat:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:feature-webcompat-reporter:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:support-webextensions:${AndroidComponents.VERSION}"
 

--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -32,6 +32,7 @@ import mozilla.components.feature.session.SettingsUseCases
 import mozilla.components.feature.session.TrackingProtectionUseCases
 import mozilla.components.feature.tabs.CustomTabsUseCases
 import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.feature.webcompat.WebCompatFeature
 import mozilla.components.feature.webcompat.reporter.WebCompatReporterFeature
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.service.CrashReporterService
@@ -90,6 +91,7 @@ class Components(
     val engine: Engine by lazy {
         engineOverride ?: EngineProvider.createEngine(context, engineDefaultSettings).apply {
             Settings.getInstance(context).setupSafeBrowsing(this)
+            WebCompatFeature.install(this)
             WebCompatReporterFeature.install(this, "focus")
         }
     }

--- a/app/src/main/java/org/mozilla/focus/browser/integration/BrowserMenuController.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/integration/BrowserMenuController.kt
@@ -18,7 +18,8 @@ class BrowserMenuController(
     private val requestDesktopCallback: (isChecked: Boolean) -> Unit,
     private val addToHomeScreenCallback: () -> Unit,
     private val showFindInPageCallback: () -> Unit,
-    private val openInCallback: () -> Unit
+    private val openInCallback: () -> Unit,
+    private val openInBrowser: () -> Unit
 ) {
 
     fun handleMenuInteraction(item: ToolbarMenu.Item) {
@@ -31,6 +32,7 @@ class BrowserMenuController(
             is ToolbarMenu.Item.FindInPage -> showFindInPageCallback()
             is ToolbarMenu.Item.RequestDesktop -> requestDesktopCallback(item.isChecked)
             is ToolbarMenu.Item.AddToHomeScreen -> addToHomeScreenCallback()
+            is ToolbarMenu.Item.OpenInBrowser -> openInBrowser()
             is ToolbarMenu.Item.OpenInApp -> openInCallback()
             is ToolbarMenu.Item.Settings -> appStore.dispatch(AppAction.OpenSettings(page = Screen.Settings.Page.Start))
         }

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -265,7 +265,8 @@ class BrowserFragment :
             ::setShouldRequestDesktop,
             ::showAddToHomescreenDialog,
             ::showFindInPageBar,
-            ::openSelectBrowser
+            ::openSelectBrowser,
+            ::openInBrowser
         )
 
         if (FeatureFlags.isMvp) {
@@ -561,6 +562,23 @@ class BrowserFragment :
         TelemetryWrapper.shareEvent()
     }
 
+    private fun openInBrowser() {
+        // Release the session from this view so that it can immediately be rendered by a different view
+        sessionFeature.get()?.release()
+
+        requireComponents.customTabsUseCases.migrate(tab.id)
+
+        val intent = Intent(context, MainActivity::class.java)
+        intent.action = Intent.ACTION_MAIN
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        startActivity(intent)
+
+        TelemetryWrapper.openFullBrowser()
+
+        val activity = activity
+        activity?.finish()
+    }
+
     internal fun edit() {
         requireComponents.appStore.dispatch(
             AppAction.EditAction(tab.id)
@@ -583,20 +601,7 @@ class BrowserFragment :
             }
 
             R.id.open_in_firefox_focus -> {
-                // Release the session from this view so that it can immediately be rendered by a different view
-                sessionFeature.get()?.release()
-
-                requireComponents.customTabsUseCases.migrate(tab.id)
-
-                val intent = Intent(context, MainActivity::class.java)
-                intent.action = Intent.ACTION_MAIN
-                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                startActivity(intent)
-
-                TelemetryWrapper.openFullBrowser()
-
-                val activity = activity
-                activity?.finish()
+                openInBrowser()
             }
 
             R.id.share -> {

--- a/app/src/main/java/org/mozilla/focus/menu/ToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/focus/menu/ToolbarMenu.kt
@@ -16,6 +16,7 @@ interface ToolbarMenu {
         object Share : Item()
         object FindInPage : Item()
         object AddToHomeScreen : Item()
+        object OpenInBrowser : Item()
         object OpenInApp : Item()
         object Settings : Item()
         object Stop : Item()

--- a/app/src/test/java/org/mozilla/focus/menu/BrowserMenuControllerTest.kt
+++ b/app/src/test/java/org/mozilla/focus/menu/BrowserMenuControllerTest.kt
@@ -45,6 +45,10 @@ class BrowserMenuControllerTest {
     @Mock
     private lateinit var openInCallback: () -> Unit
 
+    // NB: we should avoid mocking lambdas..
+    @Mock
+    private lateinit var openInBrowser: () -> Unit
+
     @Before
     fun setup() {
         val store = BrowserStore(
@@ -64,7 +68,8 @@ class BrowserMenuControllerTest {
             requestDesktopCallback,
             addToHomeScreenCallback,
             showFindInPageCallback,
-            openInCallback
+            openInCallback,
+            openInBrowser
         )
     }
 
@@ -110,6 +115,13 @@ class BrowserMenuControllerTest {
         val menuItem = ToolbarMenu.Item.RequestDesktop(isChecked = true)
         browserMenuController.handleMenuInteraction(menuItem)
         Mockito.verify(requestDesktopCallback, times(1)).invoke(true)
+    }
+
+    @Test
+    fun `GIVEN OpenInBrowser menu item WHEN the item is pressed THEN openInBrowser is called`() {
+        val menuItem = ToolbarMenu.Item.OpenInBrowser
+        browserMenuController.handleMenuInteraction(menuItem)
+        Mockito.verify(openInBrowser, times(1)).invoke()
     }
 
     @Test


### PR DESCRIPTION
The 'Report site issue' has a bug in AC which I filed [here](https://github.com/mozilla-mobile/android-components/issues/10791) and I'll look at it next.

This adds the menu items back based on Bram's confirmed designs.

cc: @sv-ohorvath 