### PR TITLE
Close #5120: Warm GeckoEngine first during app creation

### DIFF
--- a/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -45,6 +45,8 @@ open class FocusApplication : LocaleAwareApplication(), CoroutineScope {
         if (isMainProcess()) {
             PreferenceManager.setDefaultValues(this, R.xml.settings, false)
 
+            components.engine.warmUp()
+
             TelemetryWrapper.init(this)
             components.metrics.initialize(this)
 
@@ -54,8 +56,6 @@ open class FocusApplication : LocaleAwareApplication(), CoroutineScope {
 
             visibilityLifeCycleCallback = VisibilityLifeCycleCallback(this@FocusApplication)
             registerActivityLifecycleCallbacks(visibilityLifeCycleCallback)
-
-            components.engine.warmUp()
 
             storeLink.start()
 


### PR DESCRIPTION
When GleanMetricsService collects startup metrics on the IO dispatcher, we inadvertently initialize BrowserStore and thereby initialize GeckoEngine on the same dispatcher as well.

I've tried to reproduce this by enabling telemetry in a debug build and building a release variant to no avail, but I'm reasonably sure this is an appropriate fix given the ordering of features in Fenix's application class.

Also see: https://github.com/mozilla-mobile/focus-android/issues/5120#issuecomment-897832228