### PR TITLE
Closes #5134: remove unnecessary coroutines proguard rules.

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -108,11 +108,6 @@
 # Kotlinx
 ####################################################################################################
 
--keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
--keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
--keepclassmembernames class kotlinx.** {
-    volatile <fields>;
-}
 -dontwarn kotlinx.atomicfu.**
 
 ####################################################################################################


### PR DESCRIPTION
According to the coroutines docs, these rules are bundled with the
library so we no longer need to add them to our project. These rules
were added in 89cdb96cf305af041ca2ab3131376fdc4e4019df and this commit
is effectively a revert of that commit.