### PR TITLE
Issue #4901: Add activation ping metrics for data review

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -113,6 +113,26 @@ browser:
       - android-probes@mozilla.com
     expires: "2022-11-01"
 
+activation:
+  activation_id:
+    type: uuid
+    lifetime: user
+    description: |
+      An alternate identifier, not correlated with the client_id, generated once
+      and only sent with the activation ping.
+    send_in_pings:
+      - activation
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/4545
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/issues/4901
+    data_sensitivity:
+      - highly_sensitive
+    notification_emails:
+      - android-probes@mozilla.com
+      - jalmeida@mozilla.com
+    expires: never
+
 legacy_ids:
   client_id:
     type: uuid

--- a/app/src/main/java/org/mozilla/focus/telemetry/ActivationPing.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/ActivationPing.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.launch
 import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.focus.GleanMetrics.Activation
 import org.mozilla.focus.GleanMetrics.Pings
+import java.util.UUID
 
 /**
  * Ensures that only one activation ping is ever sent.
@@ -59,11 +60,9 @@ class ActivationPing(private val context: Context) {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun triggerPing() {
         // Generate the activation_id.
-        Activation.activationId.generateAndSet()
+        Activation.activationId.set(UUID.fromString(TelemetryWrapper.clientId))
 
         CoroutineScope(Dispatchers.IO).launch {
-            // Disabled until data-review r+
-            // See: https://github.com/mozilla-mobile/focus-android/pull/5065
             Pings.activation.submit()
             markAsTriggered()
         }

--- a/app/src/main/java/org/mozilla/focus/telemetry/ActivationPing.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/ActivationPing.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.support.base.log.logger.Logger
+import org.mozilla.focus.GleanMetrics.Activation
+import org.mozilla.focus.GleanMetrics.Pings
 
 /**
  * Ensures that only one activation ping is ever sent.
@@ -57,13 +59,13 @@ class ActivationPing(private val context: Context) {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun triggerPing() {
         // Generate the activation_id.
-        // Activation.activationId.generateAndSet()
+        Activation.activationId.generateAndSet()
 
         CoroutineScope(Dispatchers.IO).launch {
             // Disabled until data-review r+
             // See: https://github.com/mozilla-mobile/focus-android/pull/5065
-            // Pings.activation.submit()
-            // markAsTriggered()
+            Pings.activation.submit()
+            markAsTriggered()
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/telemetry/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/GleanMetricsService.kt
@@ -85,8 +85,7 @@ class GleanMetricsService(context: Context) : MetricsService {
                     Browser.defaultSearchEngine.set(getDefaultSearchEngineIdentifierForTelemetry(context))
                 }
 
-                // Disabled until data-review r+
-                // activationPing.checkAndSend()
+                activationPing.checkAndSend()
             }
         }
     }


### PR DESCRIPTION
The [original data-review](https://github.com/mozilla-mobile/focus-android/pull/5065#issuecomment-893957972) for activation ID was postponed from a larger data review, so I've made a new one here.