### PR TITLE
Adds support for window requests and app links

### DIFF
--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -12,6 +12,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.fetch.Client
+import mozilla.components.feature.app.links.AppLinksInterceptor
 import mozilla.components.feature.app.links.AppLinksUseCases
 import mozilla.components.feature.contextmenu.ContextMenuUseCases
 import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
@@ -37,7 +38,7 @@ import org.mozilla.focus.activity.MainActivity
 import org.mozilla.focus.components.EngineProvider
 import org.mozilla.focus.downloads.DownloadService
 import org.mozilla.focus.engine.ClientWrapper
-import org.mozilla.focus.engine.LocalizedContentInterceptor
+import org.mozilla.focus.engine.AppContentInterceptor
 import org.mozilla.focus.engine.SanityCheckMiddleware
 import org.mozilla.focus.exceptions.ExceptionMigrationMiddleware
 import org.mozilla.focus.locale.LocaleManager
@@ -70,7 +71,7 @@ class Components(
         val settings = Settings.getInstance(context)
 
         DefaultSettings(
-                requestInterceptor = LocalizedContentInterceptor(context),
+                requestInterceptor = AppContentInterceptor(context),
                 trackingProtectionPolicy = settings.createTrackingProtectionPolicy(),
                 javascriptEnabled = !settings.shouldBlockJavaScript(),
                 remoteDebuggingEnabled = settings.shouldEnableRemoteDebugging(),
@@ -92,11 +93,11 @@ class Components(
 
     val settingsUseCases by lazy { SettingsUseCases(engine, store) }
 
+    @Suppress("DEPRECATION")
     private val locationService: LocationService by lazy {
         if (BuildConfig.MLS_TOKEN.isNullOrEmpty()) {
             LocationService.default()
         } else {
-            @Suppress("DEPRECATION")
             MozillaLocationService(context, client.unwrap(), BuildConfig.MLS_TOKEN)
         }
     }
@@ -125,10 +126,8 @@ class Components(
      */
     val customTabsStore by lazy { CustomTabsServiceStore() }
 
-    @Suppress("DEPRECATION")
     val sessionUseCases: SessionUseCases by lazy { SessionUseCases(store) }
 
-    @Suppress("DEPRECATION")
     val tabsUseCases: TabsUseCases by lazy { TabsUseCases(store) }
 
     val searchUseCases: SearchUseCases by lazy {
@@ -141,12 +140,15 @@ class Components(
 
     val appLinksUseCases: AppLinksUseCases by lazy { AppLinksUseCases(context.applicationContext) }
 
-    @Suppress("DEPRECATION")
     val customTabsUseCases: CustomTabsUseCases by lazy { CustomTabsUseCases(store, sessionUseCases.loadUrl) }
 
     val crashReporter: CrashReporter by lazy { createCrashReporter(context) }
 
     val metrics: GleanMetricsService by lazy { GleanMetricsService(context) }
+
+    val appLinksInterceptor by lazy {
+        AppLinksInterceptor(context, interceptLinkClicks = true, launchInApp = { true })
+    }
 }
 
 private fun determineInitialScreen(context: Context): Screen {

--- a/app/src/main/java/org/mozilla/focus/engine/AppContentInterceptor.kt
+++ b/app/src/main/java/org/mozilla/focus/engine/AppContentInterceptor.kt
@@ -10,8 +10,9 @@ import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.request.RequestInterceptor
 import org.mozilla.focus.browser.LocalizedContent
+import org.mozilla.focus.ext.components
 
-class LocalizedContentInterceptor(
+class AppContentInterceptor(
     private val context: Context
 ) : RequestInterceptor {
     override fun onLoadRequest(
@@ -41,7 +42,16 @@ class LocalizedContentInterceptor(
                 LocalizedContent.loadLicenses(context), encoding = "base64"
             )
 
-            else -> null
+            else -> context.components.appLinksInterceptor.onLoadRequest(
+                engineSession,
+                uri,
+                lastUri,
+                hasUserGesture,
+                isSameDomain,
+                isRedirect,
+                isDirectNavigation,
+                isSubframeRequest
+            )
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -37,6 +37,7 @@ import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.engine.EngineView
+import mozilla.components.feature.app.links.AppLinksFeature
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
 import mozilla.components.feature.contextmenu.ContextMenuFeature
 import mozilla.components.feature.downloads.AbstractFetchDownloadService
@@ -61,6 +62,7 @@ import org.mozilla.focus.browser.integration.BrowserToolbarIntegration
 import org.mozilla.focus.browser.integration.FindInPageIntegration
 import org.mozilla.focus.browser.integration.FullScreenIntegration
 import org.mozilla.focus.downloads.DownloadService
+import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.ifCustomTab
 import org.mozilla.focus.ext.isCustomTab
 import org.mozilla.focus.ext.requireComponents
@@ -100,6 +102,7 @@ class BrowserFragment :
     private val downloadsFeature = ViewBoundFeatureWrapper<DownloadsFeature>()
     private val shareDownloadFeature = ViewBoundFeatureWrapper<ShareDownloadFeature>()
     private val windowFeature = ViewBoundFeatureWrapper<WindowFeature>()
+    private val appLinksFeature = ViewBoundFeatureWrapper<AppLinksFeature>()
 
     private val toolbarIntegration = ViewBoundFeatureWrapper<BrowserToolbarIntegration>()
 
@@ -239,6 +242,19 @@ class BrowserFragment :
             store = components.store,
             tabId = tab.id
         ), this, view)
+
+        appLinksFeature.set(
+            feature = AppLinksFeature(
+                requireContext(),
+                store = components.store,
+                sessionId = tabId,
+                fragmentManager = parentFragmentManager,
+                launchInApp = { true },
+                loadUrlUseCase = requireContext().components.sessionUseCases.loadUrl
+            ),
+            owner = this,
+            view = view
+        )
 
         blockingThemeBinding.set(
             BlockingThemeBinding(

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -46,6 +46,7 @@ import mozilla.components.feature.downloads.share.ShareDownloadFeature
 import mozilla.components.feature.findinpage.view.FindInPageBar
 import mozilla.components.feature.prompts.PromptFeature
 import mozilla.components.feature.session.SessionFeature
+import mozilla.components.feature.tabs.WindowFeature
 import mozilla.components.lib.crash.Crash
 import mozilla.components.support.base.feature.PermissionsFeature
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
@@ -98,6 +99,7 @@ class BrowserFragment :
     private val contextMenuFeature = ViewBoundFeatureWrapper<ContextMenuFeature>()
     private val downloadsFeature = ViewBoundFeatureWrapper<DownloadsFeature>()
     private val shareDownloadFeature = ViewBoundFeatureWrapper<ShareDownloadFeature>()
+    private val windowFeature = ViewBoundFeatureWrapper<WindowFeature>()
 
     private val toolbarIntegration = ViewBoundFeatureWrapper<BrowserToolbarIntegration>()
 
@@ -253,8 +255,22 @@ class BrowserFragment :
         val customTabConfig = tab.ifCustomTab()?.config
         if (customTabConfig != null) {
             initialiseCustomTabUi(view, customTabConfig)
+
+            // TODO Add custom tabs window feature support
+            // We to add support for Custom Tabs here, however in order to send the window request
+            // back to us through the intent system, we need to register a unique schema that we
+            // can handle. For example, Fenix Nighlyt does this today with `fenix-nightly://`.
         } else {
             initialiseNormalBrowserUi(view)
+
+            windowFeature.set(
+                feature = WindowFeature(
+                    store = components.store,
+                    tabsUseCases = components.tabsUseCases
+                ),
+                owner = this,
+                view = view
+            )
         }
     }
 


### PR DESCRIPTION
We needed to add support for `window=_blank` requests for opening new tabs and app links for sites that redirect to other apps.

I refrained from adding `CustomTabWindowFeature` because it seems like we need to add better support for redirecting intents back to us, similar to Fenix, or some other form of `customTabsUseCases.addTab(url, parentTabId)` - I think we should do that in the following release instead of this one.