### PR TITLE
Temporarily remove whats new menu item

### DIFF
--- a/app/src/main/java/org/mozilla/focus/menu/home/HomeMenuAdapter.kt
+++ b/app/src/main/java/org/mozilla/focus/menu/home/HomeMenuAdapter.kt
@@ -24,7 +24,8 @@ class HomeMenuAdapter(
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private val items: List<MenuItem> = listOf(
-            MenuItem(R.id.whats_new, WhatsNewViewHolder.LAYOUT_ID, context.getString(R.string.menu_whats_new)),
+            // Disabled for now until we know what the new SUMO link will be.
+            // MenuItem(R.id.whats_new, WhatsNewViewHolder.LAYOUT_ID, context.getString(R.string.menu_whats_new)),
             MenuItem(R.id.help, MenuItemViewHolder.LAYOUT_ID, context.getString(R.string.menu_help)),
             MenuItem(R.id.settings, MenuItemViewHolder.LAYOUT_ID, context.getString(R.string.menu_settings))
     )


### PR DESCRIPTION
We don't have an accurate SUMO "what's new" link so we're hiding this menu item until we get one, similar to iOS.