### PR TITLE
For 5056: Add Telemetry for Shortcuts.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -144,3 +144,66 @@ settings_screen:
     notification_emails:
       - android-probes@mozilla.com
     expires: "2022-08-17"
+
+shortcuts:
+  shortcuts_on_home_number:
+    type: quantity
+    description: |
+      The number of shortcuts the user has on home screen,
+      0, 1, 2, 3 or 4 (maximum)
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5056
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5189
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-08-20"
+    unit: shortcut(s)
+  shortcut_opened_counter:
+    type: counter
+    description: |
+      A counter that indicates how many times a user has opened
+      a website from a shortcut in the home screen.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5056
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5189
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-08-20"
+  shortcut_added_counter:
+    type: counter
+    description: |
+      A counter that indicates how many times a user has added
+      a website to shortcuts.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5056
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5189
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-08-20"
+  shortcut_removed_counter:
+    type: labeled_counter
+    description: |
+      A counter that indicates how many times a user has removed
+      a website from shortcuts.
+      It also indicates the screen it was removed from, home or browser.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5056
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5189
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-08-20"
+    labels:
+      - removed_from_browser_menu
+      - removed_from_home_screen

--- a/app/src/main/java/org/mozilla/focus/browser/integration/BrowserMenuController.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/integration/BrowserMenuController.kt
@@ -13,6 +13,7 @@ import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.top.sites.TopSitesUseCases
+import org.mozilla.focus.GleanMetrics.Shortcuts
 import org.mozilla.focus.ext.titleOrDomain
 import org.mozilla.focus.menu.ToolbarMenu
 import org.mozilla.focus.state.AppAction
@@ -50,6 +51,8 @@ class BrowserMenuController(
             is ToolbarMenu.Item.Share -> shareCallback()
             is ToolbarMenu.Item.FindInPage -> showFindInPageCallback()
             is ToolbarMenu.Item.AddToShortcuts -> {
+                Shortcuts.shortcutAddedCounter.add()
+
                 ioScope.launch {
                     currentTab?.let { state ->
                         topSitesUseCases.addPinnedSites(
@@ -60,6 +63,8 @@ class BrowserMenuController(
                 }
             }
             is ToolbarMenu.Item.RemoveFromShortcuts -> {
+                Shortcuts.shortcutRemovedCounter["removed_from_browser_menu"].add()
+
                 ioScope.launch {
                     currentTab?.let { state ->
                         appStore.state.topSites.find { it.url == state.content.url }

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -45,6 +45,7 @@ import mozilla.components.lib.state.ext.observeAsComposableState
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import mozilla.components.support.utils.ThreadUtils
+import org.mozilla.focus.GleanMetrics.Shortcuts
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.isSearch
 import org.mozilla.focus.ext.requireComponents
@@ -304,6 +305,8 @@ class UrlInputFragment :
                     TopSiteMenuItem(
                         title = stringResource(R.string.remove_top_site),
                         onClick = { topSite ->
+                            Shortcuts.shortcutRemovedCounter["removed_from_home_screen"].add()
+
                             viewLifecycleOwner.lifecycleScope.launch(IO) {
                                 requireComponents.topSitesUseCases.removeTopSites(topSite)
                             }
@@ -311,6 +314,8 @@ class UrlInputFragment :
                     )
                 ),
                 onTopSiteClick = { topSite ->
+                    Shortcuts.shortcutOpenedCounter.add()
+
                     requireComponents.tabsUseCases.addTab(
                         url = topSite.url,
                         source = SessionState.Source.Internal.HomeScreen,

--- a/app/src/main/java/org/mozilla/focus/telemetry/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/GleanMetricsService.kt
@@ -24,6 +24,7 @@ import org.mozilla.focus.GleanMetrics.Browser
 import org.mozilla.focus.GleanMetrics.GleanBuildInfo
 import org.mozilla.focus.GleanMetrics.LegacyIds
 import org.mozilla.focus.GleanMetrics.Pings
+import org.mozilla.focus.GleanMetrics.Shortcuts
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.telemetry.TelemetryWrapper.isTelemetryEnabled
 import org.mozilla.focus.utils.Settings
@@ -90,6 +91,8 @@ class GleanMetricsService(context: Context) : MetricsService {
     ) = CoroutineScope(IO).async {
         Browser.isDefault.set(settings.isDefaultBrowser())
         Browser.localeOverride.set(components.store.state.locale?.displayName ?: "none")
+        val shortcutsOnHomeNumber = components.appStore.state.topSites.size.toLong()
+        Shortcuts.shortcutsOnHomeNumber.set(shortcutsOnHomeNumber)
     }
 
     private fun getDefaultSearchEngineIdentifierForTelemetry(context: Context): String {


### PR DESCRIPTION
Collect telemetry data for the following

    

- [x] Do users add shortcuts to their home page? What’s the percentage of users that are adding shortcuts?
** -> **shorcuts_on_home_number**
   

- [x]  How often are users clicking on the shortcuts?
** -> **shorcut_opened_counter**
  

- [x]   Are users adding one, two, three or four shortcuts to their home page? What’s the average?
** -> **shorcuts_on_home_number**
   

- [x]  How often are users deleting a shortcut?
** -> **shorcut_removed_counter**
   

- [x]  How often are users adding a shortcut?
** -> **shorcut_added_counter**