### PR TITLE
No issue: Update Flank to v21.08.1

### DIFF
--- a/tools/taskcluster/execute-firebase-tests.sh
+++ b/tools/taskcluster/execute-firebase-tests.sh
@@ -16,7 +16,7 @@
 # and try to download the artifacts. We will exit with the actual error code later.
 set +e
 
-URL_FLANK_BIN="https://github.com/Flank/flank/releases/download/v21.05.0/flank.jar"
+URL_FLANK_BIN="https://github.com/Flank/flank/releases/download/v21.08.1/flank.jar"
 JAVA_BIN="/usr/bin/java"
 WORKDIR="/opt/focus-android"
 PATH_TOOLS="$WORKDIR/tools/taskcluster"


### PR DESCRIPTION
Flank https://github.com/Flank/flank/releases/tag/v21.08.1 has the fix for avoiding crash one of their API calls that we hit a couple times.