### PR TITLE
Fix context menu additional note string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -787,5 +787,5 @@ The new line here must be kept as the second half of the string is clickable for
 
     <!-- Text for context menu additional note.
     %1$s is a placeholder for the app name. -->
-    <string name="contextmenu_erased_images_note">Saved and shared images &lt;b>will not be&lt;/b> deleted when you erase %1s history</string>
+    <string name="contextmenu_erased_images_note">Saved and shared images &lt;b>will not be&lt;/b> deleted when you erase %1$s history</string>
 </resources>


### PR DESCRIPTION
For #5098 

Add '$' to additional note string placeholder 