### PR TITLE
Attach SearchSuggestionsViewModel to UrlInputFragment instead of Activity

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -162,7 +162,7 @@ class UrlInputFragment :
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        searchSuggestionsViewModel = ViewModelProvider(requireActivity()).get(SearchSuggestionsViewModel::class.java)
+        searchSuggestionsViewModel = ViewModelProvider(this).get(SearchSuggestionsViewModel::class.java)
 
         childFragmentManager.beginTransaction()
             .replace(searchViewContainer.id, SearchSuggestionsFragment.create())

--- a/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsFragment.kt
@@ -58,7 +58,7 @@ class SearchSuggestionsFragment : Fragment(), CoroutineScope {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        searchSuggestionsViewModel = ViewModelProvider(requireActivity())
+        searchSuggestionsViewModel = ViewModelProvider(requireParentFragment())
             .get(SearchSuggestionsViewModel::class.java)
 
         searchSuggestionsViewModel.state.observe(


### PR DESCRIPTION
Attaching the view model to the activity, to fix the communication between `UrlInputFragment` and
`SearchSuggestionsFragment`, was a mistake. Too much state survives and causes bugs. We tried to
fix some of them, but the better fix is to just bind the view model to `UrlInputFragment` again.
And to fix the communication problem we let `SearchSuggestionsFragment` get it from its parent
fragment (`UrlInputFragment`).