### PR TITLE
For #5305: Allow menu to stretch up to 314dp width.

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -71,4 +71,8 @@
 
     <dimen name="search_suggestions_padding_start">56dp</dimen>
     <dimen name="search_suggestions_padding_with_icon">16dp</dimen>
+
+    <!-- Override the default menu width values from AC. -->
+    <dimen name="mozac_browser_menu_width_min" tools:ignore="UnusedResources">112dp</dimen>
+    <dimen name="mozac_browser_menu_width_max" tools:ignore="UnusedResources">314dp</dimen>
 </resources>


### PR DESCRIPTION
Before and after the fix, for the language presented in #5305 
<img src = https://user-images.githubusercontent.com/48995920/131819252-f26191bf-1811-45ad-bce3-a3634fa0c855.png width = 45%><img src = https://user-images.githubusercontent.com/48995920/131819243-2d57c001-63bc-4a6c-943e-767c58e035fc.png width = 45%>

