### PR TITLE
Wrong text color for Powered by...

### DIFF
--- a/app/src/main/java/org/mozilla/focus/menu/browser/CustomTabMenu.kt
+++ b/app/src/main/java/org/mozilla/focus/menu/browser/CustomTabMenu.kt
@@ -135,6 +135,7 @@ class CustomTabMenu(
         val poweredBy = BrowserMenuCategory(
             label = context.getString(R.string.menu_custom_tab_branding, context.getString(R.string.app_name)),
             textSize = CAPTION_TEXT_SIZE,
+            textColorResource = context.theme.resolveAttribute(R.attr.primaryText),
             textStyle = Typeface.NORMAL
         )
 


### PR DESCRIPTION
For #5325 

[Fixed] "Powered by..." item from custom tab browser menu should have the same color as the rest of menu items