### PR TITLE
For #5390: Use translated string for about fragment title.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/AboutFragment.kt
@@ -55,7 +55,7 @@ class AboutFragment : BaseSettingsLikeFragment() {
 
     override fun onResume() {
         super.onResume()
-        updateTitle("About")
+        updateTitle(R.string.menu_about)
     }
 
     override fun onCreateView(


### PR DESCRIPTION
Due to string freeze, we are using the menu_about string for the moment.