### PR TITLE
Search engine not found

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/TextActionActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/TextActionActivity.kt
@@ -10,8 +10,10 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import androidx.annotation.RequiresApi
+import mozilla.components.feature.search.ext.buildSearchUrl
+import mozilla.components.feature.search.ext.waitForSelectedOrDefaultSearchEngine
 import mozilla.components.support.utils.SafeIntent
-import org.mozilla.focus.utils.SearchUtils
+import org.mozilla.focus.ext.components
 
 /**
  * Activity for receiving and processing an ACTION_PROCESS_TEXT intent.
@@ -26,17 +28,18 @@ class TextActionActivity : Activity() {
         val searchTextCharSequence = intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)
         val searchText = searchTextCharSequence?.toString() ?: ""
 
-        val searchUrl = SearchUtils.createSearchUrl(this, searchText)
+        components.store.waitForSelectedOrDefaultSearchEngine { searchEngine ->
 
-        val searchIntent = Intent(this, IntentReceiverActivity::class.java)
-        searchIntent.action = Intent.ACTION_VIEW
-        searchIntent.putExtra(EXTRA_TEXT_SELECTION, true)
-        searchIntent.data = Uri.parse(searchUrl)
-        searchIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            val searchUrl = searchEngine?.buildSearchUrl(searchText) ?: searchText
+            val searchIntent = Intent(this, IntentReceiverActivity::class.java)
+            searchIntent.action = Intent.ACTION_VIEW
+            searchIntent.putExtra(EXTRA_TEXT_SELECTION, true)
+            searchIntent.data = Uri.parse(searchUrl)
+            searchIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            startActivity(searchIntent)
 
-        startActivity(searchIntent)
-
-        finish()
+            finish()
+        }
     }
 
     companion object {


### PR DESCRIPTION
For #5307
App fails to search when launched from external search context menu because the current search engine is not found
To fix that waitForSelectedOrDefaultSearchEngine method was used to wait until the search engine is initialized