### PR TITLE
Remove ResizableLayout from the main page

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -18,7 +18,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.preference.PreferenceManager
-import kotlinx.android.synthetic.main.fragment_urlinput2.*
+import kotlinx.android.synthetic.main.fragment_urlinput.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -196,7 +196,7 @@ class UrlInputFragment :
             customDomainsProvider.initialize(it.applicationContext)
         }
 
-        StatusBarUtils.getStatusBarHeight(keyboardLinearLayout) {
+        StatusBarUtils.getStatusBarHeight(landingLayout) {
             adjustViewToStatusBarHeight(it)
         }
 
@@ -222,10 +222,6 @@ class UrlInputFragment :
 
     private fun adjustViewToStatusBarHeight(statusBarHeight: Int) {
         val inputHeight = resources.getDimension(R.dimen.urlinput_height)
-        if (keyboardLinearLayout.layoutParams is ViewGroup.MarginLayoutParams) {
-            val marginParams = keyboardLinearLayout.layoutParams as ViewGroup.MarginLayoutParams
-            marginParams.topMargin = (inputHeight + statusBarHeight).toInt()
-        }
 
         urlInputLayout.layoutParams.height = (inputHeight + statusBarHeight).toInt()
 
@@ -240,7 +236,7 @@ class UrlInputFragment :
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val view = inflater.inflate(R.layout.fragment_urlinput2, container, false)
+        val view = inflater.inflate(R.layout.fragment_urlinput, container, false)
 
         val topSites = view.findViewById<ComposeView>(R.id.topSites)
         topSites.setContent { HomeScreen() }
@@ -288,7 +284,7 @@ class UrlInputFragment :
         }
 
         if (isOverlay) {
-            keyboardLinearLayout?.visibility = View.GONE
+            landingLayout?.visibility = View.GONE
         } else {
             backgroundView?.setBackgroundResource(R.drawable.dark_background)
 
@@ -358,13 +354,6 @@ class UrlInputFragment :
         activity?.let {
             if (Settings.getInstance(it.applicationContext).shouldShowFirstrun()) return@onStart
         }
-    }
-
-    override fun onStop() {
-        super.onStop()
-
-        // Reset the keyboard layout to avoid a jarring animation when the view is started again. (#1135)
-        keyboardLinearLayout?.reset()
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/org/mozilla/focus/tips/TipsHorizontalCarousel.kt
+++ b/app/src/main/java/org/mozilla/focus/tips/TipsHorizontalCarousel.kt
@@ -17,35 +17,11 @@ class TipsHorizontalCarousel @JvmOverloads constructor(
     val tipsAdapter: TipsAdapter = TipsAdapter()
     private val pagerSnapHelper = PagerSnapHelper()
     private val itemDecoration = DotPagerIndicatorDecoration()
-    private val horizontalLayoutManager = HorizontalLayoutManager(context)
 
     init {
-        layoutManager = horizontalLayoutManager
+        layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
         adapter = tipsAdapter
         pagerSnapHelper.attachToRecyclerView(this)
         addItemDecoration(itemDecoration)
-    }
-
-    fun showAsCarousel(state: Boolean) {
-        if (state) {
-            addItemDecoration(itemDecoration)
-            horizontalLayoutManager.setHorizontalScrollEnabled(state)
-        } else {
-            removeItemDecoration(itemDecoration)
-            horizontalLayoutManager.setHorizontalScrollEnabled(state)
-        }
-    }
-
-    class HorizontalLayoutManager(context: Context?) :
-        LinearLayoutManager(context, HORIZONTAL, false) {
-        private var isScrollEnabled = true
-
-        fun setHorizontalScrollEnabled(flag: Boolean) {
-            isScrollEnabled = flag
-        }
-
-        override fun canScrollHorizontally(): Boolean {
-            return isScrollEnabled && super.canScrollHorizontally()
-        }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/widget/ResizableKeyboardViewDelegate.java
+++ b/app/src/main/java/org/mozilla/focus/widget/ResizableKeyboardViewDelegate.java
@@ -15,8 +15,6 @@ import android.view.View;
 import android.view.ViewTreeObserver;
 import androidx.annotation.NonNull;
 import org.mozilla.focus.R;
-import org.mozilla.focus.tips.TipsHorizontalCarousel;
-
 import java.util.ArrayList;
 
 /**
@@ -40,7 +38,6 @@ import java.util.ArrayList;
     private final ArrayList<Integer> arrayOfViewsToHide = new ArrayList<>();
     private final boolean shouldAnimate;
     private boolean isAnimating;
-    private int lastValueOfDifference = 0;
 
     private final ViewTreeObserver.OnGlobalLayoutListener layoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
         @Override
@@ -66,7 +63,6 @@ import java.util.ArrayList;
                     updateDynamicViewsVisibility(View.VISIBLE);
                 }
             }
-            setHomeTipsVisibility(difference);
         }
     };
 
@@ -162,19 +158,6 @@ import java.util.ArrayList;
                     viewToHide.setVisibility(visibility);
                 }
             }
-        }
-    }
-
-    /**
-     * If the delegate view contains a specific section for tips, then we should show it as a carousel
-     * with all tips when the keyboard is closed, other else we should show only the current tip
-     */
-    private void setHomeTipsVisibility(int difference) {
-        TipsHorizontalCarousel homeTipsCarousel = delegateView.findViewById(R.id.home_tips);
-
-        if (homeTipsCarousel != null && difference != lastValueOfDifference) {
-            lastValueOfDifference = difference;
-            homeTipsCarousel.showAsCarousel(difference <= 0);
         }
     }
 }

--- a/app/src/main/res/layout/fragment_urlinput.xml
+++ b/app/src/main/res/layout/fragment_urlinput.xml
@@ -9,38 +9,43 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <org.mozilla.focus.widget.ResizableKeyboardLinearLayout
-        android:id="@+id/keyboardLinearLayout"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/landingLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="@dimen/urlinput_height"
-        android:gravity="center"
-        android:orientation="vertical"
-        android:weightSum="1"
-        app:animate="true">
+        android:layout_marginTop="@dimen/urlinput_height">
 
         <androidx.compose.ui.platform.ComposeView
             android:id="@+id/topSites"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <ImageView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_weight="0.9"
-            android:paddingEnd="24dp"
-            android:paddingStart="24dp"
             android:contentDescription="@string/app_name"
             android:focusable="false"
-            android:src="@drawable/wordmark2" />
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp"
+            android:scaleType="centerInside"
+            android:src="@drawable/wordmark2"
+            app:layout_constraintBottom_toTopOf="@id/home_tips"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/topSites" />
 
         <org.mozilla.focus.tips.TipsHorizontalCarousel
             android:id="@+id/home_tips"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
-    </org.mozilla.focus.widget.ResizableKeyboardLinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <FrameLayout
         android:id="@+id/urlInputLayout"
@@ -83,8 +88,8 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="horizontal"
-                android:background="@android:color/transparent">
+                android:background="@android:color/transparent"
+                android:orientation="horizontal">
 
                 <mozilla.components.browser.toolbar.BrowserToolbar
                     android:id="@+id/browserToolbar"


### PR DESCRIPTION
For #5366
Sometimes the space between keyboard and toolbar is not enough to display properly all the views, even if are resized by ResizableLayout
After this commit all views from home screen aren't resized anymore when the keyboard is open

This pr fix also https://github.com/mozilla-mobile/focus-android/issues/5367