### PR TITLE
For #5429: Remove initial workaround for opening search from another app

### DIFF
--- a/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
@@ -51,7 +51,7 @@ private fun selectionChanged(state: AppState, action: AppAction.SelectionChanged
  * All tabs have been closed.
  */
 private fun noTabs(state: AppState): AppState {
-    if (state.screen is Screen.Home || state.screen is Screen.FirstRun || state.screen is Screen.Browser) {
+    if (state.screen is Screen.Home || state.screen is Screen.FirstRun) {
         return state
     }
 


### PR DESCRIPTION
This prevented navigation to home screen on using the erase button. 