### PR TITLE
Fix chain of trust error in build signing tasks

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -16,7 +16,7 @@ tasks:
                   then: '${tasks_for}@noreply.mozilla.org'
                   else:
                     $if: 'tasks_for == "github-push"'
-                    then: '${event.pusher.name}@users.noreply.github.com'
+                    then: '${event.pusher.email}'
                     else:
                         $if: 'tasks_for == "github-pull-request"'
                         then: '${event.pull_request.user.login}@users.noreply.github.com'

--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir /builds && \
 
 WORKDIR /builds/worker/
 
-# -- System -----------------------------------------------------------------------------
+# -- System ----------------------------------------------------------------------------
 
 ENV CURL='curl --location --retry 5' \
     GRADLE_OPTS='-Xmx4096m -Dorg.gradle.daemon=false' \


### PR DESCRIPTION
The comment in 'Dockerfile' was modified to force docker-image rebuilds.
Otherwise taskgraph would replace it with an older image task and we
would continue to hit this CoT issue until the tasks were rebuilt.