### PR TITLE
Change google play store channel

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -139,7 +139,7 @@ tasks:
                               && git checkout ${event.release.tag_name}
                               && python tools/taskcluster/release.py \
                                 --tag ${event.release.tag_name} \
-                                --channel alpha \
+                                --channel release \
                                 --commit \
                                 --output /opt/focus-android/app/build/outputs/apk \
                                 --apk focus/release/app-focus-armeabi-v7a-release-unsigned.apk \

--- a/tools/taskcluster/release.py
+++ b/tools/taskcluster/release.py
@@ -163,7 +163,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='Create a release pipeline (build, sign, publish) on taskcluster.')
 
-    parser.add_argument('--channel', dest="channel", action="store", choices=['internal', 'alpha', 'nightly'], help="", required=True)
+    parser.add_argument('--channel', dest="channel", action="store", choices=['release', 'nightly', 'beta'], help="", required=True)
     parser.add_argument('--commit', dest="commit", action="store_true", help="commit the google play transaction")
     parser.add_argument('--tag', dest="tag", action="store", help="git tag to build from")
     parser.add_argument('--apk', dest="apks", metavar="path", action="append", help="Path to APKs to sign and upload", required=True)


### PR DESCRIPTION
This pr updates the use of 'channel' to match the changes to support beta and nightly in the [pushapk scriptworker](https://github.com/mozilla-releng/scriptworker-scripts/pull/403) (the format has been changed so `channel` now refers to the type of app, and the 'alpha' default track is hardcoded into the config for that app).