### PR TITLE
Update keepHidden default value

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/FloatingEraseButton.java
+++ b/app/src/main/java/org/mozilla/focus/widget/FloatingEraseButton.java
@@ -15,7 +15,7 @@ import android.view.animation.AnimationUtils;
 import org.mozilla.focus.R;
 
 public class FloatingEraseButton extends FloatingActionButton {
-    private boolean keepHidden;
+    private boolean keepHidden = true;
 
     public FloatingEraseButton(Context context) {
         super(context);


### PR DESCRIPTION
For #5254
Erase button state is not persisted between tabs and it is restored at every switch. 
keepHidden default value was false which makes the button to pops up even when the number of tabs was bigger than 1
By updating keepHidden default value to true we avoid those scenarios when the visibility of button is set to VISIBLE and imediately after that is set to GONE