### PR TITLE
Add data review for Legacy Ids

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -123,7 +123,7 @@ legacy_ids:
     bugs:
       - https://github.com/mozilla-mobile/focus-android/issues/4545
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-android/issues/4901
+      - https://github.com/mozilla-mobile/focus-android/pull/5512#issuecomment-1023668181
     notification_emails:
       - jalmeida@mozilla.com
       - android-probes@mozilla.com


### PR DESCRIPTION
As requested, I'm separating out the data review for the Legacy ID [here](https://github.com/mozilla-mobile/focus-android/pull/5148#issuecomment-899793092) from the activation ID to avoid confusion.

---

# Request for data collection review form

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

1) **What questions will you answer with this data?**

   - We send our legacy telemetry ID as part of the deletion request for users who wish to have their reported Telemetry data deleted.

2) **Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?**

   - This is the supported way needed by the `deletion-request` for user to opt-out of data collection.

3) **What alternative methods did you consider to answer these questions? Why were they not sufficient?**

   - N/A

4) **Can current instrumentation answer these questions?**

   - Currently, we have telemetry from a deprecated and outdated system which we can give our users the opportunity to opt-out of.

5) **List all proposed measurements and indicate the category of data collection for each measurement, using the Firefox [data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki.**

| Measurement Description  | Data Collection Category | Tracking Bug # |
| ------------------------ | ------------------------ | -------------- |
| legacy_ids.client_id     | category 4               | #4901          |

6) **How long will this data be collected?**

   - Always.

7) **What populations will you measure?**

   -  All release, beta, and nightly users with telemetry enabled.

8) **Please provide a general description of how you will analyze this data.**

   - Glean will connect the legacy ID to collected metrics from prior systems to schedule deletion requests when users opt out of data collection.

9) **Where do you intend to share the results of your analysis?**

   - No one, only Glean internal systems will have references to this ID.


