### PR TITLE
Add Release push apk support

### DIFF
--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -59,7 +59,11 @@ jobs:
             symbol: debug(Bkl)
 
     focus-release:
-        description: 'Release Focus build for debugging'
+        description: 'Release Focus build'
+            # any tasks that have this as a primary dependency will
+            # inherit this attribute via the multi_dep loader
+        attributes:
+            release-type: release
         run-on-tasks-for: [github-pull-request]
         run:
             gradle-build-type: release
@@ -69,7 +73,9 @@ jobs:
             symbol: release(Bf)
 
     klar-release:
-        description: 'Release Klar build for debugging'
+        description: 'Release Klar build'
+        attributes:
+            release-type: release
         run-on-tasks-for: [github-pull-request]
         run:
             gradle-build-type: release
@@ -101,8 +107,3 @@ jobs:
             gradle-build: focus
         treeherder:
             symbol: beta(B)
-
-
-    # TODO modify release, nightly and beta (focus only for the latter two) for signing and push-apk
-    # Add androidTest as a separate task
-    # Note: nightly and beta will not push to google plaly store

--- a/taskcluster/ci/push-apk/kind.yml
+++ b/taskcluster/ci/push-apk/kind.yml
@@ -18,17 +18,19 @@ group-by: build-type
 
 only-for-build-types:
     - nightly
+    - release
 
 job-template:
     description: Publish Focus
     worker-type: push-apk
-    run-on-tasks-for: [cron]
+    run-on-tasks-for: []
     worker:
         certificate-alias: focus
         commit: true
         channel:
             by-build-type:
                 nightly: nightly
+                release: release
         dep:
             by-level:
                 '3': false

--- a/taskcluster/ci/push-apk/kind.yml
+++ b/taskcluster/ci/push-apk/kind.yml
@@ -18,7 +18,8 @@ group-by: build-type
 
 only-for-build-types:
     - nightly
-    - release
+    - focus-release
+    - klar-release
 
 job-template:
     description: Publish Focus
@@ -30,12 +31,17 @@ job-template:
         channel:
             by-build-type:
                 nightly: nightly
-                release: release
+                focus-release: focus-release
+                klar-release: klar-release
         dep:
             by-level:
                 '3': false
                 default: true
         product: focus-android
     treeherder:
-        job-symbol: gp
+        job-symbol:
+            by-build-type:
+                nightly: gp
+                focus-release: gpf
+                klar-release: gpkl
         kind: build

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -24,7 +24,7 @@ job-template:
         by-tasks-for:
             (action|cron|github-release):
                 by-build-type:
-                    (nightly|release):
+                    (nightly|focus-release|klar-release):
                         type: signing
                     default: {}
             default: {}

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -24,7 +24,7 @@ job-template:
         by-tasks-for:
             (action|cron|github-release):
                 by-build-type:
-                    nightly:
+                    (nightly|release):
                         type: signing
                     default: {}
             default: {}

--- a/taskcluster/focus_android_taskgraph/target_tasks.py
+++ b/taskcluster/focus_android_taskgraph/target_tasks.py
@@ -11,8 +11,16 @@ def target_tasks_default(full_task_graph, parameters, graph_config):
     """Target the tasks which have indicated they should be run on this project
     via the `run_on_projects` attributes."""
 
-    filter = filter_for_tasks_for
-    return [l for l, t in full_task_graph.tasks.items() if filter_for_tasks_for(t, parameters)]
+    # Temporary until we have official beta support
+    def releases(task, parameters):
+        return task.attributes.get("release-type", "") == 'release'
+
+    _filter = filter_for_tasks_for
+
+    if parameters["tasks_for"] == "github-release":
+        _filter = releases
+
+    return [l for l, t in full_task_graph.tasks.items() if _filter(t, parameters)]
 
 
 @_target_task('release')


### PR DESCRIPTION
Did a trial run on staging-focus-android repo, with fake pushes to google play store: https://firefox-ci-tc.services.mozilla.com/tasks/groups/NeJ984HaRVSAzByfCy45qw

@rvandermeulen and @pocmo @jonalmeida With this pr, one change you'll notice is that the push-apk tasks are broken into two - one each for klar and focus (pushapk scriptworker has been updated), so its consistent with how we've broken them into two different task for builds and signing.