### PR TITLE
For #5518: Fix condition to record uri telemetry.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryMiddleware.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryMiddleware.kt
@@ -31,7 +31,7 @@ class TelemetryMiddleware : Middleware<BrowserState, BrowserAction> {
             is ContentAction.UpdateLoadingStateAction -> {
                 context.state.findTab(action.sessionId)?.let { tab ->
                     // Record UriOpened event when a page finishes loading
-                    if (tab.content.loading && !action.loading) {
+                    if (!tab.content.loading && !action.loading) {
                         Browser.totalUriCount.add()
                     }
                 }


### PR DESCRIPTION
The metric should be recorded when the pages finishes loading.