### PR TITLE
Implement Nimbus settings screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -238,6 +238,7 @@ dependencies {
     implementation "org.mozilla.components:service-glean:${AndroidComponents.VERSION}", {
         exclude group: 'org.mozilla.telemetry', module: 'glean-native'
     }
+    implementation "org.mozilla.components:service-nimbus:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:service-location:${AndroidComponents.VERSION}"
 
     implementation "org.mozilla.components:support-ktx:${AndroidComponents.VERSION}"

--- a/app/src/main/java/org/mozilla/focus/autocomplete/StatePreference.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/StatePreference.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.autocomplete
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.TextView
+import androidx.preference.Preference
+import androidx.preference.PreferenceViewHolder
+import org.mozilla.focus.R
+import org.mozilla.focus.ext.settings
+
+/**
+ * State preference that will show the current state as a summary and a sub screen to configure the behavior.
+ */
+class StatePreference(context: Context?, attrs: AttributeSet?) : Preference(context, attrs) {
+    var summaryView: TextView? = null
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder?) {
+        super.onBindViewHolder(holder)
+
+        summaryView =
+            holder?.let { parentView -> parentView.findViewById(android.R.id.summary) as TextView }
+        setValueByKey(key)
+    }
+
+    private fun setValueByKey(key: String?) {
+        key?.let {
+            val state = when (key) {
+                context.getString(R.string.pref_key_studies) -> context.settings.isExperimentationEnabled
+
+                context.getString(R.string.pref_key_screen_autocomplete) ->
+                    context.settings.shouldAutocompleteFromShippedDomainList() ||
+                        context.settings.shouldAutocompleteFromCustomDomainList()
+                else -> false
+            }
+            val summaryText = if (state)
+                R.string.preference_state_on
+            else
+                R.string.preference_state_off
+
+            summaryView?.setText(summaryText)
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/navigation/MainActivityNavigation.kt
+++ b/app/src/main/java/org/mozilla/focus/navigation/MainActivityNavigation.kt
@@ -27,6 +27,7 @@ import org.mozilla.focus.settings.RemoveSearchEnginesSettingsFragment
 import org.mozilla.focus.settings.SearchSettingsFragment
 import org.mozilla.focus.settings.SettingsFragment
 import org.mozilla.focus.settings.privacy.PrivacySecuritySettingsFragment
+import org.mozilla.focus.settings.privacy.StudiesFragment
 import org.mozilla.focus.state.Screen
 import org.mozilla.focus.utils.ViewUtils
 import kotlin.collections.forEach as withEach
@@ -184,6 +185,7 @@ class MainActivityNavigation(
             Screen.Settings.Page.Mozilla -> MozillaSettingsFragment()
             Screen.Settings.Page.PrivacyExceptions -> ExceptionsListFragment()
             Screen.Settings.Page.PrivacyExceptionsRemove -> ExceptionsRemoveFragment()
+            Screen.Settings.Page.Studies -> StudiesFragment()
             Screen.Settings.Page.SearchList -> InstalledSearchEnginesSettingsFragment()
             Screen.Settings.Page.SearchRemove -> RemoveSearchEnginesSettingsFragment()
             Screen.Settings.Page.SearchAdd -> ManualAddSearchEngineSettingsFragment()

--- a/app/src/main/java/org/mozilla/focus/settings/privacy/PrivacySecuritySettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/privacy/PrivacySecuritySettingsFragment.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
 import org.mozilla.focus.R
+import org.mozilla.focus.autocomplete.StatePreference
 import org.mozilla.focus.biometrics.Biometrics
 import org.mozilla.focus.engine.EngineSharedPreferencesListener
 import org.mozilla.focus.ext.requireComponents
@@ -18,6 +19,7 @@ import org.mozilla.focus.settings.BaseSettingsFragment
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
 import org.mozilla.focus.telemetry.TelemetryWrapper
+import org.mozilla.focus.utils.AppConstants
 import org.mozilla.focus.widget.CookiesPreference
 
 class PrivacySecuritySettingsFragment :
@@ -38,7 +40,8 @@ class PrivacySecuritySettingsFragment :
         ) {
             preferenceScreen.removePreference(biometricPreference)
         }
-
+        (findPreference(getString(R.string.pref_key_studies)) as StatePreference?)?.isVisible =
+            AppConstants.isDevOrNightlyBuild
         val preferencesListener = EngineSharedPreferencesListener(requireContext())
 
         val cookiesPreference =
@@ -150,6 +153,10 @@ class PrivacySecuritySettingsFragment :
                     EngineSharedPreferencesListener.ChangeSource.SETTINGS.source,
                     EngineSharedPreferencesListener.TrackerChanged.CONTENT.tracker,
                     settings.shouldBlockOtherTrackers()
+                )
+            resources.getString(R.string.pref_key_studies) ->
+                requireComponents.appStore.dispatch(
+                    AppAction.OpenSettings(page = Screen.Settings.Page.Studies)
                 )
         }
         return super.onPreferenceTreeClick(preference)

--- a/app/src/main/java/org/mozilla/focus/settings/privacy/StudiesFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/privacy/StudiesFragment.kt
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.focus.settings.privacy
+
+import android.os.Bundle
+import android.text.SpannableStringBuilder
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
+import android.text.style.URLSpan
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.text.HtmlCompat
+import androidx.core.text.getSpans
+import mozilla.components.browser.state.state.SessionState
+import org.mozilla.focus.R
+import org.mozilla.focus.databinding.FragmentStudiesBinding
+import org.mozilla.focus.ext.components
+import org.mozilla.focus.ext.settings
+import org.mozilla.focus.settings.BaseSettingsLikeFragment
+import org.mozilla.focus.state.AppAction
+import org.mozilla.focus.utils.SupportUtils
+
+class StudiesFragment : BaseSettingsLikeFragment() {
+    private lateinit var binding: FragmentStudiesBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentStudiesBinding.inflate(inflater, container, false)
+        setLearnMore()
+        setStudiesState(requireContext().settings.isExperimentationEnabled)
+        setStudiesSwitch()
+        return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        updateTitle(R.string.preference_studies)
+    }
+
+    private fun setLearnMore() {
+        val sumoUrl =
+            SupportUtils.getSumoURLForTopic(requireContext(), SupportUtils.SumoTopic.STUDIES)
+        val description = getString(R.string.preference_studies_summary)
+        val learnMore = getString(R.string.studies_learn_more)
+        val rawText = "$description <a href=\"$sumoUrl\">$learnMore</a>"
+        val text = HtmlCompat.fromHtml(rawText, HtmlCompat.FROM_HTML_MODE_COMPACT)
+
+        val spannableStringBuilder = SpannableStringBuilder(text)
+        val links = spannableStringBuilder.getSpans<URLSpan>()
+        for (link in links) {
+            addActionToLinks(spannableStringBuilder, link)
+        }
+        binding.studiesDescription.text = spannableStringBuilder
+        binding.studiesDescription.movementMethod = LinkMovementMethod.getInstance()
+    }
+
+    private fun addActionToLinks(spannableStringBuilder: SpannableStringBuilder, link: URLSpan) {
+        val start = spannableStringBuilder.getSpanStart(link)
+        val end = spannableStringBuilder.getSpanEnd(link)
+        val flags = spannableStringBuilder.getSpanFlags(link)
+        val clickable: ClickableSpan = object : ClickableSpan() {
+            override fun onClick(view: View) {
+                view.setOnClickListener {
+                    openLearnMore.invoke()
+                }
+            }
+        }
+        spannableStringBuilder.setSpan(clickable, start, end, flags)
+        spannableStringBuilder.removeSpan(link)
+    }
+
+    private val openLearnMore = {
+        val tabId = requireContext().components.tabsUseCases.addTab(
+            url = SupportUtils.getSumoURLForTopic(requireContext(), SupportUtils.SumoTopic.STUDIES),
+            source = SessionState.Source.Internal.Menu,
+            selectTab = true,
+            private = true
+        )
+        requireContext().components.appStore.dispatch(AppAction.OpenTab(tabId))
+    }
+
+    private fun setStudiesState(switchState: Boolean) {
+        binding.studiesTitle.text = if (switchState) {
+            getString(R.string.preference_state_on)
+        } else {
+            getString(R.string.preference_state_off)
+        }
+    }
+
+    private fun setStudiesSwitch() {
+        binding.studiesSwitch.isChecked = requireContext().settings.isExperimentationEnabled
+        binding.studiesSwitch.setOnCheckedChangeListener { _, isChecked ->
+            setStudiesState(isChecked)
+            requireContext().settings.isExperimentationEnabled = isChecked
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
@@ -187,6 +187,7 @@ private fun navigateUp(state: AppState, action: AppAction.NavigateUp): AppState 
 
         Screen.Settings.Page.PrivacyExceptions -> Screen.Settings(page = Screen.Settings.Page.Privacy)
         Screen.Settings.Page.PrivacyExceptionsRemove -> Screen.Settings(page = Screen.Settings.Page.PrivacyExceptions)
+        Screen.Settings.Page.Studies -> Screen.Settings(page = Screen.Settings.Page.Privacy)
 
         Screen.Settings.Page.SearchList -> Screen.Settings(page = Screen.Settings.Page.Search)
         Screen.Settings.Page.SearchRemove -> Screen.Settings(page = Screen.Settings.Page.SearchList)

--- a/app/src/main/java/org/mozilla/focus/state/AppState.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppState.kt
@@ -81,6 +81,7 @@ sealed class Screen {
 
             PrivacyExceptions,
             PrivacyExceptionsRemove,
+            Studies,
 
             SearchList,
             SearchRemove,

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -105,6 +105,14 @@ class Settings(
             false
         )
 
+    var isExperimentationEnabled: Boolean
+        get() = preferences.getBoolean(getPreferenceKey(R.string.pref_key_studies), false)
+        set(value) {
+            preferences.edit()
+                .putBoolean(getPreferenceKey(R.string.pref_key_studies), value)
+                .apply()
+        }
+
     fun shouldBlockImages(): Boolean =
         // Not shipping in v1 (#188)
             /* preferences.getBoolean(

--- a/app/src/main/java/org/mozilla/focus/utils/SupportUtils.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/SupportUtils.kt
@@ -49,7 +49,8 @@ object SupportUtils {
         WHATS_NEW_FOCUS("whats-new-firefox-focus-android"),
         WHATS_NEW_KLAR("whats-new-firefox-klar-android"),
         SEARCH_SUGGESTIONS("search-suggestions-focus-android"),
-        ALLOWLIST("focus-android-allowlist")
+        ALLOWLIST("focus-android-allowlist"),
+        STUDIES("studies")
     }
 
     fun getSumoURLForTopic(context: Context, topic: SumoTopic): String {

--- a/app/src/main/res/layout/fragment_studies.xml
+++ b/app/src/main/res/layout/fragment_studies.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <View
+        android:id="@+id/status_bar_background"
+        android:layout_width="match_parent"
+        android:layout_height="0dp" />
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/settings_background" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/settings_background">
+
+        <TextView
+            android:id="@+id/studiesTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="72dp"
+            android:clickable="false"
+            android:focusable="false"
+            android:textAppearance="@style/Preference.Title"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toStartOf="@id/studies_switch"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/studiesDescription"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/preference_studies_summary"
+            android:textColor="?attr/secondaryText"
+            android:textColorLink="@color/accent"
+            app:layout_constraintEnd_toEndOf="@id/studiesTitle"
+            app:layout_constraintStart_toStartOf="@id/studiesTitle"
+            app:layout_constraintTop_toBottomOf="@id/studiesTitle" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/studies_switch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:minHeight="48dp"
+            android:textOff="@string/preference_state_off"
+            android:textOn="@string/preference_state_on"
+            app:layout_constraintBottom_toBottomOf="@id/studiesDescription"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/studiesTitle" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/studies_list"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/studiesDescription" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -49,6 +49,7 @@
     <string name="pref_key_search_screen" translatable="false"><xliff:g id="preference_key">pref_screen_search</xliff:g></string>
     <string name="pref_key_remote_debugging" translatable="false"><xliff:g id="preference_key">pref_remote_debugging</xliff:g></string>
     <string name="pref_key_open_links_in_external_app" translatable="false"><xliff:g id="preference_key">pref_key_open_links_in_external_app</xliff:g></string>
+    <string name="pref_key_studies" translatable="false"><xliff:g id="preference_key">pref_key_studies</xliff:g></string>
 
     <string name="has_opened_new_tab" translatable="false"><xliff:g id="preference_key">has_opened_new_tab</xliff:g></string>
     <string name="has_added_to_home_screen" translatable="false"><xliff:g id="preference_key">has_added_to_home_screen</xliff:g></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -607,6 +607,15 @@
     <!-- Title of Advanced Setting category -->
     <string name="preference_category_advanced">Advanced</string>
 
+    <!-- Preference for studies -->
+    <string name="preference_studies">Studies</string>
+
+    <!-- Preference for studies summary-->
+    <string name="preference_studies_summary">Firefox may install and run studies from time to time.</string>
+
+    <!-- Learn more link for studies, links to an article for more information about studies. -->
+    <string name="studies_learn_more">Learn more</string>
+
     <!-- Preference to enable remote debugging of the app via USB or Wi-Fi -->
     <string name="preference_remote_debugging">Remote debugging via USB/Wi-Fi</string>
 

--- a/app/src/main/res/xml/privacy_security_settings.xml
+++ b/app/src/main/res/xml/privacy_security_settings.xml
@@ -126,6 +126,12 @@
             android:key="@string/pref_key_telemetry"
             android:summary="@string/preference_mozilla_telemetry_summary2"
             android:title="@string/preference_mozilla_telemetry2" />
+
+        <org.mozilla.focus.autocomplete.StatePreference
+            android:key="@string/pref_key_studies"
+            android:layout="@layout/focus_preference_no_icon"
+            android:summary="@string/preference_state_off"
+            android:title="@string/preference_studies" />
     </androidx.preference.PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/search_settings.xml
+++ b/app/src/main/res/xml/search_settings.xml
@@ -16,7 +16,7 @@
         android:title="@string/preference_show_search_suggestions"
         android:summary="@string/preference_show_search_suggestions_summary"/>
 
-    <org.mozilla.focus.autocomplete.AutocompletePreference
+    <org.mozilla.focus.autocomplete.StatePreference
         android:key="@string/pref_key_screen_autocomplete"
         android:layout="@layout/focus_preference_no_icon"
         android:summary="WHAT?"


### PR DESCRIPTION
For #5601
Add a new screen for studies where we can:
- Open Learn more page
- Enable/Disable studies, just UI implementation

Marked as Draft until I receive an approve from UX about Studies option position