### PR TITLE
Refactor UI kind and gradle config to support more UI tests

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,11 +4,11 @@ pull_request_rules:
       - status-success=build-klar-release
       - status-success=test-debug
       # - status-success=ui-test-x86-debug
-      - status-success=build-beta
+      # - status-success=ui-test-x86-nightly
+      # - status-success=ui-test-x86-beta
       - status-success=build-focus-debug
       - status-success=build-focus-release
       - status-success=build-klar-debug
-      - status-success=build-nightly
       - status-success=lint-compare-locales
       - status-success=lint-detekt
       - status-success=lint-ktlint
@@ -25,11 +25,11 @@ pull_request_rules:
       - status-success=build-klar-release
       - status-success=test-debug
       # - status-success=ui-test-x86-debug
-      - status-success=build-beta
+      # - status-success=ui-test-x86-nightly
+      # - status-success=ui-test-x86-beta
       - status-success=build-focus-debug
       - status-success=build-focus-release
       - status-success=build-klar-debug
-      - status-success=build-nightly
       - status-success=lint-compare-locales
       - status-success=lint-detekt
       - status-success=lint-ktlint

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -590,10 +590,10 @@ tasks.register('printVariants') {
         variants.add([
             apks: [[
                 abi: 'noarch',
-                fileName: 'app-focus-debug-androidTest.apk',
+                fileName: 'app-debug-androidTest.apk',
             ]],
-            build_type: 'debug',
-            name: 'FocusDebugAndroidTest',
+            build_type: 'androidTest',
+            name: 'androidTest',
         ])
         println 'variants: ' + JsonOutput.toJson(variants)
     }

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -132,12 +132,12 @@ jobs:
             code-review: true
         run-on-tasks-for: [github-pull-request, github-push]
         run:
-            gradle-build-type: debug
-            gradle-build-name: FocusDebugAndroidTest
+            gradle-build-type: androidTest
+            gradle-build-name: androidTest
             gradle-build: focus
         apk-artifact-template:
-            # "androidTest/" is added to path
-            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
+            name: 'public/build/app-focus-debug-androidTest.apk'
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/focus/debug/app-focus-debug-androidTest.apk'
         treeherder:
             symbol: debug(Bat)
 
@@ -152,14 +152,13 @@ jobs:
             nightly-task: true
         run-on-tasks-for: [github-push]
         run:
-            gradle-build-type: debug
-            gradle-build-name: FocusDebugAndroidTest
+            gradle-build-type: androidTest
+            gradle-build-name: androidTest
             gradle-build: focus
             test-build-type: nightly
         apk-artifact-template:
-            # "androidTest/" is added to path
-            # filename is forced to 'app-nightly-androidTest.apk'
-            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
+            name: 'public/build/app-focus-nightly-androidTest.apk'
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/focus/nightly/app-focus-nightly-androidTest.apk'
         treeherder:
             symbol: nightly(Bat)
 

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -92,7 +92,7 @@ jobs:
             # any tasks that have this as a primary dependency will
             # inherit this attribute via the multi_dep loader
             nightly-task: true
-        run-on-tasks-for: [github-pull-request]
+        run-on-tasks-for: []
         include-shippable-secrets: true
         run:
             gradle-build-type: nightly
@@ -105,7 +105,7 @@ jobs:
         description: 'Beta focus build'
         attributes:
             release-type: beta
-        run-on-tasks-for: [github-pull-request]
+        run-on-tasks-for: []
         include-shippable-secrets: true
         run:
             gradle-build-type: beta

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -126,6 +126,18 @@ jobs:
         treeherder:
             symbol: nightly(Bf)
 
+    beta-firebase:
+        description: 'Beta build for UI tests'
+        disable-optimization: true
+        run-on-tasks-for: [github-push] # We want this on push so that we detect problem before triggering a new nightly
+        run:
+            gradle-build-type: beta
+            gradle-build-name: focusBeta
+            gradle-build: focus
+            test-build-type: beta
+        treeherder:
+            symbol: beta(Bf)
+
     android-test-debug:
         description: 'Android Test for debugging'
         attributes:
@@ -150,8 +162,6 @@ jobs:
 
     android-test-nightly:
         description: 'Nightly Android Test for debugging'
-        attributes:
-            nightly-task: true
         run-on-tasks-for: [github-push]
         run:
             gradle-build-type: androidTest
@@ -166,9 +176,6 @@ jobs:
 
     android-test-beta:
         description: 'Beta Android Test for debugging'
-        # enable this attribute if you want this build to run for beta releases
-        # attributes:
-            # release-type: beta
         run-on-tasks-for: [github-push]
         run:
             gradle-build-type: androidTest

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -176,7 +176,7 @@ jobs:
             gradle-build: focus
             test-build-type: beta
         apk-artifact-template:
-            name: 'public/build/app-focus-beta-androidTest.apk'
+            name: 'public/build/app-focus-androidTest.apk'
             path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/focus/beta/app-focus-beta-androidTest.apk'
         treeherder:
             symbol: beta(Bat)

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -15,7 +15,7 @@ kind-dependencies:
 job-defaults:
     apk-artifact-template:
         type: file
-        name: 'public/build/{fileName}'
+        name: 'public/build/{gradle_build}/{abi}/target.apk'
         path: '/builds/worker/checkouts/src/app/build/outputs/apk/{gradle_build}/{gradle_build_type}/{fileName}'
     fetches:
         toolchain:
@@ -136,7 +136,9 @@ jobs:
             gradle-build-name: androidTest
             gradle-build: focus
         apk-artifact-template:
-            name: 'public/build/app-focus-debug-androidTest.apk'
+            # we override this with a generic name to make the signing kinds cleaner
+            name: 'public/build/app-focus-androidTest.apk'
+            # this path is determined by the gradle build configs
             path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/focus/debug/app-focus-debug-androidTest.apk'
         treeherder:
             symbol: debug(Bat)
@@ -157,7 +159,7 @@ jobs:
             gradle-build: focus
             test-build-type: nightly
         apk-artifact-template:
-            name: 'public/build/app-focus-nightly-androidTest.apk'
+            name: 'public/build/app-focus-androidTest.apk'
             path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/focus/nightly/app-focus-nightly-androidTest.apk'
         treeherder:
             symbol: nightly(Bat)

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -174,8 +174,7 @@ jobs:
     #         gradle-build: focus
     #         test-build-type: beta
     #     apk-artifact-template:
-    #         # "androidTest/" is added to path
-    #         name: 'public/build/{fileName}'
-    #         path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/beta/app-beta-androidTest.apk'    
+            # name: 'public/build/app-focus-beta-androidTest.apk'
+            # path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/focus/beta/app-focus-beta-androidTest.apk'
     #     treeherder:
     #         symbol: beta(Bat)

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -136,7 +136,7 @@ jobs:
             gradle-build-name: androidTest
             gradle-build: focus
         apk-artifact-template:
-            # we override this with a generic name to make the signing kinds cleaner
+            # we override this with a generic name to make the signing kind cleaner
             name: 'public/build/app-focus-androidTest.apk'
             # this path is determined by the gradle build configs
             path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/focus/debug/app-focus-debug-androidTest.apk'
@@ -164,19 +164,19 @@ jobs:
         treeherder:
             symbol: nightly(Bat)
 
-    # android-test-beta:
-    #     description: 'Beta Android Test for debugging'
-    #     # enable this attribute if you want this build to run for beta releases
-    #     # attributes:
-    #         # release-type: beta
-    #     run-on-tasks-for: [github-push]
-    #     run:
-    #         gradle-build-type: debug
-    #         gradle-build-name: FocusDebugAndroidTest
-    #         gradle-build: focus
-    #         test-build-type: beta
-    #     apk-artifact-template:
-            # name: 'public/build/app-focus-beta-androidTest.apk'
-            # path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/focus/beta/app-focus-beta-androidTest.apk'
-    #     treeherder:
-    #         symbol: beta(Bat)
+    android-test-beta:
+        description: 'Beta Android Test for debugging'
+        # enable this attribute if you want this build to run for beta releases
+        # attributes:
+            # release-type: beta
+        run-on-tasks-for: [github-push]
+        run:
+            gradle-build-type: androidTest
+            gradle-build-name: androidTest
+            gradle-build: focus
+            test-build-type: beta
+        apk-artifact-template:
+            name: 'public/build/app-focus-beta-androidTest.apk'
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/focus/beta/app-focus-beta-androidTest.apk'
+        treeherder:
+            symbol: beta(Bat)

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -137,7 +137,6 @@ jobs:
             gradle-build: focus
         apk-artifact-template:
             # "androidTest/" is added to path
-            name: 'public/build/{fileName}'
             path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
         treeherder:
             symbol: debug(Bat)
@@ -160,7 +159,7 @@ jobs:
         apk-artifact-template:
             # "androidTest/" is added to path
             # filename is forced to 'app-nightly-androidTest.apk'
-            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/nightly/app-nightly-androidTest.apk'    
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
         treeherder:
             symbol: nightly(Bat)
 

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -159,7 +159,7 @@ jobs:
             test-build-type: nightly
         apk-artifact-template:
             # "androidTest/" is added to path
-            name: 'public/build/{fileName}'
+            # filename is forced to 'app-nightly-androidTest.apk'
             path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/nightly/app-nightly-androidTest.apk'    
         treeherder:
             symbol: nightly(Bat)

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -135,35 +135,37 @@ jobs:
     # and the APK under test to be signed with the same key. Thus, the nightly APK being signed with
     # nightly means we need an androidTest APK with the same signature.
 
-    android-test-nightly:
-        description: 'Nightly Android Test for debugging'
-        attributes:
-            nightly-task: true
-        run-on-tasks-for: [github-push]
-        run:
-            gradle-build-type: debug
-            gradle-build-name: FocusDebugAndroidTest
-            gradle-build: focus
-        apk-artifact-template:
-            # "androidTest/" is added to path
-            name: 'public/build/{fileName}'
-            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
-        treeherder:
-            symbol: nightly(Bat)
+    # android-test-nightly:
+    #     description: 'Nightly Android Test for debugging'
+    #     attributes:
+    #         nightly-task: true
+    #     run-on-tasks-for: [github-push]
+    #     run:
+    #         gradle-build-type: debug
+    #         gradle-build-name: FocusDebugAndroidTest
+    #         gradle-build: focus
+    #         test-build-type: nightly
+    #     apk-artifact-template:
+    #         # "androidTest/" is added to path
+    #         name: 'public/build/{fileName}'
+    #         path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/nightly/app-nightly-androidTest.apk'    
+    #     treeherder:
+    #         symbol: nightly(Bat)
 
-    android-test-beta:
-        description: 'Beta Android Test for debugging'
-        # enable this attribute if you want this build to run for beta releases
-        # attributes:
-            # release-type: beta
-        run-on-tasks-for: [github-push]
-        run:
-            gradle-build-type: debug
-            gradle-build-name: FocusDebugAndroidTest
-            gradle-build: focus
-        apk-artifact-template:
-            # "androidTest/" is added to path
-            name: 'public/build/{fileName}'
-            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
-        treeherder:
-            symbol: beta(Bat)
+    # android-test-beta:
+    #     description: 'Beta Android Test for debugging'
+    #     # enable this attribute if you want this build to run for beta releases
+    #     # attributes:
+    #         # release-type: beta
+    #     run-on-tasks-for: [github-push]
+    #     run:
+    #         gradle-build-type: debug
+    #         gradle-build-name: FocusDebugAndroidTest
+    #         gradle-build: focus
+    #         test-build-type: beta
+    #     apk-artifact-template:
+    #         # "androidTest/" is added to path
+    #         name: 'public/build/{fileName}'
+    #         path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/beta/app-beta-androidTest.apk'    
+    #     treeherder:
+    #         symbol: beta(Bat)

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -113,3 +113,20 @@ jobs:
             gradle-build: focus
         treeherder:
             symbol: beta(B)
+
+    android-test-debug:
+        description: 'Android Test for debugging'
+        attributes:
+            code-review: true
+        run-on-tasks-for: [github-pull-request, github-push]
+        run:
+            gradle-build-type: debug
+            gradle-build-name: FocusDebugAndroidTest
+            gradle-build: focus
+        apk-artifact-template:
+            # "androidTest/" is added
+            name: 'public/build/{fileName}'
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
+        treeherder:
+            symbol: debug(Bat)
+

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -124,9 +124,42 @@ jobs:
             gradle-build-name: FocusDebugAndroidTest
             gradle-build: focus
         apk-artifact-template:
-            # "androidTest/" is added
+            # "androidTest/" is added to path
             name: 'public/build/{fileName}'
             path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
         treeherder:
             symbol: debug(Bat)
 
+    # TODO enable this when android tests for Nightly and Beta are added
+    # android-test-nightly:
+    #     description: 'Nightly Android Test for debugging'
+    #     attributes:
+    #         nightly-task: true
+    #     run-on-tasks-for: [github-push]
+    #     run:
+    #         gradle-build-type: nightly
+    #         gradle-build-name: FocusNightlyAndroidTest
+    #         gradle-build: focus
+    #     apk-artifact-template:
+    #         # "androidTest/" is added to path
+    #         name: 'public/build/{fileName}'
+    #         path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
+    #     treeherder:
+    #         symbol: nightly(Bat)
+
+    # android-test-beta:
+    #     description: 'Beta Android Test for debugging'
+    #     # enable this attribute if you want this build to run for beta releases
+    #     # attributes:
+    #         # release-type: beta
+    #     run-on-tasks-for: [github-push]
+    #     run:
+    #         gradle-build-type: beta
+    #         gradle-build-name: FocusBetaAndroidTest
+    #         gradle-build: focus
+    #     apk-artifact-template:
+    #         # "androidTest/" is added to path
+    #         name: 'public/build/{fileName}'
+    #         path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
+    #     treeherder:
+    #         symbol: beta(Bat)

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -114,6 +114,18 @@ jobs:
         treeherder:
             symbol: beta(B)
 
+    nightly-firebase:
+        description: 'Nightly build for UI tests'
+        disable-optimization: true
+        run-on-tasks-for: [github-push] # We want this on push so that we detect problem before triggering a new nightly
+        run:
+            gradle-build-type: nightly
+            gradle-build-name: focusNightly
+            gradle-build: focus
+            test-build-type: nightly
+        treeherder:
+            symbol: nightly(Bf)
+
     android-test-debug:
         description: 'Android Test for debugging'
         attributes:
@@ -135,22 +147,22 @@ jobs:
     # and the APK under test to be signed with the same key. Thus, the nightly APK being signed with
     # nightly means we need an androidTest APK with the same signature.
 
-    # android-test-nightly:
-    #     description: 'Nightly Android Test for debugging'
-    #     attributes:
-    #         nightly-task: true
-    #     run-on-tasks-for: [github-push]
-    #     run:
-    #         gradle-build-type: debug
-    #         gradle-build-name: FocusDebugAndroidTest
-    #         gradle-build: focus
-    #         test-build-type: nightly
-    #     apk-artifact-template:
-    #         # "androidTest/" is added to path
-    #         name: 'public/build/{fileName}'
-    #         path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/nightly/app-nightly-androidTest.apk'    
-    #     treeherder:
-    #         symbol: nightly(Bat)
+    android-test-nightly:
+        description: 'Nightly Android Test for debugging'
+        attributes:
+            nightly-task: true
+        run-on-tasks-for: [github-push]
+        run:
+            gradle-build-type: debug
+            gradle-build-name: FocusDebugAndroidTest
+            gradle-build: focus
+            test-build-type: nightly
+        apk-artifact-template:
+            # "androidTest/" is added to path
+            name: 'public/build/{fileName}'
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/nightly/app-nightly-androidTest.apk'    
+        treeherder:
+            symbol: nightly(Bat)
 
     # android-test-beta:
     #     description: 'Beta Android Test for debugging'

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -130,36 +130,40 @@ jobs:
         treeherder:
             symbol: debug(Bat)
 
-    # TODO enable this when android tests for Nightly and Beta are added
-    # android-test-nightly:
-    #     description: 'Nightly Android Test for debugging'
-    #     attributes:
-    #         nightly-task: true
-    #     run-on-tasks-for: [github-push]
-    #     run:
-    #         gradle-build-type: nightly
-    #         gradle-build-name: FocusNightlyAndroidTest
-    #         gradle-build: focus
-    #     apk-artifact-template:
-    #         # "androidTest/" is added to path
-    #         name: 'public/build/{fileName}'
-    #         path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
-    #     treeherder:
-    #         symbol: nightly(Bat)
+    # android-test-nightly and android-test-beta, while still being debug builds, are meant to be signed
+    # with the nightly/beta key. The Firebase testing infrastructure requires both the androidTest APK
+    # and the APK under test to be signed with the same key. Thus, the nightly APK being signed with
+    # nightly means we need an androidTest APK with the same signature.
 
-    # android-test-beta:
-    #     description: 'Beta Android Test for debugging'
-    #     # enable this attribute if you want this build to run for beta releases
-    #     # attributes:
-    #         # release-type: beta
-    #     run-on-tasks-for: [github-push]
-    #     run:
-    #         gradle-build-type: beta
-    #         gradle-build-name: FocusBetaAndroidTest
-    #         gradle-build: focus
-    #     apk-artifact-template:
-    #         # "androidTest/" is added to path
-    #         name: 'public/build/{fileName}'
-    #         path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
-    #     treeherder:
-    #         symbol: beta(Bat)
+    android-test-nightly:
+        description: 'Nightly Android Test for debugging'
+        attributes:
+            nightly-task: true
+        run-on-tasks-for: [github-push]
+        run:
+            gradle-build-type: debug
+            gradle-build-name: FocusDebugAndroidTest
+            gradle-build: focus
+        apk-artifact-template:
+            # "androidTest/" is added to path
+            name: 'public/build/{fileName}'
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
+        treeherder:
+            symbol: nightly(Bat)
+
+    android-test-beta:
+        description: 'Beta Android Test for debugging'
+        # enable this attribute if you want this build to run for beta releases
+        # attributes:
+            # release-type: beta
+        run-on-tasks-for: [github-push]
+        run:
+            gradle-build-type: debug
+            gradle-build-name: FocusDebugAndroidTest
+            gradle-build: focus
+        apk-artifact-template:
+            # "androidTest/" is added to path
+            name: 'public/build/{fileName}'
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{gradle_build}/{gradle_build_type}/{fileName}'    
+        treeherder:
+            symbol: beta(Bat)

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -30,7 +30,7 @@ job-template:
             default: {}
     run-on-tasks-for: 
         by-build-type:
-            (focus-debug|android-test-debug): [github-push]
+            (focus-debug|android-test-debug|nightly-firebase|android-test-nightly): [github-push]
             default: []
     treeherder:
         job-symbol:
@@ -39,6 +39,7 @@ job-template:
                 klar-.*: Bkls
                 default: Bs
                 android-test.+: Bats
+                nightly-firebase: nightly(Bf)
         kind: build
         platform: android-all/opt
         tier: 1

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -30,7 +30,7 @@ job-template:
             default: {}
     run-on-tasks-for: 
         by-build-type:
-            (focus-debug|android-test-debug|nightly-firebase|android-test-nightly): [github-push]
+            (focus-debug|android-test-debug|nightly-firebase|android-test-nightly|beta-firebase|android-test-beta): [github-push]
             default: []
     treeherder:
         job-symbol:
@@ -39,7 +39,8 @@ job-template:
                 klar-.*: Bkls
                 default: Bs
                 android-test.+: Bats
-                nightly-firebase: nightly(Bf)
+                beta-firebase: Bfs
+                nightly-firebase: Bfs
         kind: build
         platform: android-all/opt
         tier: 1

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -24,13 +24,13 @@ job-template:
         by-tasks-for:
             (action|cron|github-release):
                 by-build-type:
-                    (nightly|focus-release|klar-release|beta|focus-debug):
+                    (nightly|focus-release|klar-release|beta):
                         type: signing
                     default: {}
             default: {}
     run-on-tasks-for: 
         by-build-type:
-            (android-test-beta|android-test-nightly): [github-push]
+            (focus-debug|android-test-debug): [github-push]
             default: []
     treeherder:
         job-symbol:

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -24,7 +24,7 @@ job-template:
         by-tasks-for:
             (action|cron|github-release):
                 by-build-type:
-                    (nightly|focus-release|klar-release|beta):
+                    (nightly|focus-release|klar-release|beta|focus-debug|android-test-debug):
                         type: signing
                     default: {}
             default: {}
@@ -35,6 +35,7 @@ job-template:
                 focus-.*: Bfs
                 klar-.*: Bkls
                 default: Bs
+                android-test.+: Bats
         kind: build
         platform: android-all/opt
         tier: 1

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -24,11 +24,14 @@ job-template:
         by-tasks-for:
             (action|cron|github-release):
                 by-build-type:
-                    (nightly|focus-release|klar-release|beta|focus-debug|android-test-debug):
+                    (nightly|focus-release|klar-release|beta|focus-debug):
                         type: signing
                     default: {}
             default: {}
-    run-on-tasks-for: []
+    run-on-tasks-for: 
+        by-build-type:
+            (android-test-beta|android-test-nightly): [github-push]
+            default: []
     treeherder:
         job-symbol:
             by-build-type:

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -48,15 +48,29 @@ job-defaults:
               key: firebaseToken
               path: .firebase_token.json
               json: true
-        commands: 
-            - [wget, {artifact-reference: '<signed-debug-apk/public/build/app-focus-x86-debug.apk>'}, '-O', app.apk]
-            - [wget, {artifact-reference: '<signed-android-test/public/build/app-focus-debug-androidTest.apk>'}, '-O', android-test.apk]
 
 jobs:
     x86-debug:
         description: 'UI tests with firebase'
         run:
             commands:
+                - [wget, {artifact-reference: '<signed-debug-apk/public/build/app-focus-x86-debug.apk>'}, '-O', app.apk]
+                - [wget, {artifact-reference: '<signed-android-test/public/build/app-focus-debug-androidTest.apk>'}, '-O', android-test.apk]
                 - ['automation/taskcluster/androidTest/ui-test.sh', 'x86', 'app.apk', 'android-test.apk', '-1']
         treeherder:
             symbol: debug(ui-test-x86)
+    x86-nightly:
+        attributes:
+            build-type: nightly-firebase
+        description: 'UI tests on Nightly with firebase'
+        run-on-tasks-for: [github-push]
+        dependencies:
+            signed-debug-apk: signing-nightly-firebase
+            signed-android-test: signing-android-test-nightly
+        run:
+            commands:
+                - [wget, {artifact-reference: '<signed-debug-apk/public/build/app-focus-x86-nightly.apk>'}, '-O', app.apk]
+                - [wget, {artifact-reference: '<signed-android-test/public/build/app-focus-debug-androidTest.apk>'}, '-O', android-test.apk]
+                - [automation/taskcluster/androidTest/ui-test.sh, x86-start-test, app.apk, android-test.apk, '-1']
+        treeherder:
+            symbol: nightly(ui-test-x86-nightly)

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -73,3 +73,16 @@ jobs:
                 - ['automation/taskcluster/androidTest/ui-test.sh', 'x86', 'app.apk', 'android-test.apk', '-1']
         treeherder:
             symbol: nightly(ui-test-x86-nightly)
+    x86-beta:
+        attributes:
+            build-type: nightly-firebase
+        description: 'UI tests on Nightly with firebase'
+        run-on-tasks-for: [github-push]
+        dependencies:
+            signed-debug-apk: signing-beta-firebase
+            signed-android-test: signing-android-test-beta
+        run:
+            commands:
+                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86', 'app.apk', 'android-test.apk', '-1']
+        treeherder:
+            symbol: beta(ui-test-x86-beta)

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -20,7 +20,7 @@ job-defaults:
     dependencies:
         # key is arbitrary, the value corresponds to <kind name>-<build-name> 
         signed-debug-apk: signing-focus-debug
-        signed-android-test: signing-android-test-debug  
+        signed-android-test: signing-android-test-debug
     worker-type: b-android
     worker:
         docker-image: {in-tree: ui-tests}
@@ -48,14 +48,15 @@ job-defaults:
               key: firebaseToken
               path: .firebase_token.json
               json: true
+        commands:
+            - [wget, {artifact-reference: '<signed-debug-apk/public/build/focus/x86/target.apk>'}, '-O', app.apk]
+            - [wget, {artifact-reference: '<signed-android-test/public/build/app-focus-androidTest.apk>'}, '-O', android-test.apk]
 
 jobs:
     x86-debug:
         description: 'UI tests with firebase'
         run:
             commands:
-                - [wget, {artifact-reference: '<signed-debug-apk/public/build/app-focus-x86-debug.apk>'}, '-O', app.apk]
-                - [wget, {artifact-reference: '<signed-android-test/public/build/app-focus-debug-androidTest.apk>'}, '-O', android-test.apk]
                 - ['automation/taskcluster/androidTest/ui-test.sh', 'x86', 'app.apk', 'android-test.apk', '-1']
         treeherder:
             symbol: debug(ui-test-x86)
@@ -69,8 +70,6 @@ jobs:
             signed-android-test: signing-android-test-nightly
         run:
             commands:
-                - [wget, {artifact-reference: '<signed-debug-apk/public/build/app-focus-x86-nightly-unsigned.apk>'}, '-O', app.apk]
-                - [wget, {artifact-reference: '<signed-android-test/public/build/app-focus-debug-androidTest.apk>'}, '-O', android-test.apk]
-                - [automation/taskcluster/androidTest/ui-test.sh, x86-start-test, app.apk, android-test.apk, '-1']
+                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86-start-test', 'app.apk', 'android-test.apk', '-1']
         treeherder:
             symbol: nightly(ui-test-x86-nightly)

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -70,6 +70,6 @@ jobs:
             signed-android-test: signing-android-test-nightly
         run:
             commands:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86-start-test', 'app.apk', 'android-test.apk', '-1']
+                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86', 'app.apk', 'android-test.apk', '-1']
         treeherder:
             symbol: nightly(ui-test-x86-nightly)

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -69,7 +69,7 @@ jobs:
             signed-android-test: signing-android-test-nightly
         run:
             commands:
-                - [wget, {artifact-reference: '<signed-debug-apk/public/build/app-focus-x86-nightly.apk>'}, '-O', app.apk]
+                - [wget, {artifact-reference: '<signed-debug-apk/public/build/app-focus-x86-nightly-unsigned.apk>'}, '-O', app.apk]
                 - [wget, {artifact-reference: '<signed-android-test/public/build/app-focus-debug-androidTest.apk>'}, '-O', android-test.apk]
                 - [automation/taskcluster/androidTest/ui-test.sh, x86-start-test, app.apk, android-test.apk, '-1']
         treeherder:

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -17,10 +17,10 @@ job-defaults:
         build-type: debug
         code-review: true
         retrigger: true
-    fetches:
-        toolchain:
-            - android-sdk-linux
-            - android-gradle-dependencies
+    dependencies:
+        # key is arbitrary, the value corresponds to <kind name>-<build-name> 
+        signed-debug-apk: signing-focus-debug
+        signed-android-test: signing-android-test-debug  
     worker-type: b-android
     worker:
         docker-image: {in-tree: ui-tests}
@@ -39,7 +39,7 @@ job-defaults:
         tier: 2
     run:
         use-caches: false
-        using: gradlew
+        using: run-commands
         dummy-secrets:
             - content: "faketoken"
               path: .adjust_token
@@ -48,17 +48,15 @@ job-defaults:
               key: firebaseToken
               path: .firebase_token.json
               json: true
-        # TODO retrieving these from two separate tasks means they're signed differently; need to create a signing
-        # dependency in order to get this working properly (signed with same key)
-        #     - [wget, {artifact-reference: '<build-debug/public/build/app-focus-x86-debug.apk>'}, '-O', app.apk]
-        #     - [wget, {artifact-reference: '<build-android-test/public/build/app-focus-debug-androidTest.apk>'}, '-O', android-test.apk]
+        commands: 
+            - [wget, {artifact-reference: '<signed-debug-apk/public/build/app-focus-x86-debug.apk>'}, '-O', app.apk]
+            - [wget, {artifact-reference: '<signed-android-test/public/build/app-focus-debug-androidTest.apk>'}, '-O', android-test.apk]
 
 jobs:
     x86-debug:
         description: 'UI tests with firebase'
         run:
-            gradlew: ['clean', 'assembleFocusDebug', 'assembleFocusDebugAndroidTest']
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86', './app/build/outputs/apk/focus/debug/app-focus-x86-debug.apk', './app/build/outputs/apk/androidTest/focus/debug/app-focus-debug-androidTest.apk', '-1']
+            commands:
+                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86', 'app.apk', 'android-test.apk', '-1']
         treeherder:
             symbol: debug(ui-test-x86)

--- a/taskcluster/focus_android_taskgraph/transforms/build.py
+++ b/taskcluster/focus_android_taskgraph/transforms/build.py
@@ -65,6 +65,7 @@ def build_gradle_command(config, tasks):
         gradle_build_name = task["run"]["gradle-build-name"]
         variant_config = get_variant(gradle_build_type, gradle_build_name)
         variant_name = variant_config["name"][0].upper() + variant_config["name"][1:]
+
         task["run"]["gradlew"] = [
             "clean",
             f"assemble{variant_name}",
@@ -135,6 +136,7 @@ def add_artifacts(config, tasks):
             artifact_template = task.pop("apk-artifact-template")
             for apk in variant_config["apks"]:
                 apk_name = artifact_template["name"].format(
+                    gradle_build=gradle_build,
                     **apk
                 )
                 artifacts.append({

--- a/taskcluster/focus_android_taskgraph/transforms/signing.py
+++ b/taskcluster/focus_android_taskgraph/transforms/signing.py
@@ -17,7 +17,8 @@ PRODUCTION_SIGNING_BUILD_TYPES = [
     "beta",
     "focus-release",
     "klar-release",
-    "android-test-nightly"
+    "android-test-nightly",
+    "android-test-beta"
 ]
 
 SIGNING_BUILD_TYPES = PRODUCTION_SIGNING_BUILD_TYPES + [

--- a/taskcluster/focus_android_taskgraph/transforms/signing.py
+++ b/taskcluster/focus_android_taskgraph/transforms/signing.py
@@ -17,6 +17,7 @@ PRODUCTION_SIGNING_BUILD_TYPES = [
     "beta",
     "focus-release",
     "klar-release",
+    "android-test-nightly"
 ]
 
 SIGNING_BUILD_TYPES = PRODUCTION_SIGNING_BUILD_TYPES + [


### PR DESCRIPTION
This is ready for first review - questions and comments inline. The `ui-test-x86-nightly` has 4 failing tests (just using the same test files as `ui-test-x86`).