### PR TITLE
For #5654: Migrate open with... telemetry.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -897,3 +897,49 @@ search_engines:
     notification_emails:
       - android-probes@mozilla.com
     expires: "2022-11-01"
+
+open_with:
+  list_displayed:
+    type: event
+    description: The list of apps has been opened.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5654
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5703
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      list_size:
+        description: The number of apps in the list
+        type: quantity
+  list_item_tapped:
+    type: event
+    description: The uer has opened the url with a app from the list.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5654
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5703
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      package_name:
+        description: The app the user has chosen is a Mozilla product.
+        type: boolean
+  install_firefox:
+    type: event
+    description: The user has clicked install Firefox from store item.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5654
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5703
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"

--- a/app/src/main/java/org/mozilla/focus/activity/InstallFirefoxActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/InstallFirefoxActivity.kt
@@ -12,7 +12,8 @@ import android.content.pm.ActivityInfo
 import android.net.Uri
 import android.os.Bundle
 import android.webkit.WebView
-import org.mozilla.focus.telemetry.TelemetryWrapper
+import mozilla.components.service.glean.private.NoExtras
+import org.mozilla.focus.GleanMetrics.OpenWith
 import org.mozilla.focus.utils.AppConstants
 import org.mozilla.focus.utils.Browsers
 
@@ -84,7 +85,7 @@ class InstallFirefoxActivity : Activity() {
                 context.startActivity(intent)
             }
 
-            TelemetryWrapper.installFirefoxEvent()
+            OpenWith.installFirefox.record(NoExtras())
         }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -52,6 +52,7 @@ import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 import org.mozilla.focus.GleanMetrics.Downloads
+import org.mozilla.focus.GleanMetrics.OpenWith
 import org.mozilla.focus.GleanMetrics.TabCount
 import org.mozilla.focus.GleanMetrics.TrackingProtection
 import org.mozilla.focus.R
@@ -833,7 +834,7 @@ class BrowserFragment :
         @Suppress("DEPRECATION")
         fragment.show(requireFragmentManager(), OpenWithFragment.FRAGMENT_TAG)
 
-        TelemetryWrapper.openSelectionEvent()
+        OpenWith.listDisplayed.record(OpenWith.ListDisplayedExtra(apps.size))
     }
 
     internal fun closeCustomTab() {

--- a/app/src/main/java/org/mozilla/focus/open/AppAdapter.java
+++ b/app/src/main/java/org/mozilla/focus/open/AppAdapter.java
@@ -7,9 +7,10 @@ package org.mozilla.focus.open;
 import android.content.Context;
 import android.content.pm.ActivityInfo;
 import android.graphics.drawable.Drawable;
-import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
+
+import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -17,7 +18,7 @@ import java.util.Comparator;
 import java.util.List;
 
 public class AppAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
-    /* package */ static class App {
+    static class App {
         private final Context context;
         private final ActivityInfo info;
         private final String label;
@@ -41,7 +42,7 @@ public class AppAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         }
     }
 
-    /* package */ interface OnAppSelectedListener {
+    interface OnAppSelectedListener {
         void onAppSelected(App app);
     }
 

--- a/app/src/main/java/org/mozilla/focus/open/OpenWithFragment.java
+++ b/app/src/main/java/org/mozilla/focus/open/OpenWithFragment.java
@@ -12,19 +12,22 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.net.Uri;
 import android.os.Bundle;
-import androidx.annotation.LayoutRes;
-import androidx.annotation.NonNull;
-import com.google.android.material.bottomsheet.BottomSheetBehavior;
-import com.google.android.material.bottomsheet.BottomSheetDialog;
-import androidx.appcompat.app.AppCompatDialogFragment;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatDialogFragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.bottomsheet.BottomSheetDialog;
+
+import org.mozilla.focus.GleanMetrics.OpenWith;
 import org.mozilla.focus.R;
 
 public class OpenWithFragment extends AppCompatDialogFragment implements AppAdapter.OnAppSelectedListener {
@@ -137,6 +140,8 @@ public class OpenWithFragment extends AppCompatDialogFragment implements AppAdap
         final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(getArguments().getString(ARGUMENT_URL)));
         intent.setPackage(app.getPackageName());
         startActivity(intent);
+
+        OpenWith.INSTANCE.listItemTapped().record(new OpenWith.ListItemTappedExtra(app.getPackageName().contains("mozilla")));
 
         dismiss();
     }

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -610,16 +610,6 @@ object TelemetryWrapper {
     }
 
     @JvmStatic
-    fun installFirefoxEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.INSTALL, Object.APP, Value.FIREFOX).queue()
-    }
-
-    @JvmStatic
-    fun openSelectionEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.OPEN, Object.MENU, Value.SELECTION).queue()
-    }
-
-    @JvmStatic
     fun blockingSwitchEvent(isBlockingEnabled: Boolean) {
         TelemetryEvent.create(
             Category.ACTION,


### PR DESCRIPTION
# Request for data collection review form

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

_1) What questions will you answer with this data?_
Are users using other apps to open URLs from Focus?

_2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?_
This is needed to analyze feature usage and possible feature improvements.

_3) What alternative methods did you consider to answer these questions? Why were they not sufficient?_
This is the only way.

_4) Can current instrumentation answer these questions?_
No. We need a new specific event for a specific app feature.

_5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki._

_**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**_

<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
    <td>Tracking Bug #</td>
  </tr>
  <tr>
    <td>App list displayed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5654 </td>
  </tr>
   <tr>
    <td>App list item tapped</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5654 </td>
  </tr>
  <tr>
    <td>Installed firefox</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5654 </td>
  </tr>
 
</table>

_6) How long will this data be collected?  Choose one of the following:_
    Expiry for capturing data is set to "2022-11-01"

_7) What populations will you measure?_
All release channels and locales.

_8) If this data collection is default on, what is the opt-out mechanism for users?_
 Users can opt of of data collection by disabling Usage and technical data from Settings -> Privacy and security -> Data choices.

_9) Please provide a general description of how you will analyze this data._
 Glean 

_10) Where do you intend to share the results of your analysis?_
Only on Glean, mobile teams and BD have internal access.

_12) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection?_
No.
