### PR TITLE
Update to Android-Components 94.0.11.

### DIFF
--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "94.0.8"
+    const val VERSION = "94.0.11"
 }


### PR DESCRIPTION
This is the AC94 RC build. Do we need to make any other changes for Focus to become a release build or does that key off the AC release type?