### PR TITLE
No issue: Remove Firebase shippable secrets

### DIFF
--- a/taskcluster/focus_android_taskgraph/transforms/build.py
+++ b/taskcluster/focus_android_taskgraph/transforms/build.py
@@ -41,7 +41,6 @@ def add_shippable_secrets(config, tasks):
                 "path": target_file,
             } for key, target_file in (
                 ('adjust', '.adjust_token'),
-                ('firebase', f'app/src/{gradle_build_type}/res/values/firebase.xml'),
                 ('sentry_dsn', '.sentry_token'),
                 ('mls', '.mls_token'),
                 ('nimbus_url', '.nimbus'),


### PR DESCRIPTION
In Fenix, we use Firebase Cloud Messaging for WebPush and Firebase Testlab for UI testing. In Focus, we only use Firebase for testing, so we do not need to include the push keys as a shippable secret.