### PR TITLE
For #5753: Migrate etp exceptions telemetry.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1075,3 +1075,49 @@ custom_tabs_toolbar:
     notification_emails:
       - android-probes@mozilla.com
     expires: "2022-11-01"
+
+tracking_protection_exceptions:
+  allow_list_opened:
+    type: event
+    description: The user has opened the exceptions list.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5753
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/?
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+  allow_list_cleared:
+    type: event
+    description: The user has removed all items from exceptions list.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5753
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5758
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      list_size:
+        description: The number of exceptions in the list.
+        type: quantity
+  selected_items_removed:
+    type: event
+    description: The user has removed the selected items from exceptions list.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5753
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5758
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      list_size:
+        description: The number of selected items removed.
+        type: quantity

--- a/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsListFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsListFragment.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionException
+import org.mozilla.focus.GleanMetrics.TrackingProtectionExceptions
 import org.mozilla.focus.R
 import org.mozilla.focus.autocomplete.AutocompleteDomainFormatter
 import org.mozilla.focus.ext.components
@@ -35,7 +36,6 @@ import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.settings.BaseSettingsLikeFragment
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
-import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.ViewUtils
 import java.util.Collections
 import kotlin.coroutines.CoroutineContext
@@ -123,9 +123,10 @@ open class ExceptionsListFragment : BaseSettingsLikeFragment(), CoroutineScope {
         removeAllExceptions.setOnClickListener {
             requireComponents.trackingProtectionUseCases.removeAllExceptions()
 
-            val exceptions = (exceptionList.adapter as DomainListAdapter).selection()
-            TelemetryWrapper.removeAllExceptionDomains(exceptions.count())
-
+            val exceptionsListSize = (exceptionList.adapter as DomainListAdapter).itemCount
+            TrackingProtectionExceptions.allowListCleared.record(
+                TrackingProtectionExceptions.AllowListClearedExtra(exceptionsListSize)
+            )
             requireComponents.appStore.dispatch(
                 AppAction.NavigateUp(
                     requireComponents.store.state.selectedTabId

--- a/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsRemoveFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsRemoveFragment.kt
@@ -11,11 +11,11 @@ import android.view.MenuItem
 import kotlinx.android.synthetic.main.fragment_exceptions_domains.*
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.launch
+import org.mozilla.focus.GleanMetrics.TrackingProtectionExceptions
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.state.AppAction
-import org.mozilla.focus.telemetry.TelemetryWrapper
 import kotlin.collections.forEach as withEach
 
 class ExceptionsRemoveFragment : ExceptionsListFragment() {
@@ -34,7 +34,10 @@ class ExceptionsRemoveFragment : ExceptionsListFragment() {
 
     private fun removeSelectedDomains(context: Context) {
         val exceptions = (exceptionList.adapter as DomainListAdapter).selection()
-        TelemetryWrapper.removeExceptionDomains(exceptions.size)
+        TrackingProtectionExceptions.selectedItemsRemoved.record(
+            TrackingProtectionExceptions.SelectedItemsRemovedExtra(exceptions.size)
+        )
+
         if (exceptions.isNotEmpty()) {
             launch(Main) {
 

--- a/app/src/main/java/org/mozilla/focus/settings/privacy/PrivacySecuritySettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/privacy/PrivacySecuritySettingsFragment.kt
@@ -9,6 +9,8 @@ import android.os.Build
 import android.os.Bundle
 import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
+import mozilla.components.service.glean.private.NoExtras
+import org.mozilla.focus.GleanMetrics.TrackingProtectionExceptions
 import org.mozilla.focus.R
 import org.mozilla.focus.biometrics.Biometrics
 import org.mozilla.focus.engine.EngineSharedPreferencesListener
@@ -116,7 +118,7 @@ class PrivacySecuritySettingsFragment :
         val engineSharedPreferencesListener = EngineSharedPreferencesListener(requireContext())
         when (preference.key) {
             resources.getString(R.string.pref_key_screen_exceptions) -> {
-                TelemetryWrapper.openExceptionsListSetting()
+                TrackingProtectionExceptions.allowListOpened.record(NoExtras())
                 requireComponents.appStore.dispatch(
                     AppAction.OpenSettings(page = Screen.Settings.Page.PrivacyExceptions)
                 )

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -96,7 +96,6 @@ object TelemetryWrapper {
         val HIDE = "hide"
         val SHARE_INTENT = "share_intent"
         val REMOVE = "remove"
-        val REMOVE_ALL = "remove_all"
         val REORDER = "reorder"
         val PAGE = "page"
         val RESOURCE = "resource"
@@ -125,7 +124,6 @@ object TelemetryWrapper {
         val SEARCH_SUGGESTION_PROMPT = "search_suggestion_prompt"
         val MAKE_DEFAULT_BROWSER_OPEN_WITH = "make_default_browser_open_with"
         val MAKE_DEFAULT_BROWSER_SETTINGS = "make_default_browser_settings"
-        val ALLOWLIST = "allowlist"
     }
 
     private object Value {
@@ -553,23 +551,6 @@ object TelemetryWrapper {
             Object.BLOCKING_SWITCH,
             isBlockingEnabled.toString()
         ).queue()
-    }
-
-    @JvmStatic
-    fun openExceptionsListSetting() {
-        TelemetryEvent.create(Category.ACTION, Method.OPEN, Object.ALLOWLIST).queue()
-    }
-
-    fun removeExceptionDomains(count: Int) {
-        TelemetryEvent.create(Category.ACTION, Method.REMOVE, Object.ALLOWLIST)
-            .extra(Extra.TOTAL, count.toString())
-            .queue()
-    }
-
-    fun removeAllExceptionDomains(count: Int) {
-        TelemetryEvent.create(Category.ACTION, Method.REMOVE_ALL, Object.ALLOWLIST)
-            .extra(Extra.TOTAL, count.toString())
-            .queue()
     }
 
     @JvmStatic


### PR DESCRIPTION
# Request for data collection review form

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

_1) What questions will you answer with this data?_
Are users removing etp exceptions from the execeptions list?

_2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?_
This is needed to analyze feature usage and possible feature improvements.

_3) What alternative methods did you consider to answer these questions? Why were they not sufficient?_
This is the only way.

_4) Can current instrumentation answer these questions?_
No. We need a new specific event for a specific app feature.

_5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki._

_**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**_

<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
    <td>Tracking Bug #</td>
  </tr>
  <tr>
    <td>Exceptions list displayed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5753 </td>
  <tr>
    <td>All items removed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5753 </td>
  </tr>

  <tr>
    <td>Selected items removed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5753 </td>
  </tr>
 
</table>

_6) How long will this data be collected?  Choose one of the following:_
    Expiry for capturing data is set to "2022-11-01"

_7) What populations will you measure?_
All release channels and locales.

_8) If this data collection is default on, what is the opt-out mechanism for users?_
 Users can opt out of data collection by disabling Usage and technical data from Settings -> Privacy and security -> Data choices.

_9) Please provide a general description of how you will analyze this data._
 Glean 

_10) Where do you intend to share the results of your analysis?_
Only on Glean, mobile teams, and BD have internal access.

_12) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection?_
No.
