### PR TITLE
For #5651: Migrate notification and launcher icon shortcuts telemetry.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1121,3 +1121,93 @@ tracking_protection_exceptions:
       list_size:
         description: The number of selected items removed.
         type: quantity
+
+notifications:
+  open_button_tapped:
+    type: event
+    description: The user has tapped the Open option button from notification.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5651
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/?
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+  erase_open_button_tapped:
+    type: event
+    description: The user has tapped the Erase & Open button from notification.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5651
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/?
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      opened_tabs:
+        description: Number of currently opened tabs
+        type: quantity
+  notification_tapped:
+    type: event
+    description: The user has tapped the notification to close the app.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5651
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/?
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+
+app_shortcuts:
+  just_erase_button_tapped:
+    type: event
+    description: The user has tapped the Erase option button from shortcuts.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5651
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/?
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      opened_tabs:
+        description: Number of currently opened tabs
+        type: quantity
+  erase_open_button_tapped:
+    type: event
+    description: The user has tapped the Erase & Open button from shortcuts.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5651
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/?
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      opened_tabs:
+        description: Number of currently opened tabs
+        type: quantity
+
+recent_apps:
+  app_removed_from_list:
+    type: event
+    description: The user removed the apps from recent apps screen.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5651
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/?
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"

--- a/app/src/main/java/org/mozilla/focus/activity/EraseAndOpenShortcutActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/EraseAndOpenShortcutActivity.kt
@@ -7,8 +7,9 @@ package org.mozilla.focus.activity
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import mozilla.components.browser.state.selector.privateTabs
+import org.mozilla.focus.GleanMetrics.AppShortcuts
 import org.mozilla.focus.ext.components
-import org.mozilla.focus.telemetry.TelemetryWrapper
 
 class EraseAndOpenShortcutActivity : Activity() {
 
@@ -17,7 +18,8 @@ class EraseAndOpenShortcutActivity : Activity() {
 
         components.tabsUseCases.removeAllTabs()
 
-        TelemetryWrapper.eraseAndOpenShortcutEvent()
+        val tabCount = components.store.state.privateTabs.size
+        AppShortcuts.eraseOpenButtonTapped.record(AppShortcuts.EraseOpenButtonTappedExtra(tabCount))
 
         val intent = Intent(this, MainActivity::class.java)
         intent.action = MainActivity.ACTION_OPEN

--- a/app/src/main/java/org/mozilla/focus/activity/EraseShortcutActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/EraseShortcutActivity.kt
@@ -5,8 +5,9 @@ package org.mozilla.focus.activity
 
 import android.app.Activity
 import android.os.Bundle
+import mozilla.components.browser.state.selector.privateTabs
+import org.mozilla.focus.GleanMetrics.AppShortcuts
 import org.mozilla.focus.ext.components
-import org.mozilla.focus.telemetry.TelemetryWrapper
 
 class EraseShortcutActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -14,7 +15,8 @@ class EraseShortcutActivity : Activity() {
 
         components.tabsUseCases.removeAllTabs()
 
-        TelemetryWrapper.eraseShortcutEvent()
+        val tabCount = components.store.state.privateTabs.size
+        AppShortcuts.justEraseButtonTapped.record(AppShortcuts.JustEraseButtonTappedExtra(tabCount))
 
         finishAndRemoveTask()
     }

--- a/app/src/main/java/org/mozilla/focus/session/SessionNotificationService.kt
+++ b/app/src/main/java/org/mozilla/focus/session/SessionNotificationService.kt
@@ -15,11 +15,13 @@ import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
+import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.utils.ThreadUtils
+import org.mozilla.focus.GleanMetrics.Notifications
+import org.mozilla.focus.GleanMetrics.RecentApps
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.MainActivity
 import org.mozilla.focus.ext.components
-import org.mozilla.focus.telemetry.TelemetryWrapper
 
 /**
  * As long as a session is active this service will keep the notification (and our process) alive.
@@ -38,7 +40,7 @@ class SessionNotificationService : Service() {
             }
 
             ACTION_ERASE -> {
-                TelemetryWrapper.eraseNotificationEvent()
+                Notifications.notificationTapped.record(NoExtras())
                 shouldSendTaskRemovedTelemetry = false
 
                 if (VisibilityLifeCycleCallback.isInBackground(this)) {
@@ -47,7 +49,6 @@ class SessionNotificationService : Service() {
                     val eraseIntent = Intent(this, MainActivity::class.java)
 
                     eraseIntent.action = MainActivity.ACTION_ERASE
-                    eraseIntent.putExtra(MainActivity.EXTRA_NOTIFICATION, true)
                     eraseIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
 
                     startActivity(eraseIntent)
@@ -63,7 +64,7 @@ class SessionNotificationService : Service() {
     override fun onTaskRemoved(rootIntent: Intent) {
         // Do not double send telemetry for notification erase event
         if (shouldSendTaskRemovedTelemetry) {
-            TelemetryWrapper.eraseTaskRemoved()
+            RecentApps.appRemovedFromList.record(NoExtras())
         }
 
         components.tabsUseCases.removeAllTabs()

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -103,20 +103,15 @@ object TelemetryWrapper {
 
     private object Object {
         val SEARCH_BAR = "search_bar"
-        val ERASE_BUTTON = "erase_button"
         val SETTING = "setting"
         val APP = "app"
         val MENU = "menu"
         val BACK_BUTTON = "back_button"
-        val NOTIFICATION = "notification"
-        val NOTIFICATION_ACTION = "notification_action"
-        val SHORTCUT = "shortcut"
         val BLOCKING_SWITCH = "blocking_switch"
         val BROWSER = "browser"
         val BROWSER_CONTEXTMENU = "browser_contextmenu"
         val FIRSTRUN = "firstrun"
         val HOMESCREEN_SHORTCUT = "homescreen_shortcut"
-        val RECENT_APPS = "recent_apps"
         val APP_ICON = "app_icon"
         val AUTOCOMPLETE_DOMAIN = "autocomplete_domain"
         val AUTOFILL = "autofill"
@@ -130,8 +125,6 @@ object TelemetryWrapper {
         val DEFAULT = "default"
         val FIREFOX = "firefox"
         val SELECTION = "selection"
-        val ERASE = "erase"
-        val ERASE_AND_OPEN = "erase_open"
         val ERASE_TO_HOME = "erase_home"
         val ERASE_TO_APP = "erase_app"
         val IMAGE = "image"
@@ -443,49 +436,8 @@ object TelemetryWrapper {
     }
 
     @JvmStatic
-    fun eraseNotificationEvent() {
-        withSessionCounts(TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.NOTIFICATION, Value.ERASE))
-            .queue()
-    }
-
-    @JvmStatic
-    fun eraseAndOpenNotificationActionEvent() {
-        withSessionCounts(
-            TelemetryEvent.create(
-                Category.ACTION,
-                Method.CLICK,
-                Object.NOTIFICATION_ACTION,
-                Value.ERASE_AND_OPEN
-            )
-        ).queue()
-    }
-
-    @JvmStatic
-    fun openNotificationActionEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.NOTIFICATION_ACTION, Value.OPEN).queue()
-    }
-
-    @JvmStatic
     fun openHomescreenShortcutEvent() {
         TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.HOMESCREEN_SHORTCUT, Value.OPEN).queue()
-    }
-
-    @JvmStatic
-    fun eraseShortcutEvent() {
-        withSessionCounts(TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.SHORTCUT, Value.ERASE))
-            .queue()
-    }
-
-    @JvmStatic
-    fun eraseAndOpenShortcutEvent() {
-        withSessionCounts(TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.SHORTCUT, Value.ERASE_AND_OPEN))
-            .queue()
-    }
-
-    @JvmStatic
-    fun eraseTaskRemoved() {
-        withSessionCounts(TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.RECENT_APPS, Value.ERASE))
-            .queue()
     }
 
     @JvmStatic


### PR DESCRIPTION
# Request for data collection review form

**All questions are mandatory. You must receive a review from a data steward peer on your responses to these questions before shipping new data collection.**

_1) What questions will you answer with this data?_
How are users interacting with Focus notification and if they are using launcher icon shortcuts?

_2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?_
This is needed to analyze feature usage and possible feature improvements.

_3) What alternative methods did you consider to answer these questions? Why were they not sufficient?_
This is the only way.

_4) Can current instrumentation answer these questions?_
No. We need a new specific event for a specific app feature.

_5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki._

_**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**_

<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
    <td>Tracking Bug #</td>
  </tr>
  <tr>
    <td>Open button from notification was tapped</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5651 </td>
  <tr>
    <td>Erase & Open button from notification was tapped</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5651 </td>
  </tr>

  <tr>
    <td>Notification was tapped</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5651 </td>
  </tr>
  <tr>
    <td>Erase & Open button from shortcuts was tapped</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5651 </td>
  </tr>
  <tr>
    <td>Erase button from shortcuts was tapped</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5651 </td>
  </tr>

  <tr>
    <td>App closed from recent apps</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5651 </td>
  </tr>
 
</table>

_6) How long will this data be collected?  Choose one of the following:_
    Expiry for capturing data is set to "2022-11-01"

_7) What populations will you measure?_
All release channels and locales.

_8) If this data collection is default on, what is the opt-out mechanism for users?_
 Users can opt out of data collection by disabling Usage and technical data from Settings -> Privacy and security -> Data choices.

_9) Please provide a general description of how you will analyze this data._
 Glean 

_10) Where do you intend to share the results of your analysis?_
Only on Glean, mobile teams, and BD have internal access.

_12) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection?_
No.
