### PR TITLE
For #5647: Migrate context menu telemetry

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1211,3 +1211,24 @@ recent_apps:
     notification_emails:
       - android-probes@mozilla.com
     expires: "2022-11-01"
+
+context_menu:
+  item_tapped:
+    type: event
+    description: The user has tapped an option from context menu.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5647
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5773
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      item_name:
+        description: |
+          The name of the item that was tapped. One of the following:
+          open_in_new_tab, open_in_private_tab, open_image_in_new_tab,
+          save_image, share_link, copy_link, copy_image_location, share_image
+        type: string

--- a/app/src/main/java/org/mozilla/focus/telemetry/FactsProcessor.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/FactsProcessor.kt
@@ -5,6 +5,7 @@
 package org.mozilla.focus.telemetry
 
 import androidx.annotation.VisibleForTesting
+import mozilla.components.feature.contextmenu.facts.ContextMenuFacts
 import mozilla.components.feature.customtabs.CustomTabsFacts
 import mozilla.components.feature.search.telemetry.ads.AdsTelemetry
 import mozilla.components.feature.search.telemetry.incontent.InContentTelemetry
@@ -13,6 +14,7 @@ import mozilla.components.support.base.Component
 import mozilla.components.support.base.facts.Fact
 import mozilla.components.support.base.facts.FactProcessor
 import mozilla.components.support.base.facts.Facts
+import org.mozilla.focus.GleanMetrics.ContextMenu
 import org.mozilla.focus.GleanMetrics.CustomTabsToolbar
 
 /**
@@ -47,6 +49,20 @@ object FactsProcessor {
         Component.FEATURE_CUSTOMTABS to CustomTabsFacts.Items.ACTION_BUTTON -> {
             CustomTabsToolbar.actionButtonTapped.record(NoExtras())
         }
+        Component.FEATURE_CONTEXTMENU to ContextMenuFacts.Items.ITEM -> {
+            ContextMenu.itemTapped.record(ContextMenu.ItemTappedExtra(this.toContextMenuExtraKey()))
+        }
+
         else -> Unit
     }
 }
+
+/**
+ * Extracts an extraKey from a context menu Fact.
+ */
+fun Fact.toContextMenuExtraKey() =
+    if (this.component == Component.FEATURE_CONTEXTMENU) {
+        this.metadata?.get("item").toString().removePrefix("mozac.feature.contextmenu.")
+    } else {
+        throw IllegalArgumentException("Fact is not a context menu fact")
+    }

--- a/app/src/main/java/org/mozilla/focus/telemetry/FactsProcessor.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/FactsProcessor.kt
@@ -5,12 +5,15 @@
 package org.mozilla.focus.telemetry
 
 import androidx.annotation.VisibleForTesting
+import mozilla.components.feature.customtabs.CustomTabsFacts
 import mozilla.components.feature.search.telemetry.ads.AdsTelemetry
 import mozilla.components.feature.search.telemetry.incontent.InContentTelemetry
+import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.base.Component
 import mozilla.components.support.base.facts.Fact
 import mozilla.components.support.base.facts.FactProcessor
 import mozilla.components.support.base.facts.Facts
+import org.mozilla.focus.GleanMetrics.CustomTabsToolbar
 
 /**
  * Processes all [Fact]s emitted from Android Components based on which the appropriate telemetry
@@ -35,6 +38,14 @@ object FactsProcessor {
         }
         Component.FEATURE_SEARCH to InContentTelemetry.IN_CONTENT_SEARCH -> {
             TelemetryWrapper.inContentSearchEvent(value!!)
+        }
+
+        Component.FEATURE_CUSTOMTABS to CustomTabsFacts.Items.CLOSE -> {
+            CustomTabsToolbar.closeTabTapped.record(NoExtras())
+        }
+
+        Component.FEATURE_CUSTOMTABS to CustomTabsFacts.Items.ACTION_BUTTON -> {
+            CustomTabsToolbar.actionButtonTapped.record(NoExtras())
         }
         else -> Unit
     }

--- a/app/src/main/java/org/mozilla/focus/telemetry/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/GleanMetricsService.kt
@@ -15,20 +15,13 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
-import mozilla.components.feature.customtabs.CustomTabsFacts
 import mozilla.components.feature.search.ext.waitForSelectedOrDefaultSearchEngine
 import mozilla.components.service.glean.net.ConceptFetchHttpUploader
-import mozilla.components.service.glean.private.NoExtras
-import mozilla.components.support.base.Component
-import mozilla.components.support.base.facts.Fact
-import mozilla.components.support.base.facts.FactProcessor
-import mozilla.components.support.base.facts.Facts
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.config.Configuration
 import org.mozilla.focus.BuildConfig
 import org.mozilla.focus.Components
 import org.mozilla.focus.GleanMetrics.Browser
-import org.mozilla.focus.GleanMetrics.CustomTabsToolbar
 import org.mozilla.focus.GleanMetrics.GleanBuildInfo
 import org.mozilla.focus.GleanMetrics.LegacyIds
 import org.mozilla.focus.GleanMetrics.MozillaProducts
@@ -96,21 +89,6 @@ class GleanMetricsService(context: Context) : MetricsService {
                 // activationPing.checkAndSend()
             }
         }
-
-        Facts.registerProcessor(object : FactProcessor {
-            override fun process(fact: Fact) {
-                fact.recordTelemetry()
-            }
-        }
-        )
-    }
-
-    private fun Fact.recordTelemetry() = when {
-        Component.FEATURE_CUSTOMTABS == component && CustomTabsFacts.Items.CLOSE == item ->
-            CustomTabsToolbar.closeTabTapped.record(NoExtras())
-        Component.FEATURE_CUSTOMTABS == component && CustomTabsFacts.Items.ACTION_BUTTON == item ->
-            CustomTabsToolbar.actionButtonTapped.record(NoExtras())
-        else -> null
     }
 
     private fun collectPrefMetrics(

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -84,9 +84,7 @@ object TelemetryWrapper {
         val CHANGE = "change"
         val FOREGROUND = "foreground"
         val BACKGROUND = "background"
-        val SHARE = "share"
         val SAVE = "save"
-        val COPY = "copy"
         val OPEN = "open"
         val INSTALL = "install"
         val INTENT_URL = "intent_url"
@@ -109,7 +107,6 @@ object TelemetryWrapper {
         val BACK_BUTTON = "back_button"
         val BLOCKING_SWITCH = "blocking_switch"
         val BROWSER = "browser"
-        val BROWSER_CONTEXTMENU = "browser_contextmenu"
         val FIRSTRUN = "firstrun"
         val HOMESCREEN_SHORTCUT = "homescreen_shortcut"
         val APP_ICON = "app_icon"
@@ -127,9 +124,6 @@ object TelemetryWrapper {
         val SELECTION = "selection"
         val ERASE_TO_HOME = "erase_home"
         val ERASE_TO_APP = "erase_app"
-        val IMAGE = "image"
-        val LINK = "link"
-        val IMAGE_WITH_LINK = "image+link"
         val SKIP = "skip"
         val FINISH = "finish"
         val OPEN = "open"
@@ -160,14 +154,6 @@ object TelemetryWrapper {
         val SEARCH_SUGGESTION = "search_suggestion"
         val TOTAL_URI_COUNT = "total_uri_count"
         val UNIQUE_DOMAINS_COUNT = "unique_domains_count"
-    }
-
-    enum class BrowserContextMenuValue(val value: String) {
-        Link(Value.LINK),
-        Image(Value.IMAGE),
-        ImageWithLink(Value.IMAGE_WITH_LINK);
-
-        override fun toString(): String = value
     }
 
     @JvmStatic
@@ -445,54 +431,6 @@ object TelemetryWrapper {
         TelemetryEvent.create(Category.ACTION, Method.CHANGE, Object.SETTING, key)
             .extra(Extra.TO, value)
             .queue()
-    }
-
-    @JvmStatic
-    fun shareLinkEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.SHARE, Object.BROWSER_CONTEXTMENU, Value.LINK).queue()
-    }
-
-    @JvmStatic
-    fun shareImageEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.SHARE, Object.BROWSER_CONTEXTMENU, Value.IMAGE).queue()
-    }
-
-    @JvmStatic
-    fun saveImageEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.SAVE, Object.BROWSER_CONTEXTMENU, Value.IMAGE).queue()
-    }
-
-    @JvmStatic
-    fun copyLinkEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.COPY, Object.BROWSER_CONTEXTMENU, Value.LINK).queue()
-    }
-
-    @JvmStatic
-    fun copyImageEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.COPY, Object.BROWSER_CONTEXTMENU, Value.IMAGE).queue()
-    }
-
-    @JvmStatic
-    fun openLinkInFullBrowserFromCustomTabEvent() {
-        withSessionCounts(
-            TelemetryEvent.create(
-                Category.ACTION,
-                Method.OPEN,
-                Object.BROWSER_CONTEXTMENU,
-                Value.FULL_BROWSER
-            )
-        )
-            .queue()
-    }
-
-    @JvmStatic
-    fun openWebContextMenuEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.LONG_PRESS, Object.BROWSER).queue()
-    }
-
-    @JvmStatic
-    fun cancelWebContextMenuEvent(value: BrowserContextMenuValue) {
-        TelemetryEvent.create(Category.ACTION, Method.CANCEL, Object.BROWSER_CONTEXTMENU, value.toString()).queue()
     }
 
     @JvmStatic


### PR DESCRIPTION
# Request for data collection review form

**All questions are mandatory. You must receive a review from a data steward peer on your responses to these questions before shipping new data collection.**

_1) What questions will you answer with this data?_
How is the context menu used?

_2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?_
This is needed to analyze feature usage and possible feature improvements.

_3) What alternative methods did you consider to answer these questions? Why were they not sufficient?_
This is the only way.

_4) Can current instrumentation answer these questions?_
No. We need a new specific event for a specific app feature.

_5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki._

_**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**_

<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
    <td>Tracking Bug #</td>
  </tr>
  <tr>
    <td>Context menu option was tapped</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5647 </td>
   </tr>
</table>

_6) How long will this data be collected?  Choose one of the following:_
    Expiry for capturing data is set to "2022-11-01"

_7) What populations will you measure?_
All release channels and locales.

_8) If this data collection is default on, what is the opt-out mechanism for users?_
 Users can opt out of data collection by disabling Usage and technical data from Settings -> Privacy and security -> Data choices.

_9) Please provide a general description of how you will analyze this data._
 Glean 

_10) Where do you intend to share the results of your analysis?_
Only on Glean, mobile teams, and BD have internal access.

_12) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection?_
No.
