### PR TITLE
Close #5781: Provide RustHttpConfig with a client

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -243,6 +243,8 @@ dependencies {
 
     implementation "org.mozilla.components:support-ktx:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:support-utils:${AndroidComponents.VERSION}"
+    implementation "org.mozilla.components:support-rusthttp:${AndroidComponents.VERSION}"
+    implementation "org.mozilla.components:support-rustlog:${AndroidComponents.VERSION}"
 
     implementation "org.mozilla.components:ui-autocomplete:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:ui-colors:${AndroidComponents.VERSION}"

--- a/app/src/main/java/org/mozilla/focus/experiments/NimbusSetup.kt
+++ b/app/src/main/java/org/mozilla/focus/experiments/NimbusSetup.kt
@@ -55,7 +55,7 @@ fun createNimbus(context: Context, url: String?): NimbusApi =
             serverSettings,
             { message, throwable ->
                 crashReporter.submitCaughtException(throwable)
-                Logger.error("Nimubs error: $message")
+                Logger.error("Nimbus error: $message", throwable)
             }
         ).apply {
             // This performs the minimal amount of work required to load branch and enrolment data


### PR DESCRIPTION
- I was able to reproduce the error locally and after passing in the client, I was seeing Nimbus hit the experiments server.
- We need to unwrap the client because Nimbus makes non-private connections and there isn't a way to configure this. It'll probably be an issue with any other native components we use as well, so we need to consider that if/when we add new ones.
- I recommend uplifting this to beta because it has a direct impact to the A/A experiment we're running there.