### PR TITLE
For UI tests: Fix hardcoded app name in selectors

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsGeneralMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsGeneralMenuRobot.kt
@@ -85,7 +85,7 @@ class SettingsGeneralMenuRobot {
     }
 }
 
-private val defaultBrowserSwitch = onView(withText("Make Firefox Focus default browser"))
+private val defaultBrowserSwitch = onView(withText("Make $appName default browser"))
 
 private val openWithDialogTitle = mDevice.findObject(
     UiSelector()

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsMozillaMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsMozillaMenuRobot.kt
@@ -14,6 +14,7 @@ import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import junit.framework.TestCase.assertTrue
 import org.mozilla.focus.helpers.TestHelper
+import org.mozilla.focus.helpers.TestHelper.appName
 import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 import org.mozilla.focus.helpers.TestHelper.webPageLoadwaitingTime
@@ -115,7 +116,7 @@ private val mozillaSettingsList =
 
 private val showTipsSwitch = onView(withText("Show home screen tips"))
 
-private val aboutFocusPageLink = onView(withText("About Firefox Focus"))
+private val aboutFocusPageLink = onView(withText("About $appName"))
 
 private val helpPageLink = onView(withText("Help"))
 


### PR DESCRIPTION
For #5789, #5788, #5790, #5787 tests failing on nightly & beta builds.