### PR TITLE
For #5785: Add telemetry for tabs count on app backgrounded.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -663,6 +663,23 @@ tab_count:
         description: |
           Tab opened from "custom tab", "context menu" or from "Window.open()"
         type: string
+  app_backgrounded:
+    type: custom_distribution
+    description: Number of opened tabs when the app has been send to background.
+    range_min: 0
+    range_max: 50
+    bucket_count: 51
+    histogram_type: linear
+    unit: tabs
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5583
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5793
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
 
 search_bar:
   entered_url:

--- a/app/src/main/java/org/mozilla/focus/biometrics/LockObserver.kt
+++ b/app/src/main/java/org/mozilla/focus/biometrics/LockObserver.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import mozilla.components.browser.state.selector.privateTabs
 import mozilla.components.browser.state.store.BrowserStore
+import org.mozilla.focus.GleanMetrics.TabCount
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.AppStore
 
@@ -20,7 +21,11 @@ class LockObserver(
 ) : LifecycleObserver {
     @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
     fun onPause() {
-        if (browserStore.state.privateTabs.isEmpty()) {
+
+        val tabCount = browserStore.state.privateTabs.size.toLong()
+        TabCount.appBackgrounded.accumulateSamples(longArrayOf(tabCount))
+
+        if (tabCount == 0L) {
             return
         }
 


### PR DESCRIPTION
# Request for data collection review form

**All questions are mandatory. You must receive a review from a data steward peer on your responses to these questions before shipping new data collection.**

_1) What questions will you answer with this data?_
How many users are using multitabs and how.

_2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?_
This is needed to analyze feature usage and possible feature improvements or feature elimination.

_3) What alternative methods did you consider to answer these questions? Why were they not sufficient?_
This is the only way.

_4) Can current instrumentation answer these questions?_
No. We need a new specific event for a specific app feature.

_5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki._

_**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**_

<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
    <td>Tracking Bug #</td>
  </tr>
  <tr>
    <td>App was sent to background</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5785 </td>
   </tr>
</table>

_6) How long will this data be collected?  Choose one of the following:_
    Expiry for capturing data is set to "2022-11-01"

_7) What populations will you measure?_
All release channels and locales.

_8) If this data collection is default on, what is the opt-out mechanism for users?_
 Users can opt out of data collection by disabling Usage and technical data from Settings -> Privacy and security -> Data choices.

_9) Please provide a general description of how you will analyze this data._
 Glean 

_10) Where do you intend to share the results of your analysis?_
Only on Glean, mobile teams, and BD have internal access.

_12) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection?_
No.
