### PR TITLE
Block autoplayAudible videos

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -231,7 +231,7 @@ dependencies {
     implementation "org.mozilla.components:feature-tabs:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:feature-toolbar:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:feature-top-sites:${AndroidComponents.VERSION}"
-
+    implementation "org.mozilla.components:feature-sitepermissions:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:lib-crash:${AndroidComponents.VERSION}"
     implementation "org.mozilla.components:lib-state:${AndroidComponents.VERSION}"
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -44,6 +44,8 @@ import mozilla.components.feature.downloads.manager.FetchDownloadManager
 import mozilla.components.feature.downloads.share.ShareDownloadFeature
 import mozilla.components.feature.prompts.PromptFeature
 import mozilla.components.feature.session.SessionFeature
+import mozilla.components.feature.sitepermissions.SitePermissionsFeature
+import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.feature.tabs.WindowFeature
 import mozilla.components.feature.top.sites.TopSitesConfig
 import mozilla.components.feature.top.sites.TopSitesFeature
@@ -120,6 +122,7 @@ class BrowserFragment :
     private val windowFeature = ViewBoundFeatureWrapper<WindowFeature>()
     private val appLinksFeature = ViewBoundFeatureWrapper<AppLinksFeature>()
     private val topSitesFeature = ViewBoundFeatureWrapper<TopSitesFeature>()
+    private var sitePermissionsFeature = ViewBoundFeatureWrapper<SitePermissionsFeature>()
 
     private val toolbarIntegration = ViewBoundFeatureWrapper<BrowserToolbarIntegration>()
 
@@ -331,6 +334,39 @@ class BrowserFragment :
                 view = view
             )
         }
+
+        setSitePermissions(view)
+    }
+
+    private fun setSitePermissions(rootView: View) {
+        val sitePermissionsRules = SitePermissionsRules(
+            notification = SitePermissionsRules.Action.BLOCKED,
+            microphone = SitePermissionsRules.Action.BLOCKED,
+            location = SitePermissionsRules.Action.BLOCKED,
+            camera = SitePermissionsRules.Action.BLOCKED,
+            autoplayAudible = SitePermissionsRules.AutoplayAction.BLOCKED,
+            autoplayInaudible = SitePermissionsRules.AutoplayAction.ALLOWED,
+            persistentStorage = SitePermissionsRules.Action.BLOCKED,
+            mediaKeySystemAccess = SitePermissionsRules.Action.BLOCKED
+        )
+        sitePermissionsFeature.set(
+            feature = SitePermissionsFeature(
+                context = requireContext(),
+                fragmentManager = parentFragmentManager,
+                onNeedToRequestPermissions = {
+                    // This it will be always empty because we are not asking for user input
+                },
+                onShouldShowRequestPermissionRationale = {
+                    // Since we don't request permissions this it will not be called
+                    false
+                },
+                sitePermissionsRules = sitePermissionsRules,
+                sessionId = tabId,
+                store = requireComponents.store
+            ),
+            owner = this,
+            view = rootView
+        )
     }
 
     override fun onAccessibilityStateChanged(enabled: Boolean) = when (enabled) {


### PR DESCRIPTION
For #5743
Implement a global value for autoplayAudible permission using SitePermissionsFeature, in this manner we can control how it should behave globally by default on each page