### PR TITLE
Add new Nightly/Beta Flank config

### DIFF
--- a/automation/taskcluster/androidTest/flank-x86-beta.yml
+++ b/automation/taskcluster/androidTest/flank-x86-beta.yml
@@ -1,0 +1,65 @@
+# gcloud args match the official gcloud cli
+# https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
+gcloud:
+  results-bucket: focus_android_test_artifacts
+  record-video: true
+
+  # The maximum possible testing time is 30m on physical devices and 60m on virtual devices.
+  timeout: 30m
+  # will start test then close socket. no reports will be generated.
+  # to retrieve results later, use the "refresh" command
+  # reports will be generated from /results/matrix_ids.json
+  #async: true 
+  # will start test then leave socket open. reports will be published
+  # to /results
+  # see: https://github.com/TestArmada/flank/issues/339
+  async: false
+
+  # results-history-name
+  # by default, set to app name
+  # declare results-history-name to create a separate dropdown menu in Firebase 
+  # see: https://github.com/TestArmada/flank/issues/341
+  #results-history-name: tmp_parallel 
+
+  # The number of times a test execution should be re-attempted if one or more failures occur.
+  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
+  num-flaky-test-attempts: 1
+
+  # test and app are the only required args
+  app: /app/path 
+  test: /test/path
+
+  auto-google-login: true
+  use-orchestrator: true
+  environment-variables:
+    clearPackageData: true
+  directories-to-pull:
+    - /sdcard/screenshots
+  performance-metrics: true
+
+  test-targets:
+    - package org.mozilla.focus.activity
+    - package org.mozilla.focus.privacy
+  
+  device:
+   - model: Pixel2
+     version: 28
+
+flank:
+  project: GOOGLE_PROJECT
+  # test shards - the amount of groups to split the test suite into
+  # set to -1 to use one shard per test. default: 1
+  max-test-shards: -1
+  # num-test-runs: the amount of times to run the tests.
+  # 1 runs the tests once. 10 runs all the tests 10x
+  num-test-runs: 1
+  ### Output Style flag
+  ## Output style of execution status. May be one of [verbose, multi, single, compact].
+  ## For runs with only one test execution the default value is 'verbose', in other cases
+  ## 'multi' is used as the default. The output style 'multi' is not displayed correctly on consoles
+  ## which don't support ansi codes, to avoid corrupted output use single or verbose.
+  ## The output style `compact` is used to produce less detailed output, it prints just Args, test and matrix count, weblinks, cost, and result reports.
+  output-style: compact
+  ### Full Junit Result flag
+  ## Enable create additional local junit result on local storage with failure nodes on passed flaky tests.
+  full-junit-result: true

--- a/automation/taskcluster/androidTest/flank-x86-beta.yml
+++ b/automation/taskcluster/androidTest/flank-x86-beta.yml
@@ -38,8 +38,8 @@ gcloud:
   performance-metrics: true
 
   test-targets:
-    - package org.mozilla.focus.activity
-    - package org.mozilla.focus.privacy
+    - class org.mozilla.focus.activity.SearchTest#testBlankSearchDoesNothing
+    - class org.mozilla.focus.activity.EraseBrowsingDataTest#deleteHistoryOnRestartTest
   
   device:
    - model: Pixel2

--- a/automation/taskcluster/androidTest/flank-x86-start-test.yml
+++ b/automation/taskcluster/androidTest/flank-x86-start-test.yml
@@ -39,6 +39,7 @@ gcloud:
 
   test-targets:
     - class org.mozilla.focus.activity.SearchTest#testBlankSearchDoesNothing
+    - class org.mozilla.focus.activity.EraseBrowsingDataTest#deleteHistoryOnRestartTest
   
   device:
    - model: Pixel2

--- a/automation/taskcluster/androidTest/flank-x86-start-test.yml
+++ b/automation/taskcluster/androidTest/flank-x86-start-test.yml
@@ -1,0 +1,64 @@
+# gcloud args match the official gcloud cli
+# https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
+gcloud:
+  results-bucket: focus_android_test_artifacts
+  record-video: true
+
+  # The maximum possible testing time is 30m on physical devices and 60m on virtual devices.
+  timeout: 30m
+  # will start test then close socket. no reports will be generated.
+  # to retrieve results later, use the "refresh" command
+  # reports will be generated from /results/matrix_ids.json
+  #async: true 
+  # will start test then leave socket open. reports will be published
+  # to /results
+  # see: https://github.com/TestArmada/flank/issues/339
+  async: false
+
+  # results-history-name
+  # by default, set to app name
+  # declare results-history-name to create a separate dropdown menu in Firebase 
+  # see: https://github.com/TestArmada/flank/issues/341
+  #results-history-name: tmp_parallel 
+
+  # The number of times a test execution should be re-attempted if one or more failures occur.
+  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
+  num-flaky-test-attempts: 1
+
+  # test and app are the only required args
+  app: /app/path 
+  test: /test/path
+
+  auto-google-login: true
+  use-orchestrator: true
+  environment-variables:
+    clearPackageData: true
+  directories-to-pull:
+    - /sdcard/screenshots
+  performance-metrics: true
+
+  test-targets:
+    - class org.mozilla.focus.activity.SearchTest#testBlankSearchDoesNothing
+  
+  device:
+   - model: Pixel2
+     version: 28
+
+flank:
+  project: GOOGLE_PROJECT
+  # test shards - the amount of groups to split the test suite into
+  # set to -1 to use one shard per test. default: 1
+  max-test-shards: -1
+  # num-test-runs: the amount of times to run the tests.
+  # 1 runs the tests once. 10 runs all the tests 10x
+  num-test-runs: 1
+  ### Output Style flag
+  ## Output style of execution status. May be one of [verbose, multi, single, compact].
+  ## For runs with only one test execution the default value is 'verbose', in other cases
+  ## 'multi' is used as the default. The output style 'multi' is not displayed correctly on consoles
+  ## which don't support ansi codes, to avoid corrupted output use single or verbose.
+  ## The output style `compact` is used to produce less detailed output, it prints just Args, test and matrix count, weblinks, cost, and result reports.
+  output-style: compact
+  ### Full Junit Result flag
+  ## Enable create additional local junit result on local storage with failure nodes on passed flaky tests.
+  full-junit-result: true

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -70,7 +70,7 @@ jobs:
             signed-android-test: signing-android-test-nightly
         run:
             commands:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86', 'app.apk', 'android-test.apk', '-1']
+                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86-start-test', 'app.apk', 'android-test.apk', '-1']
         treeherder:
             symbol: nightly(ui-test-x86-nightly)
     x86-beta:
@@ -83,6 +83,6 @@ jobs:
             signed-android-test: signing-android-test-beta
         run:
             commands:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86', 'app.apk', 'android-test.apk', '-1']
+                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86-beta-tests', 'app.apk', 'android-test.apk', '-1']
         treeherder:
             symbol: beta(ui-test-x86-beta)


### PR DESCRIPTION
With the new jobs, we need to create a couple new configs, and just make sure the templates are used in `ui-test.sh`.

(@sv-ohorvath can you identify the smoke-tests we wish to use in the beta configuration?)

For now I just copied over the default `x86` configuration for Beta. For Nightly, I am using your recommended `testBlankSearchDoesNothing` test.

Parameters check for template name here https://github.com/mozilla-mobile/focus-android/blob/main/automation/taskcluster/androidTest/ui-test.sh#L79