### PR TITLE
No issue: Add focus custom typography.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/AboutFragment.kt
@@ -25,10 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.Start
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.Job
 import mozilla.components.browser.state.state.SessionState
 import org.mozilla.focus.R
@@ -36,8 +33,9 @@ import org.mozilla.focus.databinding.FragmentAboutBinding
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.settings.BaseSettingsLikeFragment
 import org.mozilla.focus.state.AppAction
-import org.mozilla.focus.theme.FocusTheme
-import org.mozilla.focus.theme.focusColors
+import org.mozilla.focus.ui.theme.FocusTheme
+import org.mozilla.focus.ui.theme.focusColors
+import org.mozilla.focus.ui.theme.focusTypography
 import org.mozilla.focus.utils.SupportUtils.manifestoURL
 import org.mozilla.geckoview.BuildConfig
 
@@ -148,8 +146,7 @@ private fun VersionInfo(aboutVersion: String) {
     Text(
         text = aboutVersion,
         color = focusColors.aboutPageText,
-        fontSize = 16.sp,
-        lineHeight = 24.sp,
+        style = focusTypography.body1,
         modifier = Modifier
             .padding(10.dp)
     )
@@ -160,8 +157,7 @@ private fun AboutContent(content: String) {
     Text(
         text = content,
         color = focusColors.aboutPageText,
-        fontSize = 16.sp,
-        lineHeight = 24.sp,
+        style = focusTypography.body1,
         modifier = Modifier
             .padding(10.dp)
     )
@@ -175,9 +171,7 @@ fun ColumnScope.LearnMoreLink(
     Text(
         text = learnMore,
         color = focusColors.aboutPageLink,
-        style = TextStyle(textDecoration = TextDecoration.Underline),
-        fontSize = 16.sp,
-        lineHeight = 24.sp,
+        style = focusTypography.links,
         modifier = Modifier
             .padding(10.dp)
             .fillMaxWidth()

--- a/app/src/main/java/org/mozilla/focus/home/HomeScreen.kt
+++ b/app/src/main/java/org/mozilla/focus/home/HomeScreen.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.DelicateCoroutinesApi
 import mozilla.components.lib.state.ext.observeAsComposableState
 import org.mozilla.focus.components
-import org.mozilla.focus.theme.FocusTheme
 import org.mozilla.focus.topsites.TopSites
+import org.mozilla.focus.ui.theme.FocusTheme
 
 /**
  * The home screen.

--- a/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsFragment.kt
@@ -47,9 +47,9 @@ import org.mozilla.focus.R
 import org.mozilla.focus.components
 import org.mozilla.focus.searchsuggestions.SearchSuggestionsViewModel
 import org.mozilla.focus.searchsuggestions.State
-import org.mozilla.focus.theme.FocusTheme
-import org.mozilla.focus.theme.focusColors
 import org.mozilla.focus.topsites.TopSites
+import org.mozilla.focus.ui.theme.FocusTheme
+import org.mozilla.focus.ui.theme.focusColors
 import kotlin.coroutines.CoroutineContext
 
 class SearchSuggestionsFragment : Fragment(), CoroutineScope {

--- a/app/src/main/java/org/mozilla/focus/topsites/TopSites.kt
+++ b/app/src/main/java/org/mozilla/focus/topsites/TopSites.kt
@@ -40,7 +40,7 @@ import mozilla.components.support.ktx.kotlin.getRepresentativeCharacter
 import org.mozilla.focus.GleanMetrics.Shortcuts
 import org.mozilla.focus.R
 import org.mozilla.focus.components
-import org.mozilla.focus.theme.focusColors
+import org.mozilla.focus.ui.theme.focusColors
 
 /**
  * A list of top sites.

--- a/app/src/main/java/org/mozilla/focus/ui/theme/FocusColors.kt
+++ b/app/src/main/java/org/mozilla/focus/ui/theme/FocusColors.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.focus.theme
+package org.mozilla.focus.ui.theme
 
 import androidx.compose.material.Colors
 import androidx.compose.ui.graphics.Color

--- a/app/src/main/java/org/mozilla/focus/ui/theme/FocusTheme.kt
+++ b/app/src/main/java/org/mozilla/focus/ui/theme/FocusTheme.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.focus.theme
+package org.mozilla.focus.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.Colors
@@ -35,6 +35,7 @@ fun FocusTheme(
     CompositionLocalProvider(localColors provides colors) {
         MaterialTheme(
             colors = colors.material,
+            typography = focusTypography.materialTypography,
             content = content,
         )
     }

--- a/app/src/main/java/org/mozilla/focus/ui/theme/FocusTypography.kt
+++ b/app/src/main/java/org/mozilla/focus/ui/theme/FocusTypography.kt
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.ui.theme
+
+import androidx.compose.material.Typography
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.sp
+import org.mozilla.focus.R
+
+val metropolis = FontFamily(
+    Font(R.font.metropolis, FontWeight.Normal),
+    Font(R.font.metropolis_bold, FontWeight.Bold),
+    Font(R.font.metropolis_semibold, FontWeight.SemiBold),
+)
+
+/**
+ * Custom Focus typography, other than baseline Material typography.
+ * Custom text styles should be added with consideration,
+ * only when an existing Material style is not suitable.
+ */
+data class FocusTypography(
+    val materialTypography: Typography,
+    val links: TextStyle
+) {
+    val h1: TextStyle get() = materialTypography.h1
+    val h2: TextStyle get() = materialTypography.h2
+    val h3: TextStyle get() = materialTypography.h3
+    val h4: TextStyle get() = materialTypography.h4
+    val h5: TextStyle get() = materialTypography.h5
+    val h6: TextStyle get() = materialTypography.h6
+    val subtitle1: TextStyle get() = materialTypography.subtitle1
+    val subtitle2: TextStyle get() = materialTypography.subtitle2
+    val body1: TextStyle get() = materialTypography.body1
+    val body2: TextStyle get() = materialTypography.body2
+    val button: TextStyle get() = materialTypography.button
+    val caption: TextStyle get() = materialTypography.caption
+    val overline: TextStyle get() = materialTypography.overline
+}
+
+val focusTypography: FocusTypography
+    @Composable
+    @ReadOnlyComposable
+    get() = FocusTypography(
+        materialTypography = Typography(
+            body1 = TextStyle(
+                fontSize = 16.sp,
+                lineHeight = 24.sp
+            )
+        ),
+        links = TextStyle(
+            fontSize = 16.sp,
+            textDecoration = TextDecoration.Underline,
+            lineHeight = 24.sp
+        ),
+    )


### PR DESCRIPTION
All theme related files were moved in a distinct ui package.

This also adds an example of usage, adding a custom style for links
and an override of body1 material typography.