### PR TITLE
Mergify: Disable fallback for failed rebases

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,6 +27,7 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
+        rebase_fallback: none
   - name: Needs landing - Squash
     conditions:
       - base=main
@@ -37,6 +38,7 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
+        rebase_fallback: none
   - name: Relbot - Auto Merge
     conditions:
       - base=main
@@ -49,3 +51,4 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
+        rebase_fallback: none


### PR DESCRIPTION
With the new `queue` action, when a rebase fails, then by default Mergify will try to merge the PR. To avoid this (and because I think that may fail anyways due to our GitHub protections), let's use "None" which will cause Mergify to post an error. Like it used to do.