### PR TITLE
For #5635: Migrate onboarding related telemetry.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1348,3 +1348,69 @@ context_menu:
           open_in_new_tab, open_in_private_tab, open_image_in_new_tab,
           save_image, share_link, copy_link, copy_image_location, share_image
         type: string
+
+onboarding:
+  page_displayed:
+    type: event
+    description: A page from onboarding has been displayed.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5635
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5869
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      current_item:
+        description: The curent displayed item position.
+        type: quantity
+  skip_button_tapped:
+    type: event
+    description: The user has tapped to skip onboarding.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5635
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5869
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      current_item:
+        description: The curent displayed item position.
+        type: quantity
+  finish_button_tapped:
+    type: event
+    description: The user has tapped to finish onboarding.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5635
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5869
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      current_item:
+        description: The curent displayed item position.
+        type: quantity
+  next_button_tapped:
+    type: event
+    description: The user has tapped next onboarding.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5635
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5869
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      current_item:
+        description: The curent displayed item position.
+        type: quantity

--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
@@ -14,11 +14,11 @@ import androidx.fragment.app.Fragment
 import androidx.preference.PreferenceManager
 import androidx.viewpager.widget.ViewPager
 import com.google.android.material.tabs.TabLayout
+import org.mozilla.focus.GleanMetrics.Onboarding
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.firstrun.FirstrunPagerAdapter
 import org.mozilla.focus.state.AppAction
-import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.StatusBarUtils
 
 class FirstrunFragment : Fragment(), View.OnClickListener {
@@ -36,7 +36,7 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
 
         // We will send a telemetry event whenever a new firstrun page is shown. However this page
         // listener won't fire for the initial page we are showing. So we are going to firing here.
-        TelemetryWrapper.showFirstRunPageEvent(0)
+        Onboarding.pageDisplayed.record(Onboarding.PageDisplayedExtra(0))
     }
 
     @Suppress("MagicNumber")
@@ -59,7 +59,7 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
         viewPager!!.adapter = adapter
         viewPager!!.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
             override fun onPageSelected(position: Int) {
-                TelemetryWrapper.showFirstRunPageEvent(position)
+                Onboarding.pageDisplayed.record(Onboarding.PageDisplayedExtra(0))
 
                 viewPager!!.contentDescription = adapter.getPageAccessibilityDescription(position)
             }
@@ -76,17 +76,21 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
     }
 
     override fun onClick(view: View) {
+        val currentItem = viewPager!!.currentItem
         when (view.id) {
-            R.id.next -> viewPager!!.currentItem = viewPager!!.currentItem + 1
+            R.id.next -> {
+                viewPager!!.currentItem = viewPager!!.currentItem + 1
+                Onboarding.nextButtonTapped.record(Onboarding.NextButtonTappedExtra(currentItem))
+            }
 
             R.id.skip -> {
                 finishFirstrun()
-                TelemetryWrapper.skipFirstRunEvent()
+                Onboarding.skipButtonTapped.record(Onboarding.SkipButtonTappedExtra(currentItem))
             }
 
             R.id.finish -> {
                 finishFirstrun()
-                TelemetryWrapper.finishFirstRunEvent()
+                Onboarding.finishButtonTapped.record(Onboarding.FinishButtonTappedExtra(currentItem))
             }
 
             else -> throw IllegalArgumentException("Unknown view")

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -91,7 +91,6 @@ object TelemetryWrapper {
         val BACK_BUTTON = "back_button"
         val BLOCKING_SWITCH = "blocking_switch"
         val BROWSER = "browser"
-        val FIRSTRUN = "firstrun"
         val AUTOCOMPLETE_DOMAIN = "autocomplete_domain"
         val SEARCH_SUGGESTION_PROMPT = "search_suggestion_prompt"
         val MAKE_DEFAULT_BROWSER_OPEN_WITH = "make_default_browser_open_with"
@@ -104,8 +103,6 @@ object TelemetryWrapper {
         val SELECTION = "selection"
         val ERASE_TO_HOME = "erase_home"
         val ERASE_TO_APP = "erase_app"
-        val SKIP = "skip"
-        val FINISH = "finish"
         val OPEN = "open"
         val URL = "url"
         val SEARCH = "search"
@@ -361,21 +358,6 @@ object TelemetryWrapper {
             Object.BLOCKING_SWITCH,
             isBlockingEnabled.toString()
         ).queue()
-    }
-
-    @JvmStatic
-    fun showFirstRunPageEvent(page: Int) {
-        TelemetryEvent.create(Category.ACTION, Method.SHOW, Object.FIRSTRUN, page.toString()).queue()
-    }
-
-    @JvmStatic
-    fun skipFirstRunEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.FIRSTRUN, Value.SKIP).queue()
-    }
-
-    @JvmStatic
-    fun finishFirstRunEvent() {
-        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.FIRSTRUN, Value.FINISH).queue()
     }
 
     enum class AutoCompleteEventSource {


### PR DESCRIPTION
# Request for data collection review form

**All questions are mandatory. You must receive a review from a data steward peer on your responses to these questions before shipping new data collection.**

_1) What questions will you answer with this data?_
How are users interacting with the onboarding screen/information

_2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?_
This is needed to analyze feature usage and possible feature improvements.

_3) What alternative methods did you consider to answer these questions? Why were they not sufficient?_
This is the only way.

_4) Can current instrumentation answer these questions?_
No. We need a new specific event for a specific app feature.

_5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki._

_**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**_

<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
    <td>Tracking Bug #</td>
  </tr>

  <tr>
    <td>Onboarding page displayed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5635 </td>
    </tr>

  <tr>
    <td>Next button tapped.</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5635 </td>
    </tr>

  <tr>
    <td>Skip button tapped.</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5635 </td>
    </tr>

  <tr>
    <td>Finish button tapped.</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5635 </td>
    </tr>

</table>

_6) How long will this data be collected?  Choose one of the following:_
    Expiry for capturing data is set to "2022-11-01"

_7) What populations will you measure?_
All release channels and locales.

_8) If this data collection is default on, what is the opt-out mechanism for users?_
 Users can opt out of data collection by disabling Usage and technical data from Settings -> Privacy and security -> Data choices.

_9) Please provide a general description of how you will analyze this data._
 Glean 

_10) Where do you intend to share the results of your analysis?_
Only on Glean, mobile teams, and BD have internal access.

_12) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection?_
No.
