### PR TITLE
95.0: Uplift translation and update Android Components

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -718,7 +718,7 @@ The new line here must be kept as the second half of the string is clickable for
     <!-- Tip displayed on home view explaining how to request the desktop version of a website.
       %1$s is a placeholder for the app name. -->
     <string name="tip_request_desktop2">Хотите увидеть полную версию сайта?\n
-        Переключитесь на версию для компьютера в меню %1$</string>
+        Переключитесь на версию для компьютера в меню %1$s</string>
 
     <!-- Tip displayed on home view explaining how to add a custom autocomplete URL -->
     <string name="tip_disable_tips2">Отключить советы на домашнем экране</string>

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "95.0.6"
+    const val VERSION = "95.0.7"
 }


### PR DESCRIPTION
* Fixing the Russian string causing a crash (#5812 
* Updating Android Components to 95.0.7