### PR TITLE
Issue #5908 - WebCompatReporterFeature - Use `focus-geckoview` as the productName.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -102,7 +102,7 @@ class Components(
         engineOverride ?: EngineProvider.createEngine(context, engineDefaultSettings).apply {
             this@Components.settings.setupSafeBrowsing(this)
             WebCompatFeature.install(this)
-            WebCompatReporterFeature.install(this, "focus")
+            WebCompatReporterFeature.install(this, "focus-geckoview")
         }
     }
 


### PR DESCRIPTION
See #5908 - this change allows webcompat.com to add a matching `browser` label, and makes sure the reports end up in the same pile as all previous Focus reports we have in our system.