### PR TITLE
Add Autoplay settings screen

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -40,7 +40,6 @@ import mozilla.components.feature.downloads.share.ShareDownloadFeature
 import mozilla.components.feature.prompts.PromptFeature
 import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature
-import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.feature.tabs.WindowFeature
 import mozilla.components.feature.top.sites.TopSitesConfig
 import mozilla.components.feature.top.sites.TopSitesFeature
@@ -313,16 +312,6 @@ class BrowserFragment :
     }
 
     private fun setSitePermissions(rootView: View) {
-        val sitePermissionsRules = SitePermissionsRules(
-            notification = SitePermissionsRules.Action.BLOCKED,
-            microphone = SitePermissionsRules.Action.BLOCKED,
-            location = SitePermissionsRules.Action.BLOCKED,
-            camera = SitePermissionsRules.Action.BLOCKED,
-            autoplayAudible = SitePermissionsRules.AutoplayAction.BLOCKED,
-            autoplayInaudible = SitePermissionsRules.AutoplayAction.ALLOWED,
-            persistentStorage = SitePermissionsRules.Action.BLOCKED,
-            mediaKeySystemAccess = SitePermissionsRules.Action.BLOCKED
-        )
         sitePermissionsFeature.set(
             feature = SitePermissionsFeature(
                 context = requireContext(),
@@ -334,7 +323,7 @@ class BrowserFragment :
                     // Since we don't request permissions this it will not be called
                     false
                 },
-                sitePermissionsRules = sitePermissionsRules,
+                sitePermissionsRules = requireComponents.settings.getSitePermissionsSettingsRules(),
                 sessionId = tabId,
                 store = requireComponents.store
             ),

--- a/app/src/main/java/org/mozilla/focus/navigation/MainActivityNavigation.kt
+++ b/app/src/main/java/org/mozilla/focus/navigation/MainActivityNavigation.kt
@@ -26,6 +26,8 @@ import org.mozilla.focus.settings.MozillaSettingsFragment
 import org.mozilla.focus.settings.RemoveSearchEnginesSettingsFragment
 import org.mozilla.focus.settings.SearchSettingsFragment
 import org.mozilla.focus.settings.SettingsFragment
+import org.mozilla.focus.settings.permissions.AutoplayFragment
+import org.mozilla.focus.settings.permissions.SitePermissionsFragment
 import org.mozilla.focus.settings.privacy.PrivacySecuritySettingsFragment
 import org.mozilla.focus.settings.privacy.studies.StudiesFragment
 import org.mozilla.focus.state.Screen
@@ -185,6 +187,8 @@ class MainActivityNavigation(
             Screen.Settings.Page.Mozilla -> MozillaSettingsFragment()
             Screen.Settings.Page.PrivacyExceptions -> ExceptionsListFragment()
             Screen.Settings.Page.PrivacyExceptionsRemove -> ExceptionsRemoveFragment()
+            Screen.Settings.Page.Autoplay -> AutoplayFragment()
+            Screen.Settings.Page.SitePermissions -> SitePermissionsFragment()
             Screen.Settings.Page.Studies -> StudiesFragment()
             Screen.Settings.Page.SearchList -> InstalledSearchEnginesSettingsFragment()
             Screen.Settings.Page.SearchRemove -> RemoveSearchEnginesSettingsFragment()

--- a/app/src/main/java/org/mozilla/focus/settings/permissions/AutoplayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/permissions/AutoplayFragment.kt
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.focus.settings.permissions
+
+import android.os.Bundle
+import androidx.preference.Preference
+import org.mozilla.focus.R
+import org.mozilla.focus.ext.requireComponents
+import org.mozilla.focus.ext.requirePreference
+import org.mozilla.focus.settings.BaseSettingsFragment
+import org.mozilla.focus.settings.RadioButtonPreference
+import org.mozilla.focus.settings.addToRadioGroup
+
+class AutoplayFragment : BaseSettingsFragment() {
+
+    private lateinit var radioAllowAudioVideo: RadioButtonPreference
+    private lateinit var radioBlockAudioOnly: RadioButtonPreference
+    private lateinit var radioBlockAudioVideo: RadioButtonPreference
+
+    override fun onStart() {
+        super.onStart()
+        updateTitle(R.string.preference_autoplay)
+    }
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResource(R.xml.site_permissions_autoplay)
+        setupPreferences()
+    }
+
+    private fun setupPreferences() {
+        radioAllowAudioVideo = requirePreference(R.string.pref_key_allow_autoplay_audio_video)
+        radioAllowAudioVideo.onPreferenceChangeListener = radioButtonClickListener
+
+        radioBlockAudioOnly = requirePreference(R.string.pref_key_block_autoplay_audio_only)
+        radioBlockAudioOnly.onPreferenceChangeListener = radioButtonClickListener
+
+        radioBlockAudioVideo = requirePreference(R.string.pref_key_block_autoplay_audio_video)
+        radioBlockAudioVideo.onPreferenceChangeListener = radioButtonClickListener
+
+        addToRadioGroup(
+            radioAllowAudioVideo,
+            radioBlockAudioOnly,
+            radioBlockAudioVideo
+        )
+
+        requirePreference<RadioButtonPreference>(
+            requireComponents.settings.currentAutoplayOption.prefKeyId
+        ).updateRadioValue(
+            true
+        )
+    }
+
+    private val radioButtonClickListener =
+        Preference.OnPreferenceChangeListener { preference, newValue ->
+            if (newValue as Boolean) {
+                requireComponents.settings.updateAutoplayPrefKey(preference.key)
+            }
+            true
+        }
+}

--- a/app/src/main/java/org/mozilla/focus/settings/permissions/AutoplayOption.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/permissions/AutoplayOption.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.focus.settings.permissions
+
+import android.content.Context
+import org.mozilla.focus.R
+
+sealed class AutoplayOption(open val prefKeyId: Int, open val textId: Int) {
+    data class AllowAudioVideo(
+        override val prefKeyId: Int = R.string.pref_key_allow_autoplay_audio_video,
+        override val textId: Int = R.string.preference_allow_audio_video_autoplay
+    ) : AutoplayOption(prefKeyId = prefKeyId, textId = textId)
+
+    data class BlockAudioOnly(
+        override val prefKeyId: Int = R.string.pref_key_block_autoplay_audio_only,
+        override val textId: Int = R.string.preference_block_autoplay_audio_only,
+    ) : AutoplayOption(prefKeyId = prefKeyId, textId = textId)
+
+    data class BlockAudioVideo(
+        override val prefKeyId: Int = R.string.pref_key_block_autoplay_audio_video,
+        override val textId: Int = R.string.preference_block_autoplay_audio_video
+    ) : AutoplayOption(prefKeyId = prefKeyId, textId = textId)
+}
+
+fun getValueByPrefKey(autoplayPrefKey: String?, context: Context) =
+    when (autoplayPrefKey) {
+        context.getString(R.string.pref_key_allow_autoplay_audio_video) -> AutoplayOption.AllowAudioVideo()
+        context.getString(R.string.pref_key_block_autoplay_audio_video) -> AutoplayOption.BlockAudioVideo()
+        else -> AutoplayOption.BlockAudioOnly()
+    }

--- a/app/src/main/java/org/mozilla/focus/settings/permissions/SitePermissionsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/permissions/SitePermissionsFragment.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.focus.settings.permissions
+
+import android.os.Bundle
+import androidx.preference.Preference
+import org.mozilla.focus.R
+import org.mozilla.focus.ext.requireComponents
+import org.mozilla.focus.ext.requirePreference
+import org.mozilla.focus.settings.BaseSettingsFragment
+import org.mozilla.focus.state.AppAction
+import org.mozilla.focus.state.Screen
+
+class SitePermissionsFragment : BaseSettingsFragment() {
+
+    override fun onStart() {
+        super.onStart()
+        updateTitle(R.string.preference_site_permissions)
+    }
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResource(R.xml.site_permissions)
+        requirePreference<Preference>(R.string.pref_key_autoplay).summary =
+            getString(requireComponents.settings.currentAutoplayOption.textId)
+    }
+
+    override fun onPreferenceTreeClick(preference: Preference): Boolean {
+        when (preference.key) {
+            resources.getString(R.string.pref_key_autoplay) ->
+                requireComponents.appStore.dispatch(
+                    AppAction.OpenSettings(page = Screen.Settings.Page.Autoplay)
+                )
+        }
+        return super.onPreferenceTreeClick(preference)
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/settings/privacy/PrivacySecuritySettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/privacy/PrivacySecuritySettingsFragment.kt
@@ -150,6 +150,10 @@ class PrivacySecuritySettingsFragment :
                     EngineSharedPreferencesListener.TrackerChanged.CONTENT.tracker,
                     settings.shouldBlockOtherTrackers()
                 )
+            resources.getString(R.string.pref_key_site_permissions) ->
+                requireComponents.appStore.dispatch(
+                    AppAction.OpenSettings(page = Screen.Settings.Page.SitePermissions)
+                )
             resources.getString(R.string.pref_key_studies) ->
                 requireComponents.appStore.dispatch(
                     AppAction.OpenSettings(page = Screen.Settings.Page.Studies)

--- a/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
@@ -187,6 +187,8 @@ private fun navigateUp(state: AppState, action: AppAction.NavigateUp): AppState 
 
         Screen.Settings.Page.PrivacyExceptions -> Screen.Settings(page = Screen.Settings.Page.Privacy)
         Screen.Settings.Page.PrivacyExceptionsRemove -> Screen.Settings(page = Screen.Settings.Page.PrivacyExceptions)
+        Screen.Settings.Page.SitePermissions -> Screen.Settings(page = Screen.Settings.Page.Privacy)
+        Screen.Settings.Page.Autoplay -> Screen.Settings(page = Screen.Settings.Page.SitePermissions)
         Screen.Settings.Page.Studies -> Screen.Settings(page = Screen.Settings.Page.Privacy)
 
         Screen.Settings.Page.SearchList -> Screen.Settings(page = Screen.Settings.Page.Search)

--- a/app/src/main/java/org/mozilla/focus/state/AppState.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppState.kt
@@ -81,6 +81,8 @@ sealed class Screen {
 
             PrivacyExceptions,
             PrivacyExceptionsRemove,
+            SitePermissions,
+            Autoplay,
             Studies,
 
             SearchList,

--- a/app/src/main/res/layout/preference_radio_button.xml
+++ b/app/src/main/res/layout/preference_radio_button.xml
@@ -51,7 +51,7 @@
         tools:text="@tools:sample/lorem"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@id/title"
-        app:layout_constraintTop_toBottomOf="@id/radio_button"
+        app:layout_constraintTop_toBottomOf="@id/title"
         app:layout_constraintStart_toStartOf="@id/title" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -14,6 +14,11 @@
     <string name="pref_key_privacy_block_other3" translatable="false"><xliff:g id="preference_key">pref_privacy_block_other3</xliff:g></string>
     <string name="pref_key_privacy_total_trackers_blocked_count" translatable="false"><xliff:g id="preference_key">pref_key_privacy_total_trackers_blocked_count</xliff:g></string>
     <string name="pref_key_privacy_ever_changed_etp" translatable="false"><xliff:g id="preference_key">pref_key_privacy_ever_changed_etp</xliff:g></string>
+    <string name="pref_key_site_permissions" translatable="false"><xliff:g id="preference_key">pref_key_privacy_site_permissions</xliff:g></string>
+    <string name="pref_key_autoplay" translatable="false"><xliff:g id="preference_key">pref_key_autoplay</xliff:g></string>
+    <string name="pref_key_allow_autoplay_audio_video" translatable="false"><xliff:g id="preference_key">pref_key_allow_audio_video_autoplay</xliff:g></string>
+    <string name="pref_key_block_autoplay_audio_only" translatable="false"><xliff:g id="preference_key">pref_key_block_autoplay_audio_only</xliff:g></string>
+    <string name="pref_key_block_autoplay_audio_video" translatable="false"><xliff:g id="preference_key">pref_key_block_audio_video_autoplay</xliff:g></string>
 
     <string name="pref_key_performance_block_webfonts" translatable="false"><xliff:g id="preference_key">pref_performance_block_webfonts</xliff:g></string>
     <string name="pref_key_performance_block_javascript" translatable="false"><xliff:g id="preference_key">pref_performance_block_javascript</xliff:g></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -610,6 +610,24 @@
     <!-- Title of Advanced Setting category -->
     <string name="preference_category_advanced">Advanced</string>
 
+    <!-- Preference for site permissions -->
+    <string name="preference_site_permissions">Site permissions</string>
+
+    <!-- Preference for autoplay -->
+    <string name="preference_autoplay">Autoplay</string>
+
+    <!-- Preference for allow autoplay audio and video-->
+    <string name="preference_allow_audio_video_autoplay">Allow audio and video</string>
+
+    <!-- Preference for block autoplay audio only-->
+    <string name="preference_block_autoplay_audio_only">Block audio only</string>
+
+    <!-- Preference summary for block autoplay audio only-->
+    <string name="preference_block_autoplay_audio_only_summary">Recommended</string>
+
+    <!-- Preference for block autoplay audio and video-->
+    <string name="preference_block_autoplay_audio_video">Block audio and video</string>
+
     <!-- Preference for studies -->
     <string name="preference_studies">Studies</string>
 

--- a/app/src/main/res/xml/privacy_security_settings.xml
+++ b/app/src/main/res/xml/privacy_security_settings.xml
@@ -78,6 +78,10 @@
             android:defaultValue="@string/preference_privacy_should_block_cookies_cross_site_option"
             android:layout="@layout/cookies_preference"
             android:title="@string/preference_privacy_category_cookies" />
+        <androidx.preference.Preference
+            android:key="@string/pref_key_site_permissions"
+            android:layout="@layout/focus_preference_no_icon"
+            android:title="@string/preference_site_permissions" />
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory

--- a/app/src/main/res/xml/site_permissions.xml
+++ b/app/src/main/res/xml/site_permissions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <androidx.preference.Preference
+        android:icon="@drawable/mozac_ic_autoplay_blocked"
+        android:key="@string/pref_key_autoplay"
+        android:layout="@layout/focus_preference_new_tab"
+        android:title="@string/preference_autoplay" />
+
+</androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/site_permissions_autoplay.xml
+++ b/app/src/main/res/xml/site_permissions_autoplay.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <org.mozilla.focus.settings.RadioButtonPreference
+        android:key="@string/pref_key_allow_autoplay_audio_video"
+        android:layout="@layout/preference_radio_button"
+        android:title="@string/preference_allow_audio_video_autoplay" />
+
+    <org.mozilla.focus.settings.RadioButtonPreference
+        android:key="@string/pref_key_block_autoplay_audio_only"
+        android:layout="@layout/preference_radio_button"
+        android:summary="@string/preference_block_autoplay_audio_only_summary"
+        android:title="@string/preference_block_autoplay_audio_only" />
+
+    <org.mozilla.focus.settings.RadioButtonPreference
+        android:key="@string/pref_key_block_autoplay_audio_video"
+        android:layout="@layout/preference_radio_button"
+        android:title="@string/preference_block_autoplay_audio_video" />
+</PreferenceScreen>


### PR DESCRIPTION
For #5837
Until now only audible videos were blocked by default, this commit add a new settings screen to let the user to choose the state of Autoplay