### PR TITLE
For #5653: Migrate settings related telemetry

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -271,6 +271,40 @@ autocomplete:
     notification_emails:
       - android-probes@mozilla.com
     expires: "2022-11-01"
+  top_sites_setting_changed:
+    type: event
+    description: |
+      Autocomplete setting for top sites has changed.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5885
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5940
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      is_enabled:
+        description: The new setting true for ON, false for OFF
+        type: boolean
+  favorite_sites_setting_changed:
+    type: event
+    description: |
+      Autocomplete setting for favorite sites has changed.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5885
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5940
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      is_enabled:
+        description: The new setting true for ON, false for OFF
+        type: boolean
 
 shortcuts:
   shortcuts_on_home_number:

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -542,6 +542,23 @@ pro_tips:
           The tip code of tip being clicked.
           Can be one of fresh_look_tip, allow_list_tip, request_desktop_tip.
         type: string
+  tips_setting_changed:
+    type: event
+    description: |
+      Display setting for tips has changed.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5541
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5940
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      is_enabled:
+        description: The new setting true for ON, false for OFF
+        type: boolean
 
 preferences:
   user_theme:

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1609,3 +1609,72 @@ advanced_settings:
       is_enabled:
         description: The new setting true for ON, false for OFF
         type: boolean
+privacy_settings:
+  telemetry_setting_changed:
+    type: event
+    description: |
+      Telemetry setting has changed.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5653
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5940
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      is_enabled:
+        description: The new setting true for ON, false for OFF
+        type: boolean
+  safe_browsing_setting_changed:
+    type: event
+    description: |
+      Safe browsing setting has changed.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5653
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5940
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      is_enabled:
+        description: The new setting true for ON, false for OFF
+        type: boolean
+  unlock_setting_changed:
+    type: event
+    description: |
+      Biometric unlock setting has changed.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5653
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5940
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      is_enabled:
+        description: The new setting true for ON, false for OFF
+        type: boolean
+  stealth_setting_changed:
+    type: event
+    description: |
+      Stealth setting has changed.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5653
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5940
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      is_enabled:
+        description: The new setting true for ON, false for OFF
+        type: boolean

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -106,7 +106,7 @@ browser:
     bugs:
       - https://github.com/mozilla-mobile/focus-android/issues/5897
     data_reviews:
-      - https://github.com/mozilla-mobile/focus-android/pull/?
+      - https://github.com/mozilla-mobile/focus-android/pull/5898
     data_sensitivity:
       - interaction
     notification_emails:

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1573,3 +1573,39 @@ search_suggestions:
     notification_emails:
       - android-probes@mozilla.com
     expires: "2022-11-01"
+
+advanced_settings:
+  remote_debug_setting_changed:
+    type: event
+    description: |
+      Remote debugging setting has changed.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5653
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5940
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      is_enabled:
+        description: The new setting true for ON, false for OFF
+        type: boolean
+  open_links_setting_changed:
+    type: event
+    description: |
+      Open links setting has changed.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/5653
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/pull/5940
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+    extra_keys:
+      is_enabled:
+        description: The new setting true for ON, false for OFF
+        type: boolean

--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteSettingsFragment.kt
@@ -6,13 +6,13 @@ package org.mozilla.focus.autocomplete
 
 import android.content.SharedPreferences
 import android.os.Bundle
+import org.mozilla.focus.GleanMetrics.Autocomplete
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.ext.requirePreference
 import org.mozilla.focus.settings.BaseSettingsFragment
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
-import org.mozilla.focus.telemetry.TelemetryWrapper
 
 /**
  * Settings UI for configuring autocomplete.
@@ -67,7 +67,16 @@ class AutocompleteSettingsFragment : BaseSettingsFragment(), SharedPreferences.O
         if (key == null || sharedPreferences == null) {
             return
         }
+        when (key) {
+            topSitesAutocomplete.key ->
+                Autocomplete.topSitesSettingChanged.record(
+                    Autocomplete.TopSitesSettingChangedExtra(sharedPreferences.all[key] as Boolean)
+                )
 
-        TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
+            favoriteSitesAutocomplete.key ->
+                Autocomplete.favoriteSitesSettingChanged.record(
+                    Autocomplete.FavoriteSitesSettingChangedExtra(sharedPreferences.all[key] as Boolean)
+                )
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/settings/AdvancedSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/AdvancedSettingsFragment.kt
@@ -6,9 +6,9 @@ package org.mozilla.focus.settings
 
 import android.content.SharedPreferences
 import android.os.Bundle
+import org.mozilla.focus.GleanMetrics.AdvancedSettings
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
-import org.mozilla.focus.telemetry.TelemetryWrapper
 
 class AdvancedSettingsFragment :
     BaseSettingsFragment(),
@@ -32,10 +32,20 @@ class AdvancedSettingsFragment :
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
-        if (key == getString(R.string.pref_key_remote_debugging)) {
-            requireComponents.engine.settings.remoteDebuggingEnabled =
-                sharedPreferences.getBoolean(key, false)
+        when (key) {
+            getString(R.string.pref_key_remote_debugging) -> {
+                requireComponents.engine.settings.remoteDebuggingEnabled =
+                    sharedPreferences.getBoolean(key, false)
+
+                AdvancedSettings.remoteDebugSettingChanged.record(
+                    AdvancedSettings.RemoteDebugSettingChangedExtra(sharedPreferences.all[key] as Boolean)
+                )
+            }
+
+            getString(R.string.pref_key_open_links_in_external_app) ->
+                AdvancedSettings.openLinksSettingChanged.record(
+                    AdvancedSettings.OpenLinksSettingChangedExtra(sharedPreferences.all[key] as Boolean)
+                )
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/settings/MozillaSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/MozillaSettingsFragment.kt
@@ -8,13 +8,13 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.preference.Preference
 import mozilla.components.browser.state.state.SessionState
+import org.mozilla.focus.GleanMetrics.ProTips
 import org.mozilla.focus.R
 import org.mozilla.focus.browser.LocalizedContent
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
-import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.AppConstants
 import org.mozilla.focus.utils.SupportUtils
 
@@ -87,7 +87,9 @@ class MozillaSettingsFragment :
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
+        ProTips.tipsSettingChanged.record(
+            ProTips.TipsSettingChangedExtra(sharedPreferences.all[key] as Boolean)
+        )
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/focus/settings/SearchSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/SearchSettingsFragment.kt
@@ -14,7 +14,6 @@ import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
-import org.mozilla.focus.telemetry.TelemetryWrapper
 
 class SearchSettingsFragment :
     BaseSettingsFragment(),
@@ -53,8 +52,6 @@ class SearchSettingsFragment :
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
-
         when (key) {
             resources.getString(R.string.pref_key_show_search_suggestions) ->
                 ShowSearchSuggestions.changedFromSettings.record(

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.focus.settings
 
-import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
@@ -16,12 +15,11 @@ import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
-import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.AppConstants
 import org.mozilla.focus.utils.SupportUtils
 import org.mozilla.focus.whatsnew.WhatsNew
 
-class SettingsFragment : BaseSettingsFragment(), SharedPreferences.OnSharedPreferenceChangeListener {
+class SettingsFragment : BaseSettingsFragment() {
 
     override fun onCreatePreferences(bundle: Bundle?, s: String?) {
         setHasOptionsMenu(true)
@@ -33,14 +31,7 @@ class SettingsFragment : BaseSettingsFragment(), SharedPreferences.OnSharedPrefe
 
         (requireActivity() as AppCompatActivity).supportActionBar?.customView
 
-        preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
-
         updateTitle(R.string.menu_settings)
-    }
-
-    override fun onPause() {
-        preferenceManager.sharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
-        super.onPause()
     }
 
     override fun onPreferenceTreeClick(preference: androidx.preference.Preference): Boolean {
@@ -60,10 +51,6 @@ class SettingsFragment : BaseSettingsFragment(), SharedPreferences.OnSharedPrefe
         )
 
         return super.onPreferenceTreeClick(preference)
-    }
-
-    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/app/src/main/java/org/mozilla/focus/settings/privacy/PrivacySecuritySettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/privacy/PrivacySecuritySettingsFragment.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
 import mozilla.components.service.glean.private.NoExtras
+import org.mozilla.focus.GleanMetrics.PrivacySettings
 import org.mozilla.focus.GleanMetrics.TrackingProtectionExceptions
 import org.mozilla.focus.R
 import org.mozilla.focus.biometrics.Biometrics
@@ -19,7 +20,6 @@ import org.mozilla.focus.ext.settings
 import org.mozilla.focus.settings.BaseSettingsFragment
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
-import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.widget.CookiesPreference
 
 class PrivacySecuritySettingsFragment :
@@ -78,8 +78,28 @@ class PrivacySecuritySettingsFragment :
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
+        recordTelemetry(key, sharedPreferences.all[key] as Boolean)
         updateStealthToggleAvailability()
+    }
+
+    private fun recordTelemetry(key: String, newValue: Boolean) {
+        when (key) {
+            getString(R.string.pref_key_telemetry) -> PrivacySettings.telemetrySettingChanged.record(
+                PrivacySettings.TelemetrySettingChangedExtra(newValue)
+            )
+            getString(R.string.pref_key_safe_browsing) -> PrivacySettings.safeBrowsingSettingChanged.record(
+                PrivacySettings.SafeBrowsingSettingChangedExtra(newValue)
+            )
+            getString(R.string.pref_key_biometric) -> PrivacySettings.unlockSettingChanged.record(
+                PrivacySettings.UnlockSettingChangedExtra(newValue)
+            )
+            getString(R.string.pref_key_secure) -> PrivacySettings.stealthSettingChanged.record(
+                PrivacySettings.StealthSettingChangedExtra(newValue)
+            )
+            else -> {
+                // Telemetry for the change is recorded elsewhere.
+            }
+        }
     }
 
     private fun updateBiometricsToggleAvailability() {


### PR DESCRIPTION
# Request for data collection review form

**All questions are mandatory. You must receive a review from a data steward peer on your responses to these questions before shipping new data collection.**

_1) What questions will you answer with this data?_
How are users navigating within and out of Focus.

_2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?_
This is needed to analyze feature usage and possible feature improvements.

_3) What alternative methods did you consider to answer these questions? Why were they not sufficient?_
This is the only way.

_4) Can current instrumentation answer these questions?_
No. We need a new specific event for a specific app feature.

_5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki._

_**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**_

<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
    <td>Tracking Bug #</td>
  </tr>

  <tr>
    <td> Autocomplete setting for top sites has changed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5885 </td>
    </tr>

  <tr>
    <td> Autocomplete setting for favorite sites has changed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5885 </td>
    </tr>

  <tr>
    <td> Tips setting has changed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5541 </td>
    </tr>

  <tr>
    <td> Remote debugging setting has changed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5653 </td>
    </tr>

  <tr>
    <td> Open links setting has changed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5653 </td>
    </tr>

  <tr>
    <td> Telemetry setting has changed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5653 </td>
    </tr>

  <tr>
    <td> Safe browsing setting has changed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5653 </td>
    </tr>

  <tr>
    <td> Unlock setting has changed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5653 </td>
    </tr>

  <tr>
    <td>  Stealth setting has changed</td>
    <td>Category 2</td>
    <td>https://github.com/mozilla-mobile/focus-android/issues/5653 </td>
    </tr>

</table>

_6) How long will this data be collected?  Choose one of the following:_
    Expiry for capturing data is set to "2022-11-01"

_7) What populations will you measure?_
All release channels and locales.

_8) If this data collection is default on, what is the opt-out mechanism for users?_
 Users can opt out of data collection by disabling Usage and technical data from Settings -> Privacy and security -> Data choices.

_9) Please provide a general description of how you will analyze this data._
 Glean 

_10) Where do you intend to share the results of your analysis?_
Only on Glean, mobile teams, and BD have internal access.

_12) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection?_
No.
