### PR TITLE
Use AppCompatResources to get the drawable

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/CrashReporterFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/CrashReporterFragment.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_crash_reporter.*
 import mozilla.components.service.glean.private.NoExtras
@@ -25,6 +26,9 @@ class CrashReporterFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        view.findViewById<View>(R.id.background).background =
+            AppCompatResources.getDrawable(requireContext(), R.drawable.ic_error_session_crashed)
 
         CrashReporter.displayed.record(NoExtras())
 

--- a/app/src/main/res/layout/fragment_crash_reporter.xml
+++ b/app/src/main/res/layout/fragment_crash_reporter.xml
@@ -12,7 +12,6 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginTop="8dp"
-        android:background="@drawable/ic_error_session_crashed"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintWidth_percent="0.6"


### PR DESCRIPTION
For #5776 
Some vector resources are not loaded properly in api versions 21, 22 and we are constrained to use AppCompatResources in order to avoid the crashing of the app