### PR TITLE
Issue #5935: Introduce setting for HTTPS-Only mode

### DIFF
--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -95,7 +95,8 @@ class Components(
             trackingProtectionPolicy = settings.createTrackingProtectionPolicy(),
             javascriptEnabled = !settings.shouldBlockJavaScript(),
             remoteDebuggingEnabled = settings.shouldEnableRemoteDebugging(),
-            webFontsEnabled = !settings.shouldBlockWebFonts()
+            webFontsEnabled = !settings.shouldBlockWebFonts(),
+            httpsOnlyMode = settings.getHttpsOnlyMode()
         )
     }
 

--- a/app/src/main/java/org/mozilla/focus/settings/HttpsOnlyModePreference.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/HttpsOnlyModePreference.kt
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.settings
+
+import android.content.Context
+import android.util.AttributeSet
+import mozilla.components.concept.engine.Engine
+import org.mozilla.focus.R
+import org.mozilla.focus.ext.components
+import org.mozilla.focus.utils.Features
+
+/**
+ * Preference for HTTPS-Only mode.
+ */
+class HttpsOnlyModePreference(
+    context: Context,
+    attrs: AttributeSet?
+) : LearnMoreSwitchPreference(context, attrs) {
+    // Replace with SUMO link for Focus (This is the desktop link)
+    // https://github.com/mozilla-mobile/focus-android/issues/6008
+    override fun getLearnMoreUrl() = "https://support.mozilla.org/en-US/kb/https-only-prefs"
+
+    init {
+        if (!Features.HTTPS_ONLY_MODE) {
+            isVisible = false
+        }
+
+        setOnPreferenceChangeListener { _, newValue ->
+            val enableHttpsOnly = newValue as Boolean
+            context.components.engine.settings.httpsOnlyMode = if (enableHttpsOnly) {
+                Engine.HttpsOnlyMode.ENABLED
+            } else {
+                Engine.HttpsOnlyMode.DISABLED
+            }
+            true
+        }
+    }
+
+    override fun getDescription(): String {
+        val appName = context.getString(R.string.app_name)
+        return context.getString(R.string.preference_https_only_summary, appName)
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/utils/Features.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Features.kt
@@ -9,4 +9,10 @@ package org.mozilla.focus.utils
  */
 object Features {
     const val SEARCH_TERMS_OR_URL: Boolean = true
+
+    /**
+     * HTTPS-Only mode.
+     * https://support.mozilla.org/en-US/kb/https-only-prefs
+     */
+    val HTTPS_ONLY_MODE = AppConstants.isDevOrNightlyBuild
 }

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -306,6 +306,17 @@ class Settings(
         false
     )
 
+    fun getHttpsOnlyMode(): Engine.HttpsOnlyMode {
+        return if (
+            Features.HTTPS_ONLY_MODE &&
+            preferences.getBoolean(getPreferenceKey(R.string.pref_key_https_only), true)
+        ) {
+            Engine.HttpsOnlyMode.ENABLED
+        } else {
+            Engine.HttpsOnlyMode.DISABLED
+        }
+    }
+
     private fun getPreferenceKey(resourceId: Int): String =
         resources.getString(resourceId)
 }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -28,6 +28,8 @@
 
     <string name="pref_key_safe_browsing" translatable="false"><xliff:g id="preference_key">pref_safe_browsing</xliff:g></string>
 
+    <string name="pref_key_https_only" translatable="false"><xliff:g id="preference_key">pref_https_only</xliff:g></string>
+
     <string name="pref_key_biometric" translatable="false"><xliff:g id="preference_key">pref_biometric</xliff:g></string>
     <string name="pref_key_about" translatable="false"><xliff:g id="preference_key">pref_about</xliff:g></string>
     <string name="pref_key_help" translatable="false"><xliff:g id="preference_key">pref_help</xliff:g></string>
@@ -56,6 +58,8 @@
     <string name="has_requested_desktop" translatable="false"><xliff:g id="preference_key">has_requested_desktop</xliff:g></string>
     <string name="app_launch_count" translatable="false"><xliff:g id="preference_key">app_launch_count</xliff:g></string>
     <string name="pref_key_category_safe_browsing" translatable="false"><xliff:g id="preference_key">safe_browsing_category</xliff:g></string>
+
+    <string name="pref_key_category_security" translatable="false"><xliff:g id="preference_key">security_category</xliff:g></string>
 
     <string name="pref_key_homescreen_tips" translatable="false">
         <xliff:g id="preference_key">use_homescreen_tips</xliff:g>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<resources>
+<resources xmlns:moz="http://mozac.org/tools">
     <!-- ####################################################################################### -->
     <!-- ## Put only strings into this file that should be translated. Move all other strings ## -->
     <!-- ## into a separate file like strings_references.xml                                  ## -->
@@ -747,11 +747,15 @@ The new line here must be kept as the second half of the string is clickable for
     <string name="preference_open_new_tab">Switch to link in new tab immediately</string>
 
     <!-- Preference for safe browsing which when enabled, blocks dangerous or deceptive webpages that may include phishing or malware -->
-    <string name="preference_category_safe_browsing">Safe Browsing</string>
+    <string name="preference_category_safe_browsing" moz:removedIn="97">Safe Browsing</string>
     <!-- Preference title for safe browsing which when enabled, blocks dangerous or deceptive webpages that may include phishing or malware -->
     <string name="preference_safe_browsing_title">Block potentially dangerous and deceptive sites</string>
     <!-- Preference summary for safe browsing which when enabled, blocks dangerous or deceptive webpages that may include phishing or malware -->
     <string name="preference_safe_browsing_summary">Block reported deceptive and attack sites, malware sites, and unwanted software sites.</string>
+    <!-- Title of the preference to enable "HTTPS-Only" mode -->
+    <string name="preference_https_only_title">HTTPS-Only Mode</string>
+    <!-- Description of the preference to enable "HTTPS-Only" mode. %1$s will get replaced with the name of the app. -->
+    <string name="preference_https_only_summary">HTTPS provides a secure, encrypted connection between %1$s and the websites you visit. Most websites support HTTPS, and if HTTPS-Only Mode is enabled, then %1$s will upgrade all connections to HTTPS.</string>
 
     <!-- Preference for exceptions tracking protection -->
     <string name="preference_exceptions">Exceptions</string>

--- a/app/src/main/res/xml/privacy_security_settings.xml
+++ b/app/src/main/res/xml/privacy_security_settings.xml
@@ -106,15 +106,21 @@
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory
-        android:key="@string/pref_key_category_safe_browsing"
+        android:key="@string/pref_key_category_security"
         android:layout="@layout/preference_section_header_layout"
-        android:title="@string/preference_category_safe_browsing">
+        android:title="@string/preference_category_security">
         <org.mozilla.focus.settings.SafeBrowsingSwitchPreference
             android:defaultValue="true"
             android:key="@string/pref_key_safe_browsing"
             android:layout="@layout/focus_preference_no_icon"
             android:summary="@string/preference_safe_browsing_summary"
             android:title="@string/preference_safe_browsing_title" />
+        <org.mozilla.focus.settings.HttpsOnlyModePreference
+            android:defaultValue="true"
+            android:key="@string/pref_key_https_only"
+            android:layout="@layout/focus_preference_no_icon"
+            android:summary="@string/preference_https_only_summary"
+            android:title="@string/preference_https_only_title" />
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory


### PR DESCRIPTION
This patch introduces HTTPS-Only mode. _It's a draft_.

* For the preference: Should we have a "learn more" URL in settings like desktop? ([Desktop page](https://support.mozilla.org/en-US/kb/https-only-prefs))
* Preference placement: Like desktop, I created a "Security" section, that contains SafeBrowsing and this new setting. Is that okay?
* This is only a minimal version of the error page compared to desktop (See https://github.com/mozilla-mobile/android-components/issues/11306). The reason for that is that we do not support such rich error pages in A-C yet. But the error page is fully functional.
* All strings I used are from desktop. Do they work for mobile?

CC @jeffreygee 

![https_only_setting](https://user-images.githubusercontent.com/89638/144647476-6b3da584-ec5e-454a-8285-46bbdb0f8167.png)

![https_only_errorpage](https://user-images.githubusercontent.com/89638/144647507-c83dca1e-11a8-46c4-b73c-259ff9584d17.png)
