### PR TITLE
Disable run-ui in contributor workflow

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -107,7 +107,7 @@ jobs:
 
   run-ui:
     runs-on: macos-11
-    if: github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'MickeyMoz'
+    if: ${{ false }}
 
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
Seems to be another intermittent issue with downloading Gradle. 

```Kotlin
Downloading https://services.gradle.org/distributions/gradle-7.0.2-all.zip
Exception in thread "main" java.net.SocketException: Broken pipe (Write failed)
```

E.g, in this run https://github.com/mozilla-mobile/focus-android/runs/4437775770?check_suite_focus=true#step:3:259
but this run works fine https://github.com/mozilla-mobile/focus-android/runs/4431501204?check_suite_focus=true

It's just too inconsistent unfortunately.