### PR TITLE
Update Android Components version

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -394,7 +394,8 @@ class Settings(
         autoplayAudible = getAutoplayRules().first,
         autoplayInaudible = getAutoplayRules().second,
         persistentStorage = SitePermissionsRules.Action.BLOCKED,
-        mediaKeySystemAccess = SitePermissionsRules.Action.BLOCKED
+        mediaKeySystemAccess = SitePermissionsRules.Action.BLOCKED,
+        crossOriginStorageAccess = SitePermissionsRules.Action.BLOCKED
     )
 
     private fun getAutoplayRules(): Pair<SitePermissionsRules.AutoplayAction, SitePermissionsRules.AutoplayAction> {

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "97.0.20211221022315"
+    const val VERSION = "97.0.20211221190315"
 }


### PR DESCRIPTION
Since a new site permission were added with the last update of ac I add it also to
Focus with a BLOCKED default value