### PR TITLE
Update rename shortcut dialog colors

### DIFF
--- a/app/src/main/java/org/mozilla/focus/ui/dialog/FocusDialog.kt
+++ b/app/src/main/java/org/mozilla/focus/ui/dialog/FocusDialog.kt
@@ -126,9 +126,9 @@ fun DialogTextButton(
         Text(
             modifier = modifier,
             color = if (enabled) {
-                focusColors.onPrimary
+                focusColors.dialogActiveControls
             } else {
-                focusColors.onPrimary.copy(alpha = 0.5f)
+                focusColors.dialogActiveControls.copy(alpha = 0.5f)
             },
             text = text,
             style = MaterialTheme.typography.button
@@ -155,7 +155,10 @@ fun DialogInputField(
         textStyle = focusTypography.dialogInput,
         colors = TextFieldDefaults.textFieldColors(
             backgroundColor = focusColors.secondary,
-            textColor = focusColors.onSecondary
+            textColor = focusColors.onSecondary,
+            cursorColor = focusColors.onPrimary,
+            focusedIndicatorColor = focusColors.dialogActiveControls,
+            unfocusedIndicatorColor = focusColors.dialogActiveControls
         ),
         singleLine = true,
         shape = MaterialTheme.shapes.large

--- a/app/src/main/java/org/mozilla/focus/ui/theme/FocusColors.kt
+++ b/app/src/main/java/org/mozilla/focus/ui/theme/FocusColors.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.graphics.Color
  */
 data class FocusColors(
     val material: Colors,
+    val dialogActiveControls: Color,
     val topSiteBackground: Color,
     val topSiteFaviconText: Color,
     val topSiteTitle: Color,

--- a/app/src/main/java/org/mozilla/focus/ui/theme/FocusTheme.kt
+++ b/app/src/main/java/org/mozilla/focus/ui/theme/FocusTheme.kt
@@ -48,6 +48,7 @@ val focusColors: FocusColors
 
 private fun darkColorPalette(): FocusColors = FocusColors(
     material = darkColorsMaterial(),
+    dialogActiveControls = PhotonColors.Pink40,
     topSiteBackground = PhotonColors.Ink05,
     topSiteFaviconText = PhotonColors.LightGrey05,
     topSiteTitle = PhotonColors.LightGrey05,
@@ -59,6 +60,7 @@ private fun darkColorPalette(): FocusColors = FocusColors(
 
 private fun lightColorPalette(): FocusColors = FocusColors(
     material = lightColorsMaterial(),
+    dialogActiveControls = PhotonColors.Pink70,
     topSiteBackground = PhotonColors.White,
     topSiteFaviconText = PhotonColors.Ink50,
     topSiteTitle = PhotonColors.DarkGrey05,


### PR DESCRIPTION
For #6110
#### Light
<img src="https://user-images.githubusercontent.com/11731652/147228841-bc72f6b2-f408-483c-b73a-09eab5ba01b0.png" width="30%"/>
#### Dark
<img src="https://user-images.githubusercontent.com/11731652/147228852-f48d1508-a819-4470-985e-14392733cd26.png" width="30%"/>

