### PR TITLE
Enable the cross Origin Storage Access permission prompt

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -395,7 +395,7 @@ class Settings(
         autoplayInaudible = getAutoplayRules().second,
         persistentStorage = SitePermissionsRules.Action.BLOCKED,
         mediaKeySystemAccess = SitePermissionsRules.Action.BLOCKED,
-        crossOriginStorageAccess = SitePermissionsRules.Action.BLOCKED
+        crossOriginStorageAccess = SitePermissionsRules.Action.ASK_TO_ALLOW
     )
 
     private fun getAutoplayRules(): Pair<SitePermissionsRules.AutoplayAction, SitePermissionsRules.AutoplayAction> {


### PR DESCRIPTION
We need to enable the cross access permission prompt to be shown,  as multiple sites will be broken without it.  it's a dependency of https://github.com/mozilla-mobile/focus-android/pull/5943 you can read more about it [here](https://developer.mozilla.org/en-US/docs/Web/API/Storage_Access_API#user_prompts).