### PR TITLE
Update the initialisation order of toolbar indicators

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
@@ -96,14 +96,14 @@ class BrowserToolbarIntegration(
                 menu = ContextCompat.getColor(toolbar.context, R.color.primaryText)
             )
 
-            addTrackingProtectionIndicator()
-
-            displayIndicatorSeparator = false
-
             setOnSiteSecurityClickedListener {
                 TrackingProtection.toolbarShieldClicked.add()
                 fragment.showTrackingProtectionPanel()
             }
+
+            addTrackingProtectionIndicator()
+
+            displayIndicatorSeparator = false
 
             onUrlClicked = {
                 fragment.edit()


### PR DESCRIPTION
For #5245
Even if the tracking protection indicator were added at initialisation the security indicator observer were attached after that, fact which leads to tracking protection indicator overwriting
In setTrackingProtectionState method from DisplayToolbar.kt AC component we are checking if our current list of indicators contains a tracking protection indicator, condition which was false since it was replaced by a security one
