### PR TITLE
For #6171 - The "System default" text is missing from General - Language settings page

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/GeneralSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/GeneralSettingsFragment.kt
@@ -102,7 +102,7 @@ class GeneralSettingsFragment :
                 resources.getString(R.string.preference_language_systemdefault)
             )
         return value?.let {
-            if (value == LOCALE_SYSTEM_DEFAULT) {
+            if (value.isEmpty() || value == LOCALE_SYSTEM_DEFAULT) {
                 return resources.getString(R.string.preference_language_systemdefault)
             }
             LocaleDescriptor(it).getNativeName()

--- a/app/src/main/res/xml/general_settings.xml
+++ b/app/src/main/res/xml/general_settings.xml
@@ -29,7 +29,6 @@
 
     <!-- Empty default: we use an empty string to indicate "system default" language being selected -->
     <androidx.preference.Preference
-        android:defaultValue=""
         android:key="@string/pref_key_locale"
         android:layout="@layout/focus_preference"
         android:title="@string/preference_language"


### PR DESCRIPTION
This bug happens only at update from an older version with languages list in a pop-up window to this version. I checked SharedPreferences value for locale if  is empty and I set the value to "System default".