### PR TITLE
Reload the session with the new autoplay rules

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -332,6 +332,10 @@ class BrowserFragment :
             owner = this,
             view = rootView
         )
+        if (requireComponents.appStore.state.autoplayRulesChanged) {
+            requireComponents.sessionUseCases.reload(tabId)
+            requireComponents.appStore.dispatch(AppAction.AutoplayChange(false))
+        }
     }
 
     override fun onAccessibilityStateChanged(enabled: Boolean) = when (enabled) {

--- a/app/src/main/java/org/mozilla/focus/settings/permissions/AutoplayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/permissions/AutoplayFragment.kt
@@ -11,6 +11,7 @@ import org.mozilla.focus.ext.requirePreference
 import org.mozilla.focus.settings.BaseSettingsFragment
 import org.mozilla.focus.settings.RadioButtonPreference
 import org.mozilla.focus.settings.addToRadioGroup
+import org.mozilla.focus.state.AppAction
 
 class AutoplayFragment : BaseSettingsFragment() {
 
@@ -55,6 +56,7 @@ class AutoplayFragment : BaseSettingsFragment() {
         Preference.OnPreferenceChangeListener { preference, newValue ->
             if (newValue as Boolean) {
                 requireComponents.settings.updateAutoplayPrefKey(preference.key)
+                requireComponents.appStore.dispatch(AppAction.AutoplayChange(true))
             }
             true
         }

--- a/app/src/main/java/org/mozilla/focus/state/AppAction.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppAction.kt
@@ -75,4 +75,9 @@ sealed class AppAction : Action {
      * The list of [TopSite] has changed.
      */
     data class TopSitesChange(val topSites: List<TopSite>) : AppAction()
+
+    /**
+     * Site permissions autoplay rules has changed.
+     */
+    data class AutoplayChange(val value: Boolean) : AppAction()
 }

--- a/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
@@ -29,6 +29,7 @@ object AppReducer : Reducer<AppState, AppAction> {
             is AppAction.NavigateUp -> navigateUp(state, action)
             is AppAction.OpenTab -> openTab(state, action)
             is AppAction.TopSitesChange -> topSitesChanged(state, action)
+            is AppAction.AutoplayChange -> autoplayRulesChanged(state, action)
         }
     }
 }
@@ -143,6 +144,13 @@ private fun openTab(state: AppState, action: AppAction.OpenTab): AppState {
  */
 private fun topSitesChanged(state: AppState, action: AppAction.TopSitesChange): AppState {
     return state.copy(topSites = action.topSites)
+}
+
+/**
+ * The rules of site permissions autoplay has changed.
+ */
+private fun autoplayRulesChanged(state: AppState, action: AppAction.AutoplayChange): AppState {
+    return state.copy(autoplayRulesChanged = action.value)
 }
 
 @Suppress("ComplexMethod")

--- a/app/src/main/java/org/mozilla/focus/state/AppState.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppState.kt
@@ -13,10 +13,13 @@ import java.util.UUID
  *
  * @property screen The currently displayed screen.
  * @property topSites The list of [TopSite] to display on the Home screen.
+ * @property autoplayRulesChanged A flag which reflects the state of autoplay rules,
+ * whether they have been updated or not
  */
 data class AppState(
     val screen: Screen,
-    val topSites: List<TopSite> = emptyList()
+    val topSites: List<TopSite> = emptyList(),
+    val autoplayRulesChanged: Boolean = false
 ) : State
 
 /**

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -14,7 +14,6 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import org.mozilla.focus.R
-import org.mozilla.focus.ext.components
 import org.mozilla.focus.fragment.FirstrunFragment
 import org.mozilla.focus.searchsuggestions.SearchSuggestionsPreferences
 import org.mozilla.focus.settings.permissions.AutoplayOption
@@ -195,7 +194,6 @@ class Settings(
         preferences.edit()
             .putString(getPreferenceKey(R.string.pref_key_autoplay), prefKey)
             .apply()
-        context.components.sessionUseCases.reload.invoke(context.components.store.state.selectedTabId)
         currentAutoplayOption = getValueByPrefKey(autoplayPrefKey = prefKey, context = context)
     }
 


### PR DESCRIPTION
For #5743
Until now the the session was redundant updated with the old values and this commit add a new flag "reloadSession" to update the session when the autoplay option is changed

https://user-images.githubusercontent.com/11731652/148803226-3308f565-4a7e-485e-ac9d-f009f200cc47.mp4


