### PR TITLE
Update the target sdk to 31

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ import com.android.build.OutputFile
 import groovy.json.JsonOutput
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     if (project.hasProperty("testBuildType")) {
         // Allowing to configure the test build type via command line flag (./gradlew -PtestBuildType=beta ..)
@@ -22,7 +22,7 @@ android {
     defaultConfig {
         applicationId "org.mozilla"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
                        // override this with a generated versionCode at build time.
         versionName "98.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,9 @@
         android:name=".FocusApplication"
         android:usesCleartextTraffic="true">
 
-        <activity android:name=".activity.IntentReceiverActivity">
+        <activity
+            android:name=".activity.IntentReceiverActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -71,6 +73,7 @@
 
         <activity android:name=".activity.MainActivity"
             android:launchMode="singleTask"
+            android:exported="true"
             android:windowSoftInputMode="adjustResize|stateAlwaysHidden"
             android:configChanges="orientation|screenSize|screenLayout"
             android:label="@string/app_name">

--- a/service-telemetry/build.gradle
+++ b/service-telemetry/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
     }
 
     buildTypes {


### PR DESCRIPTION
For #6223
Update the target sdk to 31
Starting with Android 12 if the app component includes the LAUNCHER category android:exported should
be set to true
Also IntentReceiverActivity is marked as exported, in this way we can continue using the action.View