### PR TITLE
Address AC update conflicts

### DIFF
--- a/app/src/main/java/org/mozilla/focus/biometrics/LockObserver.kt
+++ b/app/src/main/java/org/mozilla/focus/biometrics/LockObserver.kt
@@ -5,9 +5,8 @@
 package org.mozilla.focus.biometrics
 
 import android.content.Context
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import mozilla.components.browser.state.selector.privateTabs
 import mozilla.components.browser.state.store.BrowserStore
 import org.mozilla.focus.GleanMetrics.TabCount
@@ -18,9 +17,10 @@ class LockObserver(
     private val context: Context,
     private val browserStore: BrowserStore,
     private val appStore: AppStore
-) : LifecycleObserver {
-    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-    fun onPause() {
+) : DefaultLifecycleObserver {
+
+    override fun onPause(owner: LifecycleOwner) {
+        super.onPause(owner)
 
         val tabCount = browserStore.state.privateTabs.size.toLong()
         TabCount.appBackgrounded.accumulateSamples(longArrayOf(tabCount))

--- a/app/src/main/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsViewModel.kt
+++ b/app/src/main/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsViewModel.kt
@@ -23,8 +23,8 @@ sealed class State {
 class SearchSuggestionsViewModel(application: Application) : AndroidViewModel(application) {
     private val preferences: SearchSuggestionsPreferences = SearchSuggestionsPreferences(application)
 
-    private val _selectedSearchSuggestion = MutableLiveData<String>()
-    val selectedSearchSuggestion: LiveData<String> = _selectedSearchSuggestion
+    private val _selectedSearchSuggestion = MutableLiveData<String?>()
+    val selectedSearchSuggestion: LiveData<String?> = _selectedSearchSuggestion
 
     private val _searchQuery = MutableLiveData<String>()
     val searchQuery: LiveData<String> = _searchQuery
@@ -32,8 +32,8 @@ class SearchSuggestionsViewModel(application: Application) : AndroidViewModel(ap
     private val _state = MutableLiveData<State>()
     val state: LiveData<State> = _state
 
-    private val _autocompleteSuggestion = MutableLiveData<String>()
-    val autocompleteSuggestion: LiveData<String> = _autocompleteSuggestion
+    private val _autocompleteSuggestion = MutableLiveData<String?>()
+    val autocompleteSuggestion: LiveData<String?> = _autocompleteSuggestion
 
     var alwaysSearch = false
         private set

--- a/app/src/test/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsViewModelTest.kt
+++ b/app/src/test/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsViewModelTest.kt
@@ -23,7 +23,7 @@ class SearchSuggestionsViewModelTest {
     var rule: TestRule = InstantTaskExecutorRule()
 
     @Mock
-    private lateinit var observer: Observer<String>
+    private lateinit var observer: Observer<String?>
 
     private lateinit var lifecycle: LifecycleRegistry
     private lateinit var viewModel: SearchSuggestionsViewModel

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "98.0.20220111190103"
+    const val VERSION = "98.0.20220114002255"
 }


### PR DESCRIPTION
For #6226
Update to Android-Components 98.0.20220114002255
OnLifecycleEvent is deprecated - to fix this we can use LifecycleEventObserver or DefaultLifecycleObserver
Now instead of using '@OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)' LockObserver.kt extends DefaultLifecycleObserver and override onPause method