### PR TITLE
For #6230 - Restore the searches measurement in core ping

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -30,6 +30,7 @@ import org.mozilla.telemetry.TelemetryHolder
 import org.mozilla.telemetry.config.TelemetryConfiguration
 import org.mozilla.telemetry.event.TelemetryEvent
 import org.mozilla.telemetry.measurement.DefaultSearchMeasurement
+import org.mozilla.telemetry.measurement.SearchesMeasurement
 import org.mozilla.telemetry.net.TelemetryClient
 import org.mozilla.telemetry.ping.TelemetryCorePingBuilder
 import org.mozilla.telemetry.ping.TelemetryEventPingBuilder
@@ -77,6 +78,8 @@ object TelemetryWrapper {
         val INSTALL = "install"
         val SHOW = "show"
         val HIDE = "hide"
+        val TYPE_QUERY = "type_query"
+        val TYPE_SELECT_QUERY = "select_query"
     }
 
     private object Object {
@@ -87,6 +90,7 @@ object TelemetryWrapper {
         val SEARCH_SUGGESTION_PROMPT = "search_suggestion_prompt"
         val MAKE_DEFAULT_BROWSER_OPEN_WITH = "make_default_browser_open_with"
         val MAKE_DEFAULT_BROWSER_SETTINGS = "make_default_browser_settings"
+        val SEARCH_BAR = "search_bar"
     }
 
     private object Value {
@@ -117,6 +121,7 @@ object TelemetryWrapper {
         val SUCCESS = "success"
         val TOTAL_URI_COUNT = "total_uri_count"
         val UNIQUE_DOMAINS_COUNT = "unique_domains_count"
+        val SEARCH_SUGGESTION = "search_suggestion"
     }
 
     @JvmStatic
@@ -294,6 +299,29 @@ object TelemetryWrapper {
             .queuePing(TelemetryEventPingBuilder.TYPE)
             .queuePing(TelemetryMobileMetricsPingBuilder.TYPE)
             .scheduleUpload()
+    }
+
+    fun searchEnterEvent() {
+        val telemetry = TelemetryHolder.get()
+
+        TelemetryEvent.create(Category.ACTION, Method.TYPE_QUERY, Object.SEARCH_BAR).queue()
+
+        val searchEngine = getDefaultSearchEngineIdentifierForTelemetry(telemetry.configuration.context)
+
+        telemetry.recordSearch(SearchesMeasurement.LOCATION_ACTIONBAR, searchEngine)
+    }
+
+    fun searchSelectEvent(isSearchSuggestion: Boolean) {
+        val telemetry = TelemetryHolder.get()
+
+        TelemetryEvent
+            .create(Category.ACTION, Method.TYPE_SELECT_QUERY, Object.SEARCH_BAR)
+            .extra(Extra.SEARCH_SUGGESTION, "$isSearchSuggestion")
+            .queue()
+
+        val searchEngineIdentifier = getDefaultSearchEngineIdentifierForTelemetry(telemetry.configuration.context)
+
+        telemetry.recordSearch(SearchesMeasurement.LOCATION_SUGGESTION, searchEngineIdentifier)
     }
 
     private fun getDefaultSearchEngineIdentifierForTelemetry(context: Context): String {


### PR DESCRIPTION
The searches measurement was inadvertently removed in the transition to Glean.
The Data Science team requested to restore the old functionality until all the
new Glean events are ready to supersede the old telemetry.

Tested using [gzipServer](https://github.com/mozilla/gzipServer):

https://user-images.githubusercontent.com/11428869/149773895-a7149b5f-9b8a-4be9-aa5f-9e05e7c9bfdc.mp4



Results:
```
{
  "searches": {
    "actionbar.Google": 2, 
    "suggestion.Google": 1
  }, 
  "tz": 120, 
  "seq": 17, 
  "created": "2022-01-19", 
  "locale": "en-US", 
  "arch": "x86", 
  "durations": 56, 
  "sessions": 1, 
  "clientId": "3576df1a-c67b-427c-afde-7737090fd4f1", 
  "profileDate": 19009, 
  "experiments": [], 
  "defaultSearch": "Google", 
  "v": 7, 
  "device": "Google-Android SDK built f", 
  "osversion": "27", 
  "os": "Android"
}
```
