### PR TITLE
Update the AC and fix the conflicts

### DIFF
--- a/app/src/test/java/org/mozilla/focus/topsites/DefaultTopSitesStorageTest.kt
+++ b/app/src/test/java/org/mozilla/focus/topsites/DefaultTopSitesStorageTest.kt
@@ -46,12 +46,11 @@ class DefaultTopSitesStorageTest {
             coroutineContext
         )
 
-        val pinnedSite = TopSite(
+        val pinnedSite = TopSite.Pinned(
             id = 2,
             title = "Firefox",
             url = "https://firefox.com",
-            createdAt = 2,
-            type = TopSite.Type.PINNED
+            createdAt = 2
         )
 
         defaultTopSitesStorage.removeTopSite(pinnedSite)
@@ -66,12 +65,11 @@ class DefaultTopSitesStorageTest {
             coroutineContext
         )
 
-        val pinnedSite = TopSite(
+        val pinnedSite = TopSite.Pinned(
             id = 2,
             title = "Wikipedia",
             url = "https://wikipedia.com",
-            createdAt = 2,
-            type = TopSite.Type.PINNED
+            createdAt = 2
         )
         defaultTopSitesStorage.updateTopSite(
             pinnedSite,
@@ -93,19 +91,17 @@ class DefaultTopSitesStorageTest {
             coroutineContext
         )
 
-        val pinnedSite1 = TopSite(
+        val pinnedSite1 = TopSite.Pinned(
             id = 2,
             title = "Wikipedia",
             url = "https://wikipedia.com",
-            createdAt = 2,
-            type = TopSite.Type.PINNED
+            createdAt = 2
         )
-        val pinnedSite2 = TopSite(
+        val pinnedSite2 = TopSite.Pinned(
             id = 3,
             title = "Example",
             url = "https://example.com",
-            createdAt = 3,
-            type = TopSite.Type.PINNED
+            createdAt = 3
         )
 
         whenever(pinnedSitesStorage.getPinnedSites()).thenReturn(

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "98.0.20220117190046"
+    const val VERSION = "98.0.20220118202952"
 }


### PR DESCRIPTION
For #6253 
Update to Android-Components 98.0.20220118202952
[Fixed] TopSite was converted to sealed class in AC and this generates reflection errors in DefaultTopSitesStorageTest.kt
This pr doesn't add something new as functionality that's why doesn't contains screenshots, accessibility

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
