### PR TITLE
Restore old telemetry.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/EraseAndOpenShortcutActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/EraseAndOpenShortcutActivity.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import mozilla.components.browser.state.selector.privateTabs
 import org.mozilla.focus.GleanMetrics.AppShortcuts
 import org.mozilla.focus.ext.components
+import org.mozilla.focus.telemetry.TelemetryWrapper
 
 class EraseAndOpenShortcutActivity : Activity() {
 
@@ -20,6 +21,8 @@ class EraseAndOpenShortcutActivity : Activity() {
 
         val tabCount = components.store.state.privateTabs.size
         AppShortcuts.eraseOpenButtonTapped.record(AppShortcuts.EraseOpenButtonTappedExtra(tabCount))
+
+        TelemetryWrapper.eraseAndOpenShortcutEvent()
 
         val intent = Intent(this, MainActivity::class.java)
         intent.action = MainActivity.ACTION_OPEN

--- a/app/src/main/java/org/mozilla/focus/activity/EraseShortcutActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/EraseShortcutActivity.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import mozilla.components.browser.state.selector.privateTabs
 import org.mozilla.focus.GleanMetrics.AppShortcuts
 import org.mozilla.focus.ext.components
+import org.mozilla.focus.telemetry.TelemetryWrapper
 
 class EraseShortcutActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -17,6 +18,8 @@ class EraseShortcutActivity : Activity() {
 
         val tabCount = components.store.state.privateTabs.size
         AppShortcuts.justEraseButtonTapped.record(AppShortcuts.JustEraseButtonTappedExtra(tabCount))
+
+        TelemetryWrapper.eraseShortcutEvent()
 
         finishAndRemoveTask()
     }

--- a/app/src/main/java/org/mozilla/focus/activity/InstallFirefoxActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/InstallFirefoxActivity.kt
@@ -15,6 +15,7 @@ import android.webkit.WebView
 import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.utils.Browsers
 import org.mozilla.focus.GleanMetrics.OpenWith
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.AppConstants
 
 /**
@@ -86,6 +87,8 @@ class InstallFirefoxActivity : Activity() {
             }
 
             OpenWith.installFirefox.record(NoExtras())
+
+            TelemetryWrapper.installFirefoxEvent()
         }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -94,6 +94,8 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
 
         if (intent.isLauncherIntent) {
             AppOpened.fromIcons.record(AppOpened.FromIconsExtra(AppOpenType.LAUNCH.type))
+
+            TelemetryWrapper.openFromIconEvent()
         }
 
         val launchCount = settings.getAppLaunchCount()
@@ -163,6 +165,8 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
 
         if (ACTION_OPEN == action) {
             Notifications.openButtonTapped.record(NoExtras())
+
+            TelemetryWrapper.openNotificationActionEvent()
         }
 
         if (ACTION_ERASE == action) {
@@ -171,18 +175,27 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
 
         if (intent.isLauncherIntent) {
             AppOpened.fromIcons.record(AppOpened.FromIconsExtra(AppOpenType.RESUME.type))
+
+            TelemetryWrapper.resumeFromIconEvent()
         }
 
         super.onNewIntent(unsafeIntent)
     }
 
     private fun processEraseAction(intent: SafeIntent) {
+        val fromShortcut = intent.getBooleanExtra(EXTRA_SHORTCUT, false)
         val fromNotificationAction = intent.getBooleanExtra(EXTRA_NOTIFICATION, false)
 
         components.tabsUseCases.removeAllTabs()
 
         if (fromNotificationAction) {
             Notifications.eraseOpenButtonTapped.record(Notifications.EraseOpenButtonTappedExtra(tabCount))
+        }
+
+        if (fromShortcut) {
+            TelemetryWrapper.eraseShortcutEvent()
+        } else if (fromNotificationAction) {
+            TelemetryWrapper.eraseAndOpenNotificationActionEvent()
         }
     }
 
@@ -294,5 +307,6 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
         const val ACTION_OPEN = "open"
 
         const val EXTRA_NOTIFICATION = "notification"
+        private const val EXTRA_SHORTCUT = "shortcut"
     }
 }

--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteAddFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteAddFragment.kt
@@ -24,6 +24,7 @@ import org.mozilla.focus.databinding.FragmentAutocompleteAddDomainBinding
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.settings.BaseSettingsLikeFragment
 import org.mozilla.focus.state.AppAction
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.ViewUtils
 import kotlin.coroutines.CoroutineContext
 
@@ -115,6 +116,7 @@ class AutocompleteAddFragment : BaseSettingsLikeFragment(), CoroutineScope {
         launch(IO) {
             CustomDomains.add(context, domain)
             Autocomplete.domainAdded.add()
+            TelemetryWrapper.saveAutocompleteDomainEvent(TelemetryWrapper.AutoCompleteEventSource.SETTINGS)
         }
 
         ViewUtils.showBrandedSnackbar(view, R.string.preference_autocomplete_add_confirmation, 0)

--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteListFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteListFragment.kt
@@ -36,6 +36,7 @@ import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.settings.BaseSettingsLikeFragment
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.ViewUtils
 import java.util.Collections
 import kotlin.coroutines.CoroutineContext
@@ -264,6 +265,7 @@ open class AutocompleteListFragment : BaseSettingsLikeFragment(), CoroutineScope
             launch(IO) {
                 CustomDomains.save(activity!!.applicationContext, domains)
                 Autocomplete.listOrderChanged.add()
+                TelemetryWrapper.reorderAutocompleteDomainEvent(from, to)
             }
         }
     }

--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteRemoveFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteRemoveFragment.kt
@@ -19,6 +19,7 @@ import org.mozilla.focus.GleanMetrics.Autocomplete
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.state.AppAction
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import kotlin.coroutines.CoroutineContext
 
 class AutocompleteRemoveFragment : AutocompleteListFragment(), CoroutineScope {
@@ -45,6 +46,7 @@ class AutocompleteRemoveFragment : AutocompleteListFragment(), CoroutineScope {
                 withContext(Dispatchers.Default) {
                     CustomDomains.remove(context, domains)
                     Autocomplete.domainRemoved.add()
+                    TelemetryWrapper.removeAutocompleteDomainsEvent(domains.size)
                 }
 
                 requireComponents.appStore.dispatch(

--- a/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteSettingsFragment.kt
@@ -13,6 +13,7 @@ import org.mozilla.focus.ext.requirePreference
 import org.mozilla.focus.settings.BaseSettingsFragment
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
+import org.mozilla.focus.telemetry.TelemetryWrapper
 
 /**
  * Settings UI for configuring autocomplete.
@@ -67,6 +68,9 @@ class AutocompleteSettingsFragment : BaseSettingsFragment(), SharedPreferences.O
         if (key == null || sharedPreferences == null) {
             return
         }
+
+        TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
+
         when (key) {
             topSitesAutocomplete.key ->
                 Autocomplete.topSitesSettingChanged.record(

--- a/app/src/main/java/org/mozilla/focus/browser/integration/BrowserMenuController.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/integration/BrowserMenuController.kt
@@ -21,6 +21,7 @@ import org.mozilla.focus.menu.ToolbarMenu
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.AppStore
 import org.mozilla.focus.state.Screen
+import org.mozilla.focus.telemetry.TelemetryWrapper
 
 @Suppress("LongParameterList")
 class BrowserMenuController(
@@ -55,9 +56,11 @@ class BrowserMenuController(
             is ToolbarMenu.Item.Forward, ToolbarMenu.CustomTabItem.Forward -> sessionUseCases.goForward(
                 currentTabId
             )
-            is ToolbarMenu.Item.Reload, ToolbarMenu.CustomTabItem.Reload -> sessionUseCases.reload(
-                currentTabId
-            )
+            is ToolbarMenu.Item.Reload, ToolbarMenu.CustomTabItem.Reload -> {
+                sessionUseCases.reload(currentTabId)
+
+                TelemetryWrapper.menuReloadEvent()
+            }
             is ToolbarMenu.Item.Stop, ToolbarMenu.CustomTabItem.Stop -> sessionUseCases.stopLoading(
                 currentTabId
             )
@@ -128,6 +131,8 @@ class BrowserMenuController(
                         BrowserMenu.BrowserMenuActionExtra("desktop_view_off")
                     )
                 }
+
+                TelemetryWrapper.desktopRequestCheckEvent(item.isChecked)
             }
             is ToolbarMenu.Item.AddToHomeScreen -> BrowserMenu.browserMenuAction.record(
                 BrowserMenu.BrowserMenuActionExtra("add_to_home_screen")

--- a/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
@@ -33,6 +33,7 @@ import org.mozilla.focus.R
 import org.mozilla.focus.ext.isCustomTab
 import org.mozilla.focus.fragment.BrowserFragment
 import org.mozilla.focus.menu.browser.CustomTabMenu
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.HardwareUtils
 
 @Suppress("LongParameterList")
@@ -70,6 +71,9 @@ class BrowserToolbarIntegration(
         listener = {
             val openedTabs = store.state.tabs.size
             TabCount.eraseButtonTapped.record(TabCount.EraseButtonTappedExtra(openedTabs))
+
+            TelemetryWrapper.eraseEvent()
+
             eraseActionListener.invoke()
         }
     )

--- a/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsListFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsListFragment.kt
@@ -36,6 +36,7 @@ import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.settings.BaseSettingsLikeFragment
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.ViewUtils
 import java.util.Collections
 import kotlin.coroutines.CoroutineContext
@@ -140,6 +141,9 @@ open class ExceptionsListFragment : BaseSettingsLikeFragment(), CoroutineScope {
                 TrackingProtectionExceptions.allowListCleared.record(
                     TrackingProtectionExceptions.AllowListClearedExtra(exceptionsListSize)
                 )
+
+                TelemetryWrapper.removeAllExceptionDomains(exceptionsListSize)
+
                 requireComponents.appStore.dispatch(
                     AppAction.NavigateUp(
                         requireComponents.store.state.selectedTabId

--- a/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsRemoveFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/exceptions/ExceptionsRemoveFragment.kt
@@ -15,6 +15,7 @@ import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.state.AppAction
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import kotlin.collections.forEach as withEach
 
 class ExceptionsRemoveFragment : ExceptionsListFragment() {
@@ -36,6 +37,8 @@ class ExceptionsRemoveFragment : ExceptionsListFragment() {
         TrackingProtectionExceptions.selectedItemsRemoved.record(
             TrackingProtectionExceptions.SelectedItemsRemovedExtra(exceptions.size)
         )
+
+        TelemetryWrapper.removeExceptionDomains(exceptions.size)
 
         if (exceptions.isNotEmpty()) {
             launch(Main) {

--- a/app/src/main/java/org/mozilla/focus/fragment/AddToHomescreenDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/AddToHomescreenDialogFragment.kt
@@ -23,6 +23,7 @@ import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.shortcut.HomeScreen
 import org.mozilla.focus.shortcut.IconGenerator
+import org.mozilla.focus.telemetry.TelemetryWrapper
 
 /**
  * Fragment displaying a dialog where a user can change the title for a homescreen shortcut
@@ -85,6 +86,9 @@ class AddToHomescreenDialogFragment : DialogFragment() {
 
         addToHomescreenDialogCancelButton.setOnClickListener {
             AddToHomeScreen.cancelButtonTapped.record(NoExtras())
+
+            TelemetryWrapper.cancelAddToHomescreenShortcutEvent()
+
             dismiss()
         }
 
@@ -104,6 +108,8 @@ class AddToHomescreenDialogFragment : DialogFragment() {
                     hasEditedTitle = hasEditedTitle
                 )
             )
+
+            TelemetryWrapper.addToHomescreenShortcutEvent()
 
             PreferenceManager.getDefaultSharedPreferences(context).edit()
                 .putBoolean(

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -80,6 +80,7 @@ import org.mozilla.focus.session.ui.TabsPopup
 import org.mozilla.focus.settings.privacy.ConnectionDetailsPanel
 import org.mozilla.focus.settings.privacy.TrackingProtectionPanel
 import org.mozilla.focus.state.AppAction
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.topsites.DefaultTopSitesStorage.Companion.TOP_SITES_MAX_LIMIT
 import org.mozilla.focus.topsites.DefaultTopSitesView
 import org.mozilla.focus.utils.FocusSnackbar
@@ -506,6 +507,9 @@ class BrowserFragment :
 
             DownloadState.Status.COMPLETED -> {
                 Downloads.downloadCompleted.record(NoExtras())
+
+                TelemetryWrapper.downloadDialogDownloadEvent(sentToDownload = true)
+
                 showDownloadCompletedSnackbar(state, extension)
             }
 
@@ -610,6 +614,7 @@ class BrowserFragment :
                 Browser.backButtonPressed.record(
                     Browser.BackButtonPressedExtra("erase_to_external_app")
                 )
+                TelemetryWrapper.eraseBackToAppEvent()
 
                 // This session has been started from a VIEW intent. Go back to the previous app
                 // immediately and erase the current browsing session.
@@ -629,6 +634,8 @@ class BrowserFragment :
                 Browser.backButtonPressed.record(
                     Browser.BackButtonPressedExtra("erase_to_home")
                 )
+
+                TelemetryWrapper.eraseBackToHomeEvent()
 
                 erase()
             }
@@ -660,6 +667,8 @@ class BrowserFragment :
             shareIntent.putExtra(Intent.EXTRA_SUBJECT, title)
         }
 
+        TelemetryWrapper.shareEvent()
+
         startActivity(Intent.createChooser(shareIntent, getString(R.string.share_dialog_title)))
     }
 
@@ -670,6 +679,8 @@ class BrowserFragment :
 
         // Release the session from this view so that it can immediately be rendered by a different view
         sessionFeature.get()?.release()
+
+        TelemetryWrapper.openFullBrowser()
 
         if (requireComponents.experimentalFeatures.tabs.isMultiTab) {
             requireComponents.customTabsUseCases.migrate(tab.id)
@@ -707,10 +718,13 @@ class BrowserFragment :
         )
 
         TabCount.sessionButtonTapped.record(TabCount.SessionButtonTappedExtra(openedTabs))
+
+        TelemetryWrapper.openTabsTrayEvent()
     }
 
     private fun showFindInPageBar() {
         findInPageIntegration.get()?.show(tab)
+        TelemetryWrapper.findInPageMenuEvent()
     }
 
     private fun openSelectBrowser() {
@@ -731,6 +745,8 @@ class BrowserFragment :
         fragment.show(requireFragmentManager(), OpenWithFragment.FRAGMENT_TAG)
 
         OpenWith.listDisplayed.record(OpenWith.ListDisplayedExtra(apps.size))
+
+        TelemetryWrapper.openSelectionEvent()
     }
 
     internal fun closeCustomTab() {

--- a/app/src/main/java/org/mozilla/focus/fragment/CrashReporterFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/CrashReporterFragment.kt
@@ -12,6 +12,7 @@ import mozilla.components.service.glean.private.NoExtras
 import org.mozilla.focus.GleanMetrics.CrashReporter
 import org.mozilla.focus.R
 import org.mozilla.focus.databinding.FragmentCrashReporterBinding
+import org.mozilla.focus.telemetry.TelemetryWrapper
 
 class CrashReporterFragment : Fragment(R.layout.fragment_crash_reporter) {
     var onCloseTabPressed: ((sendCrashReport: Boolean) -> Unit)? = null
@@ -24,9 +25,13 @@ class CrashReporterFragment : Fragment(R.layout.fragment_crash_reporter) {
 
         CrashReporter.displayed.record(NoExtras())
 
+        TelemetryWrapper.crashReporterOpened()
+
         binding.closeTabButton.setOnClickListener {
             val wantsSubmitCrashReport = binding.sendCrashCheckbox.isChecked
             CrashReporter.closeReport.record(CrashReporter.CloseReportExtra(wantsSubmitCrashReport))
+
+            TelemetryWrapper.closeTabButtonTapped(wantsSubmitCrashReport)
 
             onCloseTabPressed?.invoke(wantsSubmitCrashReport)
         }

--- a/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
@@ -19,6 +19,7 @@ import org.mozilla.focus.databinding.FragmentFirstrunBinding
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.firstrun.FirstrunPagerAdapter
 import org.mozilla.focus.state.AppAction
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.StatusBarUtils
 import kotlin.math.abs
 
@@ -37,6 +38,7 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
         // We will send a telemetry event whenever a new firstrun page is shown. However this page
         // listener won't fire for the initial page we are showing. So we are going to firing here.
         Onboarding.pageDisplayed.record(Onboarding.PageDisplayedExtra(0))
+        TelemetryWrapper.showFirstRunPageEvent(0)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -62,11 +64,15 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
             R.id.skip -> {
                 finishFirstrun()
                 Onboarding.skipButtonTapped.record(Onboarding.SkipButtonTappedExtra(currentItem))
+
+                TelemetryWrapper.skipFirstRunEvent()
             }
 
             R.id.finish -> {
                 finishFirstrun()
                 Onboarding.finishButtonTapped.record(Onboarding.FinishButtonTappedExtra(currentItem))
+
+                TelemetryWrapper.finishFirstRunEvent()
             }
 
             else -> throw IllegalArgumentException("Unknown view")
@@ -89,6 +95,7 @@ class FirstrunFragment : Fragment(), View.OnClickListener {
             addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
                 override fun onPageSelected(position: Int) {
                     Onboarding.pageDisplayed.record(Onboarding.PageDisplayedExtra(0))
+                    TelemetryWrapper.showFirstRunPageEvent(position)
 
                     contentDescription =
                         firstRunPagerAdapter.getPageAccessibilityDescription(position)

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -581,6 +581,8 @@ class UrlInputFragment :
 
             openUrl(url, searchTerms)
 
+            TelemetryWrapper.urlBarEvent(isUrl)
+
             if (isUrl) {
                 SearchBar.enteredUrl.record(NoExtras())
             } else {

--- a/app/src/main/java/org/mozilla/focus/open/OpenWithFragment.java
+++ b/app/src/main/java/org/mozilla/focus/open/OpenWithFragment.java
@@ -29,6 +29,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog;
 
 import org.mozilla.focus.GleanMetrics.OpenWith;
 import org.mozilla.focus.R;
+import org.mozilla.focus.telemetry.TelemetryWrapper;
 
 public class OpenWithFragment extends AppCompatDialogFragment implements AppAdapter.OnAppSelectedListener {
     public static final String FRAGMENT_TAG = "open_with";
@@ -142,6 +143,10 @@ public class OpenWithFragment extends AppCompatDialogFragment implements AppAdap
         startActivity(intent);
 
         OpenWith.INSTANCE.listItemTapped().record(new OpenWith.ListItemTappedExtra(app.getPackageName().contains("mozilla")));
+
+        if (app.getPackageName().contains("firefox")) {
+            TelemetryWrapper.openFirefoxEvent();
+        }
 
         dismiss();
     }

--- a/app/src/main/java/org/mozilla/focus/search/RadioSearchEngineListPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/search/RadioSearchEngineListPreference.kt
@@ -13,6 +13,7 @@ import mozilla.components.browser.state.search.SearchEngine
 import org.mozilla.focus.GleanMetrics.SearchEngines
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
+import org.mozilla.focus.telemetry.TelemetryWrapper
 
 private const val ENGINE_TYPE_CUSTOM = "custom"
 private const val ENGINE_TYPE_BUNDLED = "bundled"
@@ -56,5 +57,7 @@ class RadioSearchEngineListPreference : SearchEngineListPreference, RadioGroup.O
             ENGINE_TYPE_BUNDLED
 
         SearchEngines.setDefault.record(SearchEngines.SetDefaultExtra(source))
+
+        TelemetryWrapper.setDefaultSearchEngineEvent(source)
     }
 }

--- a/app/src/main/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsPreferences.kt
+++ b/app/src/main/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsPreferences.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import androidx.preference.PreferenceManager
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.settings
+import org.mozilla.focus.telemetry.TelemetryWrapper
 
 class SearchSuggestionsPreferences(private val context: Context) {
     private val settings = context.settings
@@ -22,6 +23,8 @@ class SearchSuggestionsPreferences(private val context: Context) {
             .putBoolean(TOGGLED_SUGGESTIONS_PREF, true)
             .putBoolean(context.resources.getString(R.string.pref_key_show_search_suggestions), true)
             .apply()
+
+        TelemetryWrapper.respondToSearchSuggestionPrompt(true)
     }
 
     fun disableSearchSuggestions() {
@@ -29,6 +32,8 @@ class SearchSuggestionsPreferences(private val context: Context) {
             .putBoolean(TOGGLED_SUGGESTIONS_PREF, true)
             .putBoolean(context.resources.getString(R.string.pref_key_show_search_suggestions), false)
             .apply()
+
+        TelemetryWrapper.respondToSearchSuggestionPrompt(false)
     }
 
     fun dismissNoSuggestionsMessage() {

--- a/app/src/main/java/org/mozilla/focus/session/SessionNotificationService.kt
+++ b/app/src/main/java/org/mozilla/focus/session/SessionNotificationService.kt
@@ -22,6 +22,7 @@ import org.mozilla.focus.GleanMetrics.RecentApps
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.MainActivity
 import org.mozilla.focus.ext.components
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.IntentUtils
 
 /**
@@ -42,6 +43,9 @@ class SessionNotificationService : Service() {
 
             ACTION_ERASE -> {
                 Notifications.notificationTapped.record(NoExtras())
+
+                TelemetryWrapper.eraseNotificationEvent()
+
                 shouldSendTaskRemovedTelemetry = false
 
                 if (VisibilityLifeCycleCallback.isInBackground(this)) {
@@ -66,6 +70,8 @@ class SessionNotificationService : Service() {
         // Do not double send telemetry for notification erase event
         if (shouldSendTaskRemovedTelemetry) {
             RecentApps.appRemovedFromList.record(NoExtras())
+
+            TelemetryWrapper.eraseTaskRemoved()
         }
 
         components.tabsUseCases.removeAllTabs()

--- a/app/src/main/java/org/mozilla/focus/session/ui/TabsPopup.kt
+++ b/app/src/main/java/org/mozilla/focus/session/ui/TabsPopup.kt
@@ -15,6 +15,7 @@ import org.mozilla.focus.Components
 import org.mozilla.focus.GleanMetrics.TabCount
 import org.mozilla.focus.databinding.PopupTabsBinding
 import org.mozilla.focus.state.AppAction
+import org.mozilla.focus.telemetry.TelemetryWrapper
 
 class TabsPopup(
     private val parentView: ViewGroup,
@@ -53,6 +54,9 @@ class TabsPopup(
         super.dismiss()
         val openedTabs = components.store.state.tabs.size
         TabCount.sessionListClosed.record(TabCount.SessionListClosedExtra(openedTabs))
+
+        TelemetryWrapper.closeTabsTrayEvent()
+
         components.appStore.dispatch(AppAction.HideTabs)
     }
 

--- a/app/src/main/java/org/mozilla/focus/settings/AdvancedSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/AdvancedSettingsFragment.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import org.mozilla.focus.GleanMetrics.AdvancedSettings
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
+import org.mozilla.focus.telemetry.TelemetryWrapper
 
 class AdvancedSettingsFragment :
     BaseSettingsFragment(),
@@ -32,6 +33,7 @@ class AdvancedSettingsFragment :
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+        TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
         when (key) {
             getString(R.string.pref_key_remote_debugging) -> {
                 requireComponents.engine.settings.remoteDebuggingEnabled =

--- a/app/src/main/java/org/mozilla/focus/settings/InstalledSearchEnginesSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/InstalledSearchEnginesSettingsFragment.kt
@@ -21,6 +21,7 @@ import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.search.RadioSearchEngineListPreference
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import kotlin.collections.forEach as withEach
 
 class InstalledSearchEnginesSettingsFragment : BaseSettingsFragment() {
@@ -68,6 +69,9 @@ class InstalledSearchEnginesSettingsFragment : BaseSettingsFragment() {
                 SearchEngines.openRemoveScreen.record(
                     SearchEngines.OpenRemoveScreenExtra(currentEnginesCount)
                 )
+
+                TelemetryWrapper.menuRemoveEnginesEvent()
+
                 true
             }
             R.id.menu_restore_default_engines -> {
@@ -84,6 +88,7 @@ class InstalledSearchEnginesSettingsFragment : BaseSettingsFragment() {
     private fun restoreSearchEngines() {
         restoreSearchDefaults(requireComponents.store, requireComponents.searchUseCases)
         refetchSearchEngines()
+        TelemetryWrapper.menuRestoreEnginesEvent()
         languageChanged = false
     }
 
@@ -94,6 +99,9 @@ class InstalledSearchEnginesSettingsFragment : BaseSettingsFragment() {
                     AppAction.OpenSettings(page = Screen.Settings.Page.SearchAdd)
                 )
                 SearchEngines.addEngineTapped.record(NoExtras())
+
+                TelemetryWrapper.menuAddSearchEngineEvent()
+
                 return true
             }
             else -> {

--- a/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
@@ -38,6 +38,7 @@ import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.ext.settings
 import org.mozilla.focus.search.ManualAddSearchEnginePreference
 import org.mozilla.focus.state.AppAction
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.SupportUtils
 import org.mozilla.focus.utils.UrlUtils
 import org.mozilla.focus.utils.ViewUtils
@@ -82,6 +83,8 @@ class ManualAddSearchEngineSettingsFragment : BaseSettingsFragment() {
             )
             SupportUtils.openUrlInCustomTab(requireActivity(), learnMoreUrl)
             SearchEngines.learnMoreTapped.record(NoExtras())
+
+            TelemetryWrapper.addSearchEngineLearnMoreEvent()
         }
 
         val saveSearchEngine = {
@@ -105,6 +108,8 @@ class ManualAddSearchEngineSettingsFragment : BaseSettingsFragment() {
                 }
             } else {
                 SearchEngines.saveEngineTapped.record(SearchEngines.SaveEngineTappedExtra(false))
+
+                TelemetryWrapper.saveCustomSearchEngineEvent(false)
             }
         }
 
@@ -218,6 +223,7 @@ class ManualAddSearchEngineSettingsFragment : BaseSettingsFragment() {
 
     private suspend fun validateSearchEngine(engineName: String, query: String, client: Client) {
         val isValidSearchQuery = isValidSearchQueryURL(client, query)
+        TelemetryWrapper.saveCustomSearchEngineEvent(isValidSearchQuery)
 
         withContext(Dispatchers.Main) {
             if (!isActive) {

--- a/app/src/main/java/org/mozilla/focus/settings/MozillaSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/MozillaSettingsFragment.kt
@@ -15,6 +15,7 @@ import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.AppConstants
 import org.mozilla.focus.utils.SupportUtils
 
@@ -87,6 +88,7 @@ class MozillaSettingsFragment :
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+        TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
         ProTips.tipsSettingChanged.record(
             ProTips.TipsSettingChangedExtra(sharedPreferences.all[key] as Boolean)
         )

--- a/app/src/main/java/org/mozilla/focus/settings/RemoveSearchEnginesSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/RemoveSearchEnginesSettingsFragment.kt
@@ -14,6 +14,7 @@ import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.search.MultiselectSearchEngineListPreference
 import org.mozilla.focus.state.AppAction
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.ViewUtils
 
 class RemoveSearchEnginesSettingsFragment : BaseSettingsFragment() {
@@ -58,6 +59,8 @@ class RemoveSearchEnginesSettingsFragment : BaseSettingsFragment() {
                     .findPreference(resources.getString(R.string.pref_key_multiselect_search_engine_list))
 
                 val enginesToRemove = pref!!.checkedEngineIds
+
+                TelemetryWrapper.removeSearchEnginesEvent(enginesToRemove.size)
 
                 requireComponents.store.state.search.searchEngines.filter { searchEngine ->
                     searchEngine.id in enginesToRemove

--- a/app/src/main/java/org/mozilla/focus/settings/SearchSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/SearchSettingsFragment.kt
@@ -14,6 +14,7 @@ import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
+import org.mozilla.focus.telemetry.TelemetryWrapper
 
 class SearchSettingsFragment :
     BaseSettingsFragment(),
@@ -42,6 +43,8 @@ class SearchSettingsFragment :
                     AppAction.OpenSettings(page = Screen.Settings.Page.SearchList)
                 )
                 SearchEngines.openSettings.record(NoExtras())
+
+                TelemetryWrapper.openSearchSettingsEvent()
             }
             resources.getString(R.string.pref_key_screen_autocomplete) ->
                 requireComponents.appStore.dispatch(

--- a/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.kt
@@ -15,6 +15,7 @@ import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.AppConstants
 import org.mozilla.focus.utils.SupportUtils
 import org.mozilla.focus.whatsnew.WhatsNew
@@ -69,6 +70,9 @@ class SettingsFragment : BaseSettingsFragment() {
         val context = requireContext()
 
         SettingsScreen.whatsNewTapped.add()
+
+        TelemetryWrapper.openWhatsNewEvent(WhatsNew.shouldHighlightWhatsNew(context))
+
         WhatsNew.userViewedWhatsNew(context)
 
         val sumoTopic = if (AppConstants.isKlarBuild)

--- a/app/src/main/java/org/mozilla/focus/settings/privacy/PrivacySecuritySettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/privacy/PrivacySecuritySettingsFragment.kt
@@ -20,6 +20,7 @@ import org.mozilla.focus.ext.settings
 import org.mozilla.focus.settings.BaseSettingsFragment
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
+import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.widget.CookiesPreference
 
 class PrivacySecuritySettingsFragment :
@@ -79,6 +80,7 @@ class PrivacySecuritySettingsFragment :
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
         recordTelemetry(key, sharedPreferences.all[key])
+        TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
         updateStealthToggleAvailability()
     }
 
@@ -136,6 +138,9 @@ class PrivacySecuritySettingsFragment :
         when (preference.key) {
             resources.getString(R.string.pref_key_screen_exceptions) -> {
                 TrackingProtectionExceptions.allowListOpened.record(NoExtras())
+
+                TelemetryWrapper.openExceptionsListSetting()
+
                 requireComponents.appStore.dispatch(
                     AppAction.OpenSettings(page = Screen.Settings.Page.PrivacyExceptions)
                 )

--- a/app/src/main/java/org/mozilla/focus/telemetry/FactsProcessor.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/FactsProcessor.kt
@@ -47,11 +47,16 @@ object FactsProcessor {
 
         Component.FEATURE_CUSTOMTABS to CustomTabsFacts.Items.CLOSE -> {
             CustomTabsToolbar.closeTabTapped.record(NoExtras())
+
+            TelemetryWrapper.closeCustomTabEvent()
         }
 
         Component.FEATURE_CUSTOMTABS to CustomTabsFacts.Items.ACTION_BUTTON -> {
             CustomTabsToolbar.actionButtonTapped.record(NoExtras())
+
+            TelemetryWrapper.customTabActionButtonEvent()
         }
+
         Component.FEATURE_CONTEXTMENU to ContextMenuFacts.Items.ITEM -> {
             ContextMenu.itemTapped.record(ContextMenu.ItemTappedExtra(toContextMenuExtraKey()))
         }
@@ -59,6 +64,8 @@ object FactsProcessor {
         Component.BROWSER_MENU to BrowserMenuFacts.Items.WEB_EXTENSION_MENU_ITEM -> {
             if (metadata?.get("id") == "webcompat-reporter@mozilla.org") {
                 Browser.reportSiteIssueCounter.add()
+
+                TelemetryWrapper.reportSiteIssueEvent()
             } else {
                 // other extension action was emitted
             }

--- a/app/src/main/java/org/mozilla/focus/telemetry/FactsProcessor.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/FactsProcessor.kt
@@ -85,6 +85,10 @@ object FactsProcessor {
             }
         }
 
+        Component.BROWSER_TOOLBAR to ToolbarFacts.Items.MENU -> {
+            metadata?.get("customTab")?.let { TelemetryWrapper.customTabMenuEvent() }
+        }
+
         else -> Unit
     }
 }

--- a/app/src/main/java/org/mozilla/focus/telemetry/FactsProcessor.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/FactsProcessor.kt
@@ -6,6 +6,7 @@ package org.mozilla.focus.telemetry
 
 import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.menu.facts.BrowserMenuFacts
+import mozilla.components.browser.toolbar.facts.ToolbarFacts
 import mozilla.components.feature.contextmenu.facts.ContextMenuFacts
 import mozilla.components.feature.customtabs.CustomTabsFacts
 import mozilla.components.feature.search.telemetry.ads.AdsTelemetry
@@ -59,6 +60,19 @@ object FactsProcessor {
 
         Component.FEATURE_CONTEXTMENU to ContextMenuFacts.Items.ITEM -> {
             ContextMenu.itemTapped.record(ContextMenu.ItemTappedExtra(toContextMenuExtraKey()))
+
+            when (this.toContextMenuExtraKey()) {
+                "copy_link" -> TelemetryWrapper.copyLinkEvent()
+                "share_link" -> TelemetryWrapper.shareLinkEvent()
+                "copy_image_location" -> TelemetryWrapper.copyImageEvent()
+                "share_image" -> TelemetryWrapper.shareImageEvent()
+                "save_image" -> TelemetryWrapper.saveImageEvent()
+                "open_in_private_tab" -> TelemetryWrapper.openLinkInNewTabEvent()
+                "open_in_external_app" -> TelemetryWrapper.openLinkInFullBrowserFromCustomTabEvent()
+                else -> {
+                    // no op
+                }
+            }
         }
 
         Component.BROWSER_MENU to BrowserMenuFacts.Items.WEB_EXTENSION_MENU_ITEM -> {

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryMiddleware.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryMiddleware.kt
@@ -61,6 +61,8 @@ class TelemetryMiddleware : Middleware<BrowserState, BrowserAction> {
             is DownloadAction.UpdateDownloadAction -> {
                 if (action.download.status == DownloadState.Status.CANCELLED) {
                     Downloads.downloadCanceled.record(NoExtras())
+
+                    TelemetryWrapper.downloadDialogDownloadEvent(sentToDownload = false)
                 }
             }
         }
@@ -75,17 +77,25 @@ class TelemetryMiddleware : Middleware<BrowserState, BrowserAction> {
         when (tab.source) {
             is SessionState.Source.External.ActionView -> {
                 AppOpened.browseIntent.record(NoExtras())
+
+                TelemetryWrapper.browseIntentEvent()
             }
             is SessionState.Source.External.ActionSend -> {
                 AppOpened.shareIntent.record(
                     AppOpened.ShareIntentExtra(tab.content.searchTerms.isNotEmpty())
                 )
+
+                TelemetryWrapper.shareIntentEvent(tab.content.searchTerms.isNotEmpty())
             }
             SessionState.Source.Internal.TextSelection -> {
                 AppOpened.textSelectionIntent.record(NoExtras())
+
+                TelemetryWrapper.textSelectionIntentEvent()
             }
             SessionState.Source.Internal.HomeScreen -> {
                 AppOpened.fromLauncherSiteShortcut.record(NoExtras())
+
+                TelemetryWrapper.openHomescreenShortcutEvent()
             }
             SessionState.Source.Internal.NewTab -> {
                 val parentTab = (tab as TabSessionState).parentId?.let { context.state.findTab(it) }

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -64,64 +64,109 @@ object TelemetryWrapper {
         get() = !AppConstants.isKlarBuild
 
     private object Category {
-        val ACTION = "action"
-        val ERROR = "error"
-        val HISTOGRAM = "histogram"
+        const val ACTION = "action"
+        const val HISTOGRAM = "histogram"
     }
 
     private object Method {
-        val CLICK = "click"
-        val CANCEL = "cancel"
-        val LONG_PRESS = "long_press"
-        val CHANGE = "change"
-        val OPEN = "open"
-        val INSTALL = "install"
-        val SHOW = "show"
-        val HIDE = "hide"
-        val TYPE_QUERY = "type_query"
-        val TYPE_SELECT_QUERY = "select_query"
+        const val TYPE_URL = "type_url"
+        const val TYPE_QUERY = "type_query"
+        const val TYPE_SELECT_QUERY = "select_query"
+        const val CLICK = "click"
+        const val CHANGE = "change"
+        const val FOREGROUND = "foreground"
+        const val BACKGROUND = "background"
+        const val SHARE = "share"
+        const val SAVE = "save"
+        const val COPY = "copy"
+        const val OPEN = "open"
+        const val INSTALL = "install"
+        const val INTENT_URL = "intent_url"
+        const val TEXT_SELECTION_INTENT = "text_selection_intent"
+        const val SHOW = "show"
+        const val HIDE = "hide"
+        const val SHARE_INTENT = "share_intent"
+        const val REMOVE = "remove"
+        const val REMOVE_ALL = "remove_all"
+        const val REORDER = "reorder"
+        const val RESTORE = "restore"
     }
 
     private object Object {
-        val SETTING = "setting"
-        val MENU = "menu"
-        val BLOCKING_SWITCH = "blocking_switch"
-        val BROWSER = "browser"
-        val SEARCH_SUGGESTION_PROMPT = "search_suggestion_prompt"
-        val MAKE_DEFAULT_BROWSER_OPEN_WITH = "make_default_browser_open_with"
-        val MAKE_DEFAULT_BROWSER_SETTINGS = "make_default_browser_settings"
-        val SEARCH_BAR = "search_bar"
+        const val SEARCH_BAR = "search_bar"
+        const val ERASE_BUTTON = "erase_button"
+        const val SETTING = "setting"
+        const val APP = "app"
+        const val MENU = "menu"
+        const val BACK_BUTTON = "back_button"
+        const val NOTIFICATION = "notification"
+        const val NOTIFICATION_ACTION = "notification_action"
+        const val SHORTCUT = "shortcut"
+        const val DESKTOP_REQUEST_CHECK = "desktop_request_check"
+        const val BROWSER = "browser"
+        const val BROWSER_CONTEXTMENU = "browser_contextmenu"
+        const val CUSTOM_TAB_CLOSE_BUTTON = "custom_tab_close_but"
+        const val CUSTOM_TAB_ACTION_BUTTON = "custom_tab_action_bu"
+        const val FIRSTRUN = "firstrun"
+        const val DOWNLOAD_DIALOG = "download_dialog"
+        const val ADD_TO_HOMESCREEN_DIALOG = "add_to_homescreen_dialog"
+        const val HOMESCREEN_SHORTCUT = "homescreen_shortcut"
+        const val TABS_TRAY = "tabs_tray"
+        const val RECENT_APPS = "recent_apps"
+        const val APP_ICON = "app_icon"
+        const val AUTOCOMPLETE_DOMAIN = "autocomplete_domain"
+        const val SEARCH_ENGINE_SETTING = "search_engine_setting"
+        const val ADD_SEARCH_ENGINE_LEARN_MORE = "search_engine_learn_more"
+        const val CUSTOM_SEARCH_ENGINE = "custom_search_engine"
+        const val REMOVE_SEARCH_ENGINES = "remove_search_engines"
+        const val SEARCH_SUGGESTION_PROMPT = "search_suggestion_prompt"
+        const val MAKE_DEFAULT_BROWSER_OPEN_WITH = "make_default_browser_open_with"
+        const val MAKE_DEFAULT_BROWSER_SETTINGS = "make_default_browser_settings"
+        const val ALLOWLIST = "allowlist"
+        const val CRASH_REPORTER = "crash_reporter"
     }
 
     private object Value {
-        val DEFAULT = "default"
-        val FIREFOX = "firefox"
-        val SELECTION = "selection"
-        val OPEN = "open"
-        val URL = "url"
-        val SEARCH = "search"
-        val CANCEL = "cancel"
-        val TAB = "tab"
-        val WHATS_NEW = "whats_new"
-        val RESUME = "resume"
-        val FULL_BROWSER = "full_browser"
-        val SETTINGS = "settings"
-        val QUICK_ADD = "quick_add"
-        val CLOSE_TAB = "close_tab"
+        const val FIREFOX = "firefox"
+        const val SELECTION = "selection"
+        const val ERASE = "erase"
+        const val ERASE_AND_OPEN = "erase_open"
+        const val ERASE_TO_HOME = "erase_home"
+        const val ERASE_TO_APP = "erase_app"
+        const val IMAGE = "image"
+        const val LINK = "link"
+        const val CUSTOM_TAB = "custom_tab"
+        const val SKIP = "skip"
+        const val FINISH = "finish"
+        const val OPEN = "open"
+        const val DOWNLOAD = "download"
+        const val URL = "url"
+        const val SEARCH = "search"
+        const val CANCEL = "cancel"
+        const val ADD_TO_HOMESCREEN = "add_to_homescreen"
+        const val TAB = "tab"
+        const val WHATS_NEW = "whats_new"
+        const val RESUME = "resume"
+        const val RELOAD = "refresh"
+        const val FULL_BROWSER = "full_browser"
+        const val REPORT_ISSUE = "report_issue"
+        const val SETTINGS = "settings"
+        const val FIND_IN_PAGE = "find_in_page"
+        const val CLOSE_TAB = "close_tab"
     }
 
     private object Extra {
-        val FROM = "from"
-        val TO = "to"
-        val TOTAL = "total"
-        val SELECTED = "selected"
-        val HIGHLIGHTED = "highlighted"
-        val AUTOCOMPLETE = "autocomplete"
-        val SOURCE = "source"
-        val SUCCESS = "success"
-        val TOTAL_URI_COUNT = "total_uri_count"
-        val UNIQUE_DOMAINS_COUNT = "unique_domains_count"
-        val SEARCH_SUGGESTION = "search_suggestion"
+        const val FROM = "from"
+        const val TO = "to"
+        const val TOTAL = "total"
+        const val SELECTED = "selected"
+        const val HIGHLIGHTED = "highlighted"
+        const val SOURCE = "source"
+        const val SUCCESS = "success"
+        const val SEARCH_SUGGESTION = "search_suggestion"
+        const val TOTAL_URI_COUNT = "total_uri_count"
+        const val UNIQUE_DOMAINS_COUNT = "unique_domains_count"
+        const val SUBMIT_CRASH = "submit_crash"
     }
 
     @JvmStatic
@@ -250,6 +295,8 @@ object TelemetryWrapper {
     @JvmStatic
     fun startSession() {
         TelemetryHolder.get().recordSessionStart()
+
+        TelemetryEvent.create(Category.ACTION, Method.FOREGROUND, Object.APP).queue()
     }
 
     @VisibleForTesting var histogram = IntArray(HISTOGRAM_SIZE)
@@ -279,6 +326,15 @@ object TelemetryWrapper {
     fun stopSession() {
         TelemetryHolder.get().recordSessionEnd()
 
+        val histogramEvent = TelemetryEvent.create(Category.HISTOGRAM, Method.FOREGROUND, Object.BROWSER)
+        for (bucketIndex in histogram.indices) {
+            histogramEvent.extra((bucketIndex * BUCKET_SIZE_MS).toString(), histogram[bucketIndex].toString())
+        }
+        histogramEvent.queue()
+
+        // Clear histogram array after queueing it
+        histogram = IntArray(HISTOGRAM_SIZE)
+
         TelemetryEvent.create(Category.ACTION, Method.OPEN, Object.BROWSER).extra(
             Extra.UNIQUE_DOMAINS_COUNT,
             domainMap.size.toString()
@@ -290,6 +346,8 @@ object TelemetryWrapper {
             numUri.toString()
         ).queue()
         numUri = 0
+
+        TelemetryEvent.create(Category.ACTION, Method.BACKGROUND, Object.APP).queue()
     }
 
     @JvmStatic
@@ -299,6 +357,64 @@ object TelemetryWrapper {
             .queuePing(TelemetryEventPingBuilder.TYPE)
             .queuePing(TelemetryMobileMetricsPingBuilder.TYPE)
             .scheduleUpload()
+    }
+
+    @JvmStatic
+    fun urlBarEvent(isUrl: Boolean) {
+        if (isUrl) {
+            browseEvent()
+        } else {
+            searchEnterEvent()
+        }
+    }
+
+    private fun browseEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.TYPE_URL, Object.SEARCH_BAR)
+            .queue()
+    }
+
+    @JvmStatic
+    fun browseIntentEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.INTENT_URL, Object.APP).queue()
+    }
+
+    @JvmStatic
+    fun shareIntentEvent(isSearch: Boolean) {
+        if (isSearch) {
+            TelemetryEvent.create(Category.ACTION, Method.SHARE_INTENT, Object.APP, Value.SEARCH).queue()
+        } else {
+            TelemetryEvent.create(Category.ACTION, Method.SHARE_INTENT, Object.APP, Value.URL).queue()
+        }
+    }
+
+    @JvmStatic
+    fun downloadDialogDownloadEvent(sentToDownload: Boolean) {
+        if (sentToDownload) {
+            TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.DOWNLOAD_DIALOG, Value.DOWNLOAD).queue()
+        } else {
+            TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.DOWNLOAD_DIALOG, Value.CANCEL).queue()
+        }
+    }
+
+    @JvmStatic
+    fun closeCustomTabEvent() {
+        withSessionCounts(TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.CUSTOM_TAB_CLOSE_BUTTON))
+            .queue()
+    }
+
+    @JvmStatic
+    fun customTabActionButtonEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.CUSTOM_TAB_ACTION_BUTTON).queue()
+    }
+
+    @JvmStatic
+    fun customTabMenuEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.OPEN, Object.MENU, Value.CUSTOM_TAB).queue()
+    }
+
+    @JvmStatic
+    fun textSelectionIntentEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.TEXT_SELECTION_INTENT, Object.APP).queue()
     }
 
     fun searchEnterEvent() {
@@ -334,6 +450,101 @@ object TelemetryWrapper {
     }
 
     @JvmStatic
+    fun eraseEvent() {
+        withSessionCounts(TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.ERASE_BUTTON))
+            .queue()
+    }
+
+    @JvmStatic
+    fun eraseBackToHomeEvent() {
+        withSessionCounts(TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.BACK_BUTTON, Value.ERASE_TO_HOME))
+            .queue()
+    }
+
+    @JvmStatic
+    fun eraseBackToAppEvent() {
+        withSessionCounts(TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.BACK_BUTTON, Value.ERASE_TO_APP))
+            .queue()
+    }
+
+    @JvmStatic
+    fun eraseNotificationEvent() {
+        withSessionCounts(TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.NOTIFICATION, Value.ERASE))
+            .queue()
+    }
+
+    @JvmStatic
+    fun eraseAndOpenNotificationActionEvent() {
+        withSessionCounts(
+            TelemetryEvent.create(
+                Category.ACTION,
+                Method.CLICK,
+                Object.NOTIFICATION_ACTION,
+                Value.ERASE_AND_OPEN
+            )
+        ).queue()
+    }
+
+    @JvmStatic
+    fun crashReporterOpened() {
+        TelemetryEvent.create(Category.ACTION, Method.SHOW, Object.CRASH_REPORTER).queue()
+    }
+
+    @JvmStatic
+    fun closeTabButtonTapped(crashSubmitted: Boolean) {
+        TelemetryEvent.create(
+            Category.ACTION,
+            Method.CLICK,
+            Object.CRASH_REPORTER,
+            Value.CLOSE_TAB
+        )
+            .extra(Extra.SUBMIT_CRASH, crashSubmitted.toString()).queue()
+    }
+
+    @JvmStatic
+    fun openNotificationActionEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.NOTIFICATION_ACTION, Value.OPEN).queue()
+    }
+
+    @JvmStatic
+    fun openHomescreenShortcutEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.HOMESCREEN_SHORTCUT, Value.OPEN).queue()
+    }
+
+    @JvmStatic
+    fun addToHomescreenShortcutEvent() {
+        TelemetryEvent.create(
+            Category.ACTION,
+            Method.CLICK,
+            Object.ADD_TO_HOMESCREEN_DIALOG,
+            Value.ADD_TO_HOMESCREEN
+        ).queue()
+    }
+
+    @JvmStatic
+    fun cancelAddToHomescreenShortcutEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.ADD_TO_HOMESCREEN_DIALOG, Value.CANCEL).queue()
+    }
+
+    @JvmStatic
+    fun eraseShortcutEvent() {
+        withSessionCounts(TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.SHORTCUT, Value.ERASE))
+            .queue()
+    }
+
+    @JvmStatic
+    fun eraseAndOpenShortcutEvent() {
+        withSessionCounts(TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.SHORTCUT, Value.ERASE_AND_OPEN))
+            .queue()
+    }
+
+    @JvmStatic
+    fun eraseTaskRemoved() {
+        withSessionCounts(TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.RECENT_APPS, Value.ERASE))
+            .queue()
+    }
+
+    @JvmStatic
     fun settingsEvent(key: String, value: String) {
         TelemetryEvent.create(Category.ACTION, Method.CHANGE, Object.SETTING, key)
             .extra(Extra.TO, value)
@@ -341,17 +552,244 @@ object TelemetryWrapper {
     }
 
     @JvmStatic
-    fun blockingSwitchEvent(isBlockingEnabled: Boolean) {
+    fun shareEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.SHARE, Object.MENU).queue()
+    }
+
+    @JvmStatic
+    fun shareLinkEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.SHARE, Object.BROWSER_CONTEXTMENU, Value.LINK).queue()
+    }
+
+    @JvmStatic
+    fun shareImageEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.SHARE, Object.BROWSER_CONTEXTMENU, Value.IMAGE).queue()
+    }
+
+    @JvmStatic
+    fun saveImageEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.SAVE, Object.BROWSER_CONTEXTMENU, Value.IMAGE).queue()
+    }
+
+    @JvmStatic
+    fun copyLinkEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.COPY, Object.BROWSER_CONTEXTMENU, Value.LINK).queue()
+    }
+
+    @JvmStatic
+    fun copyImageEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.COPY, Object.BROWSER_CONTEXTMENU, Value.IMAGE).queue()
+    }
+
+    @JvmStatic
+    fun openLinkInNewTabEvent() {
+        withSessionCounts(TelemetryEvent.create(Category.ACTION, Method.OPEN, Object.BROWSER_CONTEXTMENU, Value.TAB))
+            .queue()
+    }
+
+    @JvmStatic
+    fun openLinkInFullBrowserFromCustomTabEvent() {
+        withSessionCounts(
+            TelemetryEvent.create(
+                Category.ACTION,
+                Method.OPEN,
+                Object.BROWSER_CONTEXTMENU,
+                Value.FULL_BROWSER
+            )
+        )
+            .queue()
+    }
+
+    /**
+     * Switching from a custom tab to the full-featured browser (regular tab).
+     */
+    @JvmStatic
+    fun openFullBrowser() {
+        TelemetryEvent.create(Category.ACTION, Method.OPEN, Object.MENU, Value.FULL_BROWSER).queue()
+    }
+
+    @JvmStatic
+    fun openFromIconEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.APP_ICON, Value.OPEN).queue()
+    }
+
+    @JvmStatic
+    fun resumeFromIconEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.APP_ICON, Value.RESUME).queue()
+    }
+
+    @JvmStatic
+    fun openFirefoxEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.OPEN, Object.MENU, Value.FIREFOX).queue()
+    }
+
+    @JvmStatic
+    fun installFirefoxEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.INSTALL, Object.APP, Value.FIREFOX).queue()
+    }
+
+    @JvmStatic
+    fun openSelectionEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.OPEN, Object.MENU, Value.SELECTION).queue()
+    }
+
+    @JvmStatic
+    fun openExceptionsListSetting() {
+        TelemetryEvent.create(Category.ACTION, Method.OPEN, Object.ALLOWLIST).queue()
+    }
+
+    fun removeExceptionDomains(count: Int) {
+        TelemetryEvent.create(Category.ACTION, Method.REMOVE, Object.ALLOWLIST)
+            .extra(Extra.TOTAL, count.toString())
+            .queue()
+    }
+
+    fun removeAllExceptionDomains(count: Int) {
+        TelemetryEvent.create(Category.ACTION, Method.REMOVE_ALL, Object.ALLOWLIST)
+            .extra(Extra.TOTAL, count.toString())
+            .queue()
+    }
+
+    @JvmStatic
+    fun desktopRequestCheckEvent(shouldRequestDesktop: Boolean) {
         TelemetryEvent.create(
             Category.ACTION,
             Method.CLICK,
-            Object.BLOCKING_SWITCH,
-            isBlockingEnabled.toString()
+            Object.DESKTOP_REQUEST_CHECK,
+            shouldRequestDesktop.toString()
         ).queue()
+    }
+
+    @JvmStatic
+    fun showFirstRunPageEvent(page: Int) {
+        TelemetryEvent.create(Category.ACTION, Method.SHOW, Object.FIRSTRUN, page.toString()).queue()
+    }
+
+    @JvmStatic
+    fun skipFirstRunEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.FIRSTRUN, Value.SKIP).queue()
+    }
+
+    @JvmStatic
+    fun finishFirstRunEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.FIRSTRUN, Value.FINISH).queue()
+    }
+
+    @JvmStatic
+    fun openTabsTrayEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.SHOW, Object.TABS_TRAY).queue()
+    }
+
+    @JvmStatic
+    fun openWhatsNewEvent(highlighted: Boolean) {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.SETTING, Value.WHATS_NEW)
+            .extra(Extra.HIGHLIGHTED, highlighted.toString())
+            .queue()
+    }
+
+    @JvmStatic
+    fun findInPageMenuEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.OPEN, Object.MENU, Value.FIND_IN_PAGE).queue()
+    }
+
+    @JvmStatic
+    fun closeTabsTrayEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.HIDE, Object.TABS_TRAY).queue()
+    }
+
+    @JvmStatic
+    fun menuReloadEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.MENU, Value.RELOAD).queue()
     }
 
     enum class AutoCompleteEventSource {
         SETTINGS
+    }
+
+    fun saveAutocompleteDomainEvent(eventSource: AutoCompleteEventSource) {
+        val source = when (eventSource) {
+            AutoCompleteEventSource.SETTINGS -> Value.SETTINGS
+        }
+
+        TelemetryEvent.create(Category.ACTION, Method.SAVE, Object.AUTOCOMPLETE_DOMAIN)
+            .extra(Extra.SOURCE, source)
+            .queue()
+    }
+
+    fun removeAutocompleteDomainsEvent(count: Int) {
+        TelemetryEvent.create(Category.ACTION, Method.REMOVE, Object.AUTOCOMPLETE_DOMAIN)
+            .extra(Extra.TOTAL, count.toString())
+            .queue()
+    }
+
+    fun reorderAutocompleteDomainEvent(from: Int, to: Int) {
+        TelemetryEvent.create(Category.ACTION, Method.REORDER, Object.AUTOCOMPLETE_DOMAIN)
+            .extra(Extra.FROM, from.toString())
+            .extra(Extra.TO, to.toString())
+            .queue()
+    }
+
+    @JvmStatic
+    fun setDefaultSearchEngineEvent(source: String) {
+        TelemetryEvent.create(Category.ACTION, Method.SAVE, Object.SEARCH_ENGINE_SETTING)
+            .extra(Extra.SOURCE, source)
+            .queue()
+    }
+
+    @JvmStatic
+    fun openSearchSettingsEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.OPEN, Object.SEARCH_ENGINE_SETTING).queue()
+    }
+
+    @JvmStatic
+    fun menuRemoveEnginesEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.REMOVE, Object.SEARCH_ENGINE_SETTING).queue()
+    }
+
+    @JvmStatic
+    fun menuRestoreEnginesEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.RESTORE, Object.SEARCH_ENGINE_SETTING).queue()
+    }
+
+    @JvmStatic
+    fun menuAddSearchEngineEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.SHOW, Object.CUSTOM_SEARCH_ENGINE).queue()
+    }
+
+    @JvmStatic
+    fun saveCustomSearchEngineEvent(success: Boolean) {
+        TelemetryEvent.create(Category.ACTION, Method.SAVE, Object.CUSTOM_SEARCH_ENGINE)
+            .extra(Extra.SUCCESS, success.toString())
+            .queue()
+    }
+
+    @JvmStatic
+    fun removeSearchEnginesEvent(selected: Int) {
+        TelemetryEvent.create(Category.ACTION, Method.REMOVE, Object.REMOVE_SEARCH_ENGINES)
+            .extra(Extra.SELECTED, selected.toString())
+            .queue()
+    }
+
+    @JvmStatic
+    fun addSearchEngineLearnMoreEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.ADD_SEARCH_ENGINE_LEARN_MORE).queue()
+    }
+
+    @JvmStatic
+    fun reportSiteIssueEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.MENU, Value.REPORT_ISSUE).queue()
+    }
+
+    @JvmStatic
+    fun respondToSearchSuggestionPrompt(enable: Boolean) {
+        TelemetryEvent
+            .create(Category.ACTION, Method.CLICK, Object.SEARCH_SUGGESTION_PROMPT, "$enable")
+            .queue()
+    }
+
+    @JvmStatic
+    fun makeDefaultBrowserSettings() {
+        TelemetryEvent.create(Category.ACTION, Method.SHOW, Object.MAKE_DEFAULT_BROWSER_SETTINGS).queue()
     }
 
     @JvmStatic


### PR DESCRIPTION
Notes:

1. This restores the old telemetry in the same state that it was when the migration to Glean process began. Meaning, if the previous implementation was not proper, this just restores it. Some of the obvious errors were fixed while restoring.
2. The tips telemetry has not been restored, the previous one even had a wrong trigger.
3. Some of the context menu/browser telemetry was not recorded after the migration to AC. I reintroduced the ones that are still valid.
4. Some telemetry was obsolete even before the migration, for example, switch to gecko view from the web view. This obsolete telemetry was not reinstated. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
