### PR TITLE
Address conflicts of AC update to 98.0.20220121045448

### DIFF
--- a/app/src/main/java/org/mozilla/focus/experiments/NimbusSetup.kt
+++ b/app/src/main/java/org/mozilla/focus/experiments/NimbusSetup.kt
@@ -93,7 +93,7 @@ fun createNimbus(context: Context, url: String?): NimbusApi =
         } else {
             Logger.error("Failed to initialize Nimbus", e)
         }
-        NimbusDisabled()
+        NimbusDisabled(context = context)
     }
 
 fun getNimbusAppName(): String {

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "98.0.20220120190433"
+    const val VERSION = "98.0.20220121045448"
 }


### PR DESCRIPTION
Update version AC to 98.0.20220121045448
NimbusDisabled.class was updated in the last version of AC and now we need to override its context
No need of Tests, screenshots, accessibility

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
