### PR TITLE
For #6152: Re-enable first run tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/AddToHomescreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/AddToHomescreenTest.kt
@@ -12,9 +12,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.settings
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
-import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.readTestAsset
 import org.mozilla.focus.helpers.TestHelper.webPageLoadwaitingTime
 import org.mozilla.focus.testAnnotations.SmokeTest
@@ -26,6 +25,7 @@ import java.io.IOException
 @RunWith(AndroidJUnit4ClassRunner::class)
 class AddToHomescreenTest {
     private lateinit var webServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get: Rule
     var mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
@@ -42,7 +42,7 @@ class AddToHomescreenTest {
         } catch (e: IOException) {
             throw AssertionError("Could not start web server", e)
         }
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
     }
 
     @After
@@ -52,6 +52,7 @@ class AddToHomescreenTest {
         } catch (e: IOException) {
             throw AssertionError("Could not stop web server", e)
         }
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
@@ -95,8 +95,7 @@ class CustomTabTest {
 
     @SmokeTest
     @Test
-    @Ignore("This test should be updated since kotlin extensions were migrated to view binding")
-    // https://github.com/mozilla-mobile/focus-android/issues/5767
+    @Ignore("Crashing, see: https://github.com/mozilla-mobile/focus-android/issues/5283")
     fun openCustomTabInFocusTest() {
         val browserPage = webServer.url("plain_test.html").toString()
         val customTabPage = webServer.url("tab1.html").toString()

--- a/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
@@ -29,8 +29,7 @@ import org.mozilla.focus.activity.robots.browserScreen
 import org.mozilla.focus.activity.robots.customTab
 import org.mozilla.focus.activity.robots.homeScreen
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.settings
-import org.mozilla.focus.helpers.TestHelper
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.TestHelper.createMockResponseFromAsset
 import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.webPageLoadwaitingTime
@@ -44,6 +43,7 @@ class CustomTabTest {
     private val MENU_ITEM_LABEL = "TestItem4223"
     private val ACTION_BUTTON_DESCRIPTION = "TestButton"
     private val TEST_PAGE_HEADER_TEXT = "focus test page"
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get: Rule
     val activityTestRule = ActivityTestRule(
@@ -52,7 +52,7 @@ class CustomTabTest {
 
     @Before
     fun setUp() {
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
         webServer = MockWebServer()
         webServer.enqueue(createMockResponseFromAsset("plain_test.html"))
         webServer.enqueue(createMockResponseFromAsset("tab1.html"))
@@ -66,6 +66,7 @@ class CustomTabTest {
         } catch (e: IOException) {
             throw AssertionError("Could not stop web server", e)
         }
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
@@ -15,8 +15,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.activity.robots.downloadRobot
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.settings
 import org.mozilla.focus.helpers.DeleteFilesHelper.deleteFileUsingDisplayName
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityIntentsTestRule
 import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.mDevice
@@ -29,6 +29,7 @@ import java.io.IOException
 @RunWith(AndroidJUnit4ClassRunner::class)
 class DownloadFileTest {
     private lateinit var webServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
     var mActivityTestRule = MainActivityIntentsTestRule(showFirstRun = false)
@@ -41,7 +42,7 @@ class DownloadFileTest {
 
     @Before
     fun setUp() {
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
         webServer = MockWebServer()
         try {
             webServer.enqueue(
@@ -80,6 +81,7 @@ class DownloadFileTest {
         }
         val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
         deleteFileUsingDisplayName(context, "download.jpg")
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/activity/EnhancedTrackingProtectionSettingsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/EnhancedTrackingProtectionSettingsTest.kt
@@ -14,9 +14,8 @@ import org.junit.runner.RunWith
 import org.mozilla.focus.activity.robots.browserScreen
 import org.mozilla.focus.activity.robots.homeScreen
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.settings
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
-import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.createMockResponseFromAsset
 import org.mozilla.focus.helpers.TestHelper.exitToBrowser
 import org.mozilla.focus.helpers.TestHelper.exitToTop
@@ -27,13 +26,14 @@ import java.io.IOException
 @RunWith(AndroidJUnit4ClassRunner::class)
 class EnhancedTrackingProtectionSettingsTest {
     private lateinit var webServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get: Rule
     var mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
 
     @Before
     fun setUp() {
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
         webServer = MockWebServer()
         try {
             webServer.start()
@@ -50,6 +50,7 @@ class EnhancedTrackingProtectionSettingsTest {
         } catch (e: IOException) {
             throw AssertionError("Could not stop web server", e)
         }
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/activity/EraseBrowsingDataTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/EraseBrowsingDataTest.kt
@@ -21,9 +21,8 @@ import org.mozilla.focus.R
 import org.mozilla.focus.activity.robots.homeScreen
 import org.mozilla.focus.activity.robots.notificationTray
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.settings
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
-import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.getStringResource
 import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.pressHomeKey
@@ -37,6 +36,7 @@ import java.io.IOException
 @RunWith(AndroidJUnit4ClassRunner::class)
 class EraseBrowsingDataTest {
     private lateinit var webServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get: Rule
     var mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
@@ -61,7 +61,7 @@ class EraseBrowsingDataTest {
         } catch (e: IOException) {
             throw AssertionError("Could not start web server", e)
         }
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
     }
 
     @After
@@ -72,6 +72,7 @@ class EraseBrowsingDataTest {
         } catch (e: IOException) {
             throw AssertionError("Could not stop web server", e)
         }
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
@@ -4,27 +4,34 @@
 package org.mozilla.focus.activity
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.settings
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
-import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.getStringResource
 import org.mozilla.focus.helpers.TestHelper.setNetworkEnabled
 
 // This tests verify invalid URL and no network connection error pages
 @RunWith(AndroidJUnit4ClassRunner::class)
 class ErrorPagesTest {
+    private val featureSettingsHelper = FeatureSettingsHelper()
+
     @get: Rule
     val mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
 
     @Before
     fun setUp() {
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
+    }
+
+    @After
+    fun tearDown() {
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/focus/activity/FirstRunTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/FirstRunTest.kt
@@ -9,13 +9,13 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.robots.homeScreen
 import org.mozilla.focus.activity.robots.searchScreen
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
 import org.mozilla.focus.helpers.TestHelper.createMockResponseFromAsset
 import org.mozilla.focus.helpers.TestHelper.getStringResource
@@ -24,8 +24,9 @@ import org.mozilla.focus.testAnnotations.SmokeTest
 
 // Tests the First run onboarding screens
 @RunWith(AndroidJUnit4ClassRunner::class)
-class FirstRunDialogueTest {
+class FirstRunTest {
     private lateinit var webServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get: Rule
     val mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = true)
@@ -34,11 +35,13 @@ class FirstRunDialogueTest {
     fun startWebServer() {
         webServer = MockWebServer()
         webServer.start()
+        featureSettingsHelper.setShieldIconCFREnabled(false)
     }
 
     @After
     fun stopWebServer() {
         webServer.shutdown()
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @Test
@@ -57,8 +60,6 @@ class FirstRunDialogueTest {
     }
 
     @Test
-    @Ignore("This test should be updated since kotlin extensions were migrated to view binding")
-    // https://github.com/mozilla-mobile/focus-android/issues/5767
     fun skipFirstRunOnboardingTest() {
         homeScreen {
             verifyOnboardingFirstSlide()
@@ -71,8 +72,6 @@ class FirstRunDialogueTest {
 
     @SmokeTest
     @Test
-    @Ignore("This test should be updated since kotlin extensions were migrated to view binding")
-    // https://github.com/mozilla-mobile/focus-android/issues/5767
     fun homeScreenTipsTest() {
         // Scrolling left/right through the tips carousel to check the tips displaying order
         homeScreen {
@@ -101,8 +100,6 @@ class FirstRunDialogueTest {
 
     @SmokeTest
     @Test
-    @Ignore("This test should be updated since kotlin extensions were migrated to view binding")
-    // https://github.com/mozilla-mobile/focus-android/issues/5767
     fun verifyWhatsNewLinkFromTips() {
         homeScreen {
             skipFirstRun()
@@ -116,8 +113,6 @@ class FirstRunDialogueTest {
 
     @SmokeTest
     @Test
-    @Ignore("This test should be updated since kotlin extensions were migrated to view binding")
-    // https://github.com/mozilla-mobile/focus-android/issues/5767
     fun verifyAllowListLinkFromTips() {
         homeScreen {
             skipFirstRun()
@@ -132,8 +127,6 @@ class FirstRunDialogueTest {
 
     @SmokeTest
     @Test
-    @Ignore("This test should be updated since kotlin extensions were migrated to view binding")
-    // https://github.com/mozilla-mobile/focus-android/issues/5767
     fun verifySwitchToDesktopSiteLinkFromTips() {
         homeScreen {
             skipFirstRun()
@@ -150,8 +143,6 @@ class FirstRunDialogueTest {
 
     @SmokeTest
     @Test
-    @Ignore("This test should be updated since kotlin extensions were migrated to view binding")
-    // https://github.com/mozilla-mobile/focus-android/issues/5767
     fun firstTipIsAlwaysDisplayedTest() {
         webServer.enqueue(createMockResponseFromAsset("tab1.html"))
         val pageUrl = webServer.url("tab1.html").toString()

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MediaPlaybackTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MediaPlaybackTest.kt
@@ -9,21 +9,21 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.settings
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
-import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.createMockResponseFromAsset
 import org.mozilla.focus.testAnnotations.SmokeTest
 
 class MediaPlaybackTest {
     private lateinit var webServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
     var mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
 
     @Before
     fun setUp() {
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
         webServer = MockWebServer()
         webServer.start()
     }
@@ -31,6 +31,7 @@ class MediaPlaybackTest {
     @After
     fun tearDown() {
         webServer.shutdown()
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MozillaSupportPagesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MozillaSupportPagesTest.kt
@@ -4,13 +4,14 @@
 package org.mozilla.focus.activity
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.robots.homeScreen
-import org.mozilla.focus.ext.settings
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
 import org.mozilla.focus.helpers.TestHelper.appContext
 import org.mozilla.focus.helpers.TestHelper.exitToTop
@@ -19,12 +20,19 @@ import org.mozilla.focus.testAnnotations.SmokeTest
 // This test visits each About page and checks whether some essential elements are being displayed
 @RunWith(AndroidJUnit4ClassRunner::class)
 class MozillaSupportPagesTest {
+    private val featureSettingsHelper = FeatureSettingsHelper()
+
     @get: Rule
     val mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
 
     @Before
     fun setUp() {
-        appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
+    }
+
+    @After
+    fun tearDown() {
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MultitaskingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MultitaskingTest.kt
@@ -16,9 +16,8 @@ import org.junit.runner.RunWith
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.robots.searchScreen
 import org.mozilla.focus.ext.components
-import org.mozilla.focus.ext.settings
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
-import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.clickSnackBarActionButton
 import org.mozilla.focus.helpers.TestHelper.createMockResponseFromAsset
 import org.mozilla.focus.helpers.TestHelper.getStringResource
@@ -36,6 +35,7 @@ class MultitaskingTest {
         .applicationContext
         .components
         .store
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get: Rule
     var mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
@@ -43,7 +43,7 @@ class MultitaskingTest {
     @Before
     @Throws(Exception::class)
     fun startWebServer() {
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
         webServer = MockWebServer()
         webServer.enqueue(createMockResponseFromAsset("tab1.html"))
         webServer.enqueue(createMockResponseFromAsset("tab2.html"))
@@ -53,8 +53,9 @@ class MultitaskingTest {
 
     @After
     @Throws(Exception::class)
-    fun stopWebServer() {
+    fun tearDown() {
         webServer.shutdown()
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/activity/OpenInExternalBrowserDialogueTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/OpenInExternalBrowserDialogueTest.kt
@@ -17,9 +17,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.settings
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityIntentsTestRule
-import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.isPackageInstalled
 import org.mozilla.focus.helpers.TestHelper.readTestAsset
 import org.mozilla.focus.helpers.TestHelper.waitingTime
@@ -30,13 +29,14 @@ import java.io.IOException
 @RunWith(AndroidJUnit4ClassRunner::class)
 class OpenInExternalBrowserDialogueTest {
     private lateinit var webServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get: Rule
     var mActivityTestRule = MainActivityIntentsTestRule(showFirstRun = false)
 
     @Before
     fun setUp() {
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
         webServer = MockWebServer()
         try {
             webServer.enqueue(
@@ -53,6 +53,7 @@ class OpenInExternalBrowserDialogueTest {
     fun tearDown() {
         mActivityTestRule.activity.finishAndRemoveTask()
         webServer.shutdown()
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SafeBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SafeBrowsingTest.kt
@@ -11,9 +11,8 @@ import org.junit.Test
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.robots.homeScreen
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.settings
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
-import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.createMockResponseFromAsset
 import org.mozilla.focus.helpers.TestHelper.exitToTop
 import org.mozilla.focus.helpers.TestHelper.getStringResource
@@ -28,13 +27,14 @@ class SafeBrowsingTest {
         getStringResource(R.string.mozac_browser_errorpages_safe_browsing_unwanted_uri_title)
     private val harmfulSiteWarning = getStringResource(R.string.mozac_browser_errorpages_safe_harmful_uri_title)
     private val tryAgainButton = getStringResource(R.string.mozac_browser_errorpages_page_refresh)
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get: Rule
     val mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
 
     @Before
     fun setUp() {
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
         webServer = MockWebServer()
         webServer.start()
     }
@@ -42,6 +42,7 @@ class SafeBrowsingTest {
     @After
     fun tearDown() {
         webServer.shutdown()
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SearchTest.kt
@@ -4,15 +4,15 @@
 package org.mozilla.focus.activity
 
 import androidx.test.espresso.Espresso.pressBack
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.focus.activity.robots.browserScreen
 import org.mozilla.focus.activity.robots.homeScreen
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.settings
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
-import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.exitToTop
 import org.mozilla.focus.helpers.TestHelper.pressEnterKey
 import org.mozilla.focus.helpers.TestHelper.webPageLoadwaitingTime
@@ -21,13 +21,19 @@ import org.mozilla.focus.testAnnotations.SmokeTest
 // This test checks the search engine can be changed and that search suggestions appear
 class SearchTest {
     private val enginesList = listOf("DuckDuckGo", "Google", "Amazon.com", "Wikipedia")
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get: Rule
     var mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
 
     @Before
     fun setUp() {
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
+    }
+
+    @After
+    fun tearDown() {
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ShareWebsiteTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ShareWebsiteTest.kt
@@ -12,9 +12,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.settings
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
-import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.readTestAsset
 import org.mozilla.focus.helpers.TestHelper.webPageLoadwaitingTime
@@ -25,13 +24,14 @@ import java.io.IOException
 @RunWith(AndroidJUnit4ClassRunner::class)
 class ShareWebsiteTest {
     private lateinit var webServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get: Rule
     var mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
 
     @Before
     fun setUp() {
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
         webServer = MockWebServer()
         try {
             webServer.enqueue(
@@ -51,6 +51,7 @@ class ShareWebsiteTest {
         } catch (e: IOException) {
             throw AssertionError("Could not stop web server", e)
         }
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SwitchContextTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SwitchContextTest.kt
@@ -21,9 +21,8 @@ import org.junit.runner.RunWith
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.robots.notificationTray
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.settings
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
-import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.getStringResource
 import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.pressHomeKey
@@ -36,13 +35,14 @@ import java.io.IOException
 @RunWith(AndroidJUnit4ClassRunner::class)
 class SwitchContextTest {
     private lateinit var webServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get: Rule
     var mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
 
     @Before
     fun setUp() {
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
         webServer = MockWebServer()
         try {
             webServer.enqueue(
@@ -80,6 +80,7 @@ class SwitchContextTest {
         } catch (e: IOException) {
             throw AssertionError("Could not stop web server", e)
         }
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ThreeDotMainMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ThreeDotMainMenuTest.kt
@@ -10,7 +10,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.focus.activity.robots.homeScreen
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.settings
+import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
 import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.testAnnotations.SmokeTest
@@ -20,6 +20,7 @@ import org.mozilla.focus.testAnnotations.SmokeTest
  */
 class ThreeDotMainMenuTest {
     private lateinit var webServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get: Rule
     val mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
@@ -29,12 +30,13 @@ class ThreeDotMainMenuTest {
         webServer = MockWebServer()
         webServer.enqueue(TestHelper.createMockResponseFromAsset("tab1.html"))
         webServer.start()
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        featureSettingsHelper.setShieldIconCFREnabled(false)
     }
 
     @After
-    fun stopWebServer() {
+    fun tearDown() {
         webServer.shutdown()
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/focus/helpers/FeatureSettingsHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/FeatureSettingsHelper.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.helpers
+
+import android.content.Context
+import androidx.test.platform.app.InstrumentationRegistry
+import org.mozilla.focus.ext.settings
+
+class FeatureSettingsHelper {
+    val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val settings = context.settings
+
+    // saving default values of feature flags
+    private var isShieldIconCFREnabled: Boolean = settings.isCfrForForShieldToolbarIconVisible
+
+
+    fun setShieldIconCFREnabled(enabled: Boolean) {
+        settings.isCfrForForShieldToolbarIconVisible = enabled
+    }
+
+    // Important:
+    // Use this after each test if you have modified these feature settings
+    // to make sure the app goes back to the default state
+    fun resetAllFeatureFlags() {
+        settings.isCfrForForShieldToolbarIconVisible = isShieldIconCFREnabled
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/focus/helpers/FeatureSettingsHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/FeatureSettingsHelper.kt
@@ -15,7 +15,6 @@ class FeatureSettingsHelper {
     // saving default values of feature flags
     private var isShieldIconCFREnabled: Boolean = settings.isCfrForForShieldToolbarIconVisible
 
-
     fun setShieldIconCFREnabled(enabled: Boolean) {
         settings.isCfrForForShieldToolbarIconVisible = enabled
     }


### PR DESCRIPTION
Also, added a featureSettingsHelper for setting feature flags (similar to Fenix) to all affected tests.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
