### PR TITLE
For #6332 - Properly anchor the Tracking Protection CFR

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/helpers/FeatureSettingsHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/FeatureSettingsHelper.kt
@@ -13,16 +13,16 @@ class FeatureSettingsHelper {
     private val settings = context.settings
 
     // saving default values of feature flags
-    private var isShieldIconCFREnabled: Boolean = settings.isCfrForForShieldToolbarIconVisible
+    private var shouldShowCfrForShieldToolbarIcon: Boolean = settings.shouldShowCfrForShieldToolbarIcon
 
     fun setShieldIconCFREnabled(enabled: Boolean) {
-        settings.isCfrForForShieldToolbarIconVisible = enabled
+        settings.shouldShowCfrForShieldToolbarIcon = enabled
     }
 
     // Important:
     // Use this after each test if you have modified these feature settings
     // to make sure the app goes back to the default state
     fun resetAllFeatureFlags() {
-        settings.isCfrForForShieldToolbarIconVisible = isShieldIconCFREnabled
+        settings.shouldShowCfrForShieldToolbarIcon = shouldShowCfrForShieldToolbarIcon
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/privacy/LocalSessionStorageTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/privacy/LocalSessionStorageTest.kt
@@ -54,7 +54,7 @@ class LocalSessionStorageTest {
         } catch (e: IOException) {
             throw AssertionError("Could not start web server", e)
         }
-        TestHelper.appContext.settings.isCfrForForShieldToolbarIconVisible = false
+        TestHelper.appContext.settings.shouldShowCfrForShieldToolbarIcon = false
     }
 
     @After

--- a/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
@@ -47,6 +47,7 @@ class BrowserToolbarIntegration(
     private val onUrlLongClicked: () -> Boolean,
     private val eraseActionListener: () -> Unit,
     private val tabCounterListener: () -> Unit,
+    private val onTrackingProtectionShown: () -> Unit,
     private val customTabId: String? = null,
     inTesting: Boolean = false
 ) : LifecycleAwareFeature {
@@ -216,6 +217,7 @@ class BrowserToolbarIntegration(
                     val url = it.content.url
                     if (secure && Indicators.SECURITY in toolbar.display.indicators) {
                         addTrackingProtectionIndicator()
+                        onTrackingProtectionShown()
                     } else if (!secure && Indicators.SECURITY !in toolbar.display.indicators &&
                         !url.trim().startsWith("about:")
                     ) {

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -322,11 +322,10 @@ class BrowserFragment :
         }
 
         setSitePermissions(view)
-        showCfrForShieldToolbarIcon()
     }
 
     private fun showCfrForShieldToolbarIcon() {
-        val cfrForShieldToolbarIcon = CfrUtils.shouldShowCFRForShieldToolbarIcon(
+        val cfrForShieldToolbarIcon = CfrUtils.showCFRForShieldToolbarIconIfNeeded(
             rootView = binding.browserToolbar.rootView, context = requireContext(),
             isContentSecure = tab.content.securityInfo.secure
         )
@@ -418,7 +417,8 @@ class BrowserFragment :
                 sessionUseCases = requireComponents.sessionUseCases,
                 onUrlLongClicked = ::onUrlLongClicked,
                 eraseActionListener = { erase(shouldEraseAllTabs = true) },
-                tabCounterListener = ::tabCounterListener
+                tabCounterListener = ::tabCounterListener,
+                onTrackingProtectionShown = ::showCfrForShieldToolbarIcon
             ),
             owner = this,
             view = binding.browserToolbar
@@ -448,6 +448,8 @@ class BrowserFragment :
         _toolbarShieldIconCfrBinding = null
         // PopupWindow should be dismissed because it causes Static Field Leaked
         if (toolbarShieldIconCfrPopupWindow != null && toolbarShieldIconCfrPopupWindow?.isShowing == true) {
+            // DismissListener from CfrUtils should not be called when user exits the screen
+            toolbarShieldIconCfrPopupWindow?.setOnDismissListener(null)
             toolbarShieldIconCfrPopupWindow?.dismiss()
         }
     }

--- a/app/src/main/java/org/mozilla/focus/utils/CfrUtils.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/CfrUtils.kt
@@ -26,14 +26,15 @@ class CfrUtils {
         private const val SHIELD_ICON_CFR_Y_OFFSET = -18f
 
         /**
-         * Shows CFR for Shield Toolbar Icon  if content is not secure.
+         * Shows CFR for Shield Toolbar Icon  if content is secure.
+         * This should be shown only when Shield Icon is visible.
          *
          * @property rootView of Browser Toolbar.
          * @property context where CFR should be shown.
          * @property isContentSecure true if the tab is currently pointed to a URL
          * with a valid SSL certificate, otherwise false.
          */
-        fun shouldShowCFRForShieldToolbarIcon(
+        fun showCFRForShieldToolbarIconIfNeeded(
             rootView: View,
             context: Context,
             isContentSecure: Boolean
@@ -42,8 +43,8 @@ class CfrUtils {
                 R.id.mozac_browser_toolbar_tracking_protection_indicator
             )
             if (shieldToolbarIcon != null &&
-                context.settings.isCfrForForShieldToolbarIconVisible &&
-                !isContentSecure
+                context.settings.shouldShowCfrForShieldToolbarIcon &&
+                isContentSecure
             ) {
 
                 val toolbarShieldIconCfrBinding = ToolbarShieldIconCfrBinding.inflate(
@@ -58,23 +59,19 @@ class CfrUtils {
                         LinearLayout.LayoutParams.WRAP_CONTENT,
                         true
                     )
-
-                shieldToolbarIcon.post {
-                    toolbarShieldIconCfrPopupWindow.showAsDropDown(
-                        shieldToolbarIcon, 0,
-                        TypedValue.applyDimension(
-                            TypedValue.COMPLEX_UNIT_DIP, SHIELD_ICON_CFR_Y_OFFSET,
-                            context.resources.displayMetrics
-                        ).roundToInt(),
-                        Gravity.BOTTOM
-                    )
-                }
-
+                toolbarShieldIconCfrPopupWindow.showAsDropDown(
+                    shieldToolbarIcon, 0,
+                    TypedValue.applyDimension(
+                        TypedValue.COMPLEX_UNIT_DIP, SHIELD_ICON_CFR_Y_OFFSET,
+                        context.resources.displayMetrics
+                    ).roundToInt(),
+                    Gravity.BOTTOM
+                )
                 toolbarShieldIconCfrBinding.closeInfoBanner.setOnClickListener {
                     toolbarShieldIconCfrPopupWindow.dismiss()
                 }
                 toolbarShieldIconCfrPopupWindow.setOnDismissListener {
-                    context.settings.isCfrForForShieldToolbarIconVisible = false
+                    context.settings.shouldShowCfrForShieldToolbarIcon = false
                 }
                 return CFRForShieldToolbarIcon(toolbarShieldIconCfrBinding, toolbarShieldIconCfrPopupWindow)
             }

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -176,7 +176,7 @@ class Settings(
                 .commit()
         }
 
-    var isCfrForForShieldToolbarIconVisible: Boolean
+    var shouldShowCfrForShieldToolbarIcon: Boolean
         get() = preferences.getBoolean(getPreferenceKey(R.string.pref_cfr_visibility_for_shield_toolbar_icon), true)
         set(value) {
             preferences.edit()

--- a/app/src/test/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegrationTest.kt
+++ b/app/src/test/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegrationTest.kt
@@ -84,7 +84,8 @@ class BrowserToolbarIntegrationTest {
                 onUrlLongClicked = { false },
                 eraseActionListener = {},
                 tabCounterListener = {},
-                inTesting = true
+                inTesting = true,
+                onTrackingProtectionShown = {},
             )
         )
     }


### PR DESCRIPTION
 Add cfrForShieldToolbarIconListener in BrowserToolbarIntegration and show cfr only after Shield Icon is visible.
 Add toolbarShieldIconCfrPopupWindow?.setOnDismissListener(null) in onDestroyView . 
 Rename some files .

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
