### PR TITLE
For #6297 - Add flag for CFR Shield Icon to be shown only in DevOrNig…

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/CfrUtils.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/CfrUtils.kt
@@ -42,9 +42,10 @@ class CfrUtils {
             val shieldToolbarIcon = rootView.findViewById<View>(
                 R.id.mozac_browser_toolbar_tracking_protection_indicator
             )
-            if (shieldToolbarIcon != null &&
-                context.settings.shouldShowCfrForShieldToolbarIcon &&
-                isContentSecure
+            if (shouldShowCFRForShieldToolbarIcon(
+                    shieldToolbarIcon = shieldToolbarIcon, context = context,
+                    isContentSecure = isContentSecure
+                )
             ) {
 
                 val toolbarShieldIconCfrBinding = ToolbarShieldIconCfrBinding.inflate(
@@ -77,5 +78,14 @@ class CfrUtils {
             }
             return null
         }
+
+        private fun shouldShowCFRForShieldToolbarIcon(
+            shieldToolbarIcon: View?,
+            context: Context,
+            isContentSecure: Boolean
+        ): Boolean =
+            Features.SHOULD_SHOW_CFR_FOR_SHIELD_TOOLBAR_ICON && shieldToolbarIcon != null &&
+                context.settings.shouldShowCfrForShieldToolbarIcon &&
+                isContentSecure
     }
 }

--- a/app/src/main/java/org/mozilla/focus/utils/Features.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Features.kt
@@ -9,7 +9,7 @@ package org.mozilla.focus.utils
  */
 object Features {
     const val SEARCH_TERMS_OR_URL: Boolean = true
-
+    val SHOULD_SHOW_CFR_FOR_SHIELD_TOOLBAR_ICON = AppConstants.isDevOrNightlyBuild
     /**
      * HTTPS-Only mode.
      * https://support.mozilla.org/en-US/kb/https-only-prefs-focus


### PR DESCRIPTION

 Add flag for CFR Shield Icon to be shown only in DevOrNightlyBuild

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
