### PR TITLE
For #6393: Ensure that browser fragment is initialised and added to activity.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/CustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/CustomTabActivity.kt
@@ -45,7 +45,7 @@ class CustomTabActivity : LocaleAwareAppCompatActivity() {
 
         setContentView(R.layout.activity_customtab)
 
-        if (savedInstanceState == null) {
+        if (savedInstanceState == null || !this::browserFragment.isInitialized) {
             browserFragment = BrowserFragment.createForTab(customTabId)
             supportFragmentManager.beginTransaction()
                 .add(R.id.container, browserFragment)


### PR DESCRIPTION
…ctivity.

This ensures that activity is not restored without a fragment.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
