### PR TITLE
for #5310 Integrate LeakCanary

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -261,6 +261,7 @@ dependencies {
 
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.kotlin_coroutines
+    debugImplementation Dependencies.leakcanary
 
     focusImplementation 'com.adjust.sdk:adjust-android:4.11.4'
     focusImplementation 'com.android.installreferrer:installreferrer:1.1' // Required by Adjust

--- a/app/src/androidTest/java/org/mozilla/focus/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/TestHelper.kt
@@ -20,7 +20,6 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import okhttp3.mockwebserver.MockResponse
 import okio.Buffer
-import okio.Okio
 import org.hamcrest.Matchers
 import org.hamcrest.Matchers.allOf
 import org.junit.Assert
@@ -342,7 +341,7 @@ object TestHelper {
     @Throws(IOException::class)
     fun readStreamFile(file: InputStream?): Buffer {
         val buffer = Buffer()
-        buffer.writeAll(Okio.source(file!!))
+        buffer.write(file!!.readBytes())
         return buffer
     }
 

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,4 +15,9 @@
     <!-- Allows changing locales for FastLane screenshots -->
     <uses-permission android:name="android.permission.CHANGE_CONFIGURATION"
         tools:ignore="ProtectedPermissions" />
+    <application
+        tools:replace="android:name"
+        android:name="org.mozilla.focus.DebugFocusApplication"
+        android:icon="@mipmap/ic_launcher">
+    </application>
 </manifest>

--- a/app/src/debug/java/org/mozilla/focus/DebugFocusApplication.kt
+++ b/app/src/debug/java/org/mozilla/focus/DebugFocusApplication.kt
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus
+
+import androidx.preference.PreferenceManager
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import leakcanary.AppWatcher
+import leakcanary.LeakCanary
+import org.mozilla.focus.ext.application
+
+class DebugFocusApplication : FocusApplication() {
+
+    @OptIn(DelicateCoroutinesApi::class)
+    override fun setupLeakCanary() {
+        if (!AppWatcher.isInstalled) {
+            AppWatcher.manualInstall(
+                application = application,
+                watchersToInstall = AppWatcher.appDefaultWatchers(application)
+            )
+        }
+        GlobalScope.launch(Dispatchers.IO) {
+            val isEnabled = PreferenceManager.getDefaultSharedPreferences(applicationContext)
+                .getBoolean(getString(R.string.pref_key_leakcanary), true)
+            updateLeakCanaryState(isEnabled)
+        }
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    override fun updateLeakCanaryState(isEnabled: Boolean) {
+        GlobalScope.launch(Dispatchers.IO) {
+            LeakCanary.showLeakDisplayActivityLauncherIcon(isEnabled)
+            LeakCanary.config = LeakCanary.config.copy(dumpHeap = isEnabled)
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -85,8 +85,18 @@ open class FocusApplication : LocaleAwareApplication(), CoroutineScope {
 
             initializeWebExtensionSupport()
 
+            setupLeakCanary()
+
             ProcessLifecycleOwner.get().lifecycle.addObserver(lockObserver)
         }
+    }
+
+    protected open fun setupLeakCanary() {
+        // no-op, LeakCanary is disabled by default
+    }
+
+    open fun updateLeakCanaryState(isEnabled: Boolean) {
+        // no-op, LeakCanary is disabled by default
     }
 
     @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage

--- a/app/src/main/java/org/mozilla/focus/settings/advanced/AdvancedSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/advanced/AdvancedSettingsFragment.kt
@@ -9,12 +9,14 @@ import android.os.Bundle
 import androidx.preference.Preference
 import org.mozilla.focus.GleanMetrics.AdvancedSettings
 import org.mozilla.focus.R
+import org.mozilla.focus.ext.application
 import org.mozilla.focus.ext.getPreferenceKey
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.settings.BaseSettingsFragment
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
 import org.mozilla.focus.telemetry.TelemetryWrapper
+import org.mozilla.focus.utils.AppConstants.isDevBuild
 
 class AdvancedSettingsFragment :
     BaseSettingsFragment(),
@@ -24,6 +26,8 @@ class AdvancedSettingsFragment :
         addPreferencesFromResource(R.xml.advanced_settings)
         findPreference<Preference>(getPreferenceKey(R.string.pref_key_secret_settings))?.isVisible =
             requireComponents.appStore.state.secretSettingsEnabled
+        findPreference<Preference>(getPreferenceKey(R.string.pref_key_leakcanary))?.isVisible =
+            isDevBuild
     }
 
     override fun onResume() {
@@ -55,6 +59,9 @@ class AdvancedSettingsFragment :
                 AdvancedSettings.openLinksSettingChanged.record(
                     AdvancedSettings.OpenLinksSettingChangedExtra(sharedPreferences.all[key] as Boolean)
                 )
+            getString(R.string.pref_key_leakcanary) -> {
+                context?.application?.updateLeakCanaryState(sharedPreferences.all[key] as Boolean)
+            }
         }
     }
 

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -27,6 +27,7 @@
     <string name="pref_key_performance_block_images" translatable="false"><xliff:g id="preference_key">pref_performance_block_images</xliff:g></string>
 
     <string name="pref_key_default_browser" translatable="false"><xliff:g id="preference_key">pref_default_browser</xliff:g></string>
+    <string name="pref_key_leakcanary" translatable="false"><xliff:g id="preference_key">pref_key_leakcanary</xliff:g></string>
 
     <string name="pref_key_telemetry" translatable="false"><xliff:g id="preference_key">pref_telemetry</xliff:g></string>
 

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -15,4 +15,7 @@
     <string name="about_debug_menu_toast_progress" translatable="false">Debug menu: %1$d click(s) left to enable</string>
     <string name="about_debug_menu_toast_done" translatable="false">Debug menu enabled</string>
 
+    <!-- Label for LeakCanary Toggle. It's used in Advanced Settings. -->
+    <string name="preference_leakcanary" translatable="false">LeakCanary</string>
+
 </resources>

--- a/app/src/main/res/xml/advanced_settings.xml
+++ b/app/src/main/res/xml/advanced_settings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
@@ -16,8 +15,14 @@
         <androidx.preference.SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/pref_key_open_links_in_external_app"
-            android:title="@string/preferences_open_links_in_apps"
-            android:layout="@layout/focus_preference_no_icon"/>
+            android:layout="@layout/focus_preference_no_icon"
+            android:title="@string/preferences_open_links_in_apps" />
+
+        <androidx.preference.SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="@string/pref_key_leakcanary"
+            android:title="@string/preference_leakcanary"
+            app:iconSpaceReserved="false" />
 
         <androidx.preference.Preference
             android:key="@string/pref_key_secret_settings"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -4,6 +4,7 @@
 
 object Versions {
     const val compose_version = "1.0.4"
+    const val leakcanary = "2.8.1"
 
     object AndroidX {
         const val activity_compose = "1.3.1"
@@ -67,6 +68,7 @@ object Dependencies {
     const val google_play = "com.google.android.play:core:${Versions.Google.play}"
     const val kotlin_gradle_plugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.Gradle.kotlin_plugin}"
     const val android_gradle_plugin = "com.android.tools.build:gradle:${Versions.Gradle.android_plugin}"
+    const val leakcanary = "com.squareup.leakcanary:leakcanary-android-core:${Versions.leakcanary}"
 
     const val kotlin_stdlib = "org.jetbrains.kotlin:kotlin-stdlib:${Versions.Kotlin.version}"
     const val kotlin_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.Kotlin.coroutines}"


### PR DESCRIPTION
I added a toggle button in Advanced Settings Screen . The toggle is visible only if the app is in Debug Mode. By default the toggle is activated . It is the same functionality like in Fenix. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
