### PR TITLE
No issue: Reduce number of FTL shards by pairing tests

### DIFF
--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -49,7 +49,7 @@ flank:
   project: GOOGLE_PROJECT
   # test shards - the amount of groups to split the test suite into
   # set to -1 to use one shard per test. default: 1
-  max-test-shards: -1
+  max-test-shards: 36
   # num-test-runs: the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
   num-test-runs: 1

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -57,7 +57,7 @@ jobs:
         description: 'UI tests with firebase'
         run:
             commands:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86', 'app.apk', 'android-test.apk', '-1']
+                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86', 'app.apk', 'android-test.apk', '36']
         treeherder:
             symbol: debug(ui-test-x86)
     x86-nightly:


### PR DESCRIPTION
For https://github.com/mozilla-mobile/focus-android/issues/6428, while the Firebase team investigates the `Inconclusive Result` infrastructure problem it was recommended that we try reducing our shard count by pairing UI tests (number of UI tests / 2 so 36 (72 tests at this time of writing)). 

From Firebase Community Slack

> If we assume the infrastructure failure rate is the same, more sharding will increase the chance for the matrix to fail.  Further, these test executions all have overhead in terms of device scheduling, preparation, post test run result processing, these time combined might be much longer than the time running the test. So in practice, more sharding might not help you at some point.

Based on runs in https://github.com/mozilla-mobile/focus-android/pull/6457 this looks promising. This PR reduces the shard count for debug where we run all tests (`-1` previously indicates create a shard for every test).