### PR TITLE
For #6487 - Update compose to 1.1.0 and kotlin to 1.6.10

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/BlockedTrackersMiddleware.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BlockedTrackersMiddleware.kt
@@ -34,6 +34,9 @@ class BlockedTrackersMiddleware(
             is TrackingProtectionAction.TrackerBlockedAction -> {
                 incrementCount()
             }
+            else -> {
+                // no-op
+            }
         }
 
         next(action)

--- a/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchOverlay.kt
+++ b/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchOverlay.kt
@@ -65,6 +65,9 @@ fun SearchOverlay(
                 )
             }
         }
+        else -> {
+            // no-op
+        }
     }
 }
 

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryMiddleware.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryMiddleware.kt
@@ -65,6 +65,9 @@ class TelemetryMiddleware : Middleware<BrowserState, BrowserAction> {
                     TelemetryWrapper.downloadDialogDownloadEvent(sentToDownload = false)
                 }
             }
+            else -> {
+                // no-op
+            }
         }
     }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,11 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object Versions {
-    const val compose_version = "1.0.4"
+    const val compose_version = "1.1.0"
     const val leakcanary = "2.8.1"
 
     object AndroidX {
-        const val activity_compose = "1.3.1"
         const val annotation = "1.1.0"
         const val appcompat = "1.3.0"
         const val arch = "2.1.0"
@@ -28,7 +27,7 @@ object Versions {
     }
 
     object Kotlin {
-        const val version = "1.5.31"
+        const val version = "1.6.10"
         const val coroutines = "1.5.2"
     }
 


### PR DESCRIPTION
The Middlewares changes are needed because of the new requirements for `when`s for sealed classes: https://kotlinlang.org/docs/whatsnew1530.html#exhaustive-when-statements-for-sealed-and-boolean-subjects

Also updating `kotlin-coroutines` will be a followup - https://github.com/mozilla-mobile/focus-android/issues/6488

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
