### PR TITLE
Make ui-test-x86-debug builds optional

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,7 +14,7 @@ queue_rules:
       - status-success=lint-lint
       - status-success=test-debug
       - status-success=ui-test-x86-beta
-      - status-success=ui-test-x86-debug
+      #- status-success=ui-test-x86-debug # Disabled until #6428 is fixed.
       - status-success=ui-test-x86-nightly
 pull_request_rules:
   - name: Needs landing - Rebase


### PR DESCRIPTION

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
