### PR TITLE
For #6297 implement cfrForTrackingProtection on Fenix architecture

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/AddToHomescreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/AddToHomescreenTest.kt
@@ -47,7 +47,7 @@ class AddToHomescreenTest {
         } catch (e: IOException) {
             throw AssertionError("Could not start web server", e)
         }
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
     }
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ContextMenusTest.kt
@@ -34,7 +34,7 @@ class ContextMenusTest {
 
     @Before
     fun setup() {
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
         webServer = MockWebServer()
         webServer.enqueue(TestHelper.createMockResponseFromAsset("tab1.html"))

--- a/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
@@ -54,7 +54,7 @@ class CustomTabTest {
 
     @Before
     fun setUp() {
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
         webServer = MockWebServer()
         webServer.enqueue(createMockResponseFromAsset("plain_test.html"))

--- a/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
@@ -41,7 +41,7 @@ class DownloadFileTest {
 
     @Before
     fun setUp() {
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
         webServer = MockWebServer()
         try {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/EnhancedTrackingProtectionSettingsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/EnhancedTrackingProtectionSettingsTest.kt
@@ -38,7 +38,7 @@ class EnhancedTrackingProtectionSettingsTest {
 
     @Before
     fun setUp() {
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
         webServer = MockWebServer()
         try {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/EraseBrowsingDataTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/EraseBrowsingDataTest.kt
@@ -66,7 +66,7 @@ class EraseBrowsingDataTest {
         } catch (e: IOException) {
             throw AssertionError("Could not start web server", e)
         }
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
     }
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
@@ -26,7 +26,7 @@ class ErrorPagesTest {
 
     @Before
     fun setUp() {
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
     }
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/FirstRunTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/FirstRunTest.kt
@@ -35,7 +35,7 @@ class FirstRunTest {
     fun startWebServer() {
         webServer = MockWebServer()
         webServer.start()
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
     }
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MediaPlaybackTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MediaPlaybackTest.kt
@@ -23,7 +23,7 @@ class MediaPlaybackTest {
 
     @Before
     fun setUp() {
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
         webServer = MockWebServer()
         webServer.start()

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MozillaSupportPagesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MozillaSupportPagesTest.kt
@@ -27,7 +27,7 @@ class MozillaSupportPagesTest {
 
     @Before
     fun setUp() {
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
     }
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MultitaskingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MultitaskingTest.kt
@@ -48,7 +48,7 @@ class MultitaskingTest {
     @Before
     @Throws(Exception::class)
     fun startWebServer() {
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
         webServer = MockWebServer()
         webServer.enqueue(createMockResponseFromAsset("tab1.html"))

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SafeBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SafeBrowsingTest.kt
@@ -34,7 +34,7 @@ class SafeBrowsingTest {
 
     @Before
     fun setUp() {
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
         webServer = MockWebServer()
         webServer.start()

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SearchTest.kt
@@ -28,7 +28,7 @@ class SearchTest {
 
     @Before
     fun setUp() {
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
     }
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SettingsAdvancedTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SettingsAdvancedTest.kt
@@ -37,7 +37,7 @@ class SettingsAdvancedTest {
         webServer = MockWebServer()
         webServer.enqueue(createMockResponseFromAsset("tab3.html"))
         webServer.enqueue(createMockResponseFromAsset("tab3.html"))
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
     }
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ShareWebsiteTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ShareWebsiteTest.kt
@@ -3,12 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.focus.activity
 
-import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiSelector
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
@@ -18,21 +13,21 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.activity.robots.searchScreen
 import org.mozilla.focus.helpers.FeatureSettingsHelper
-import org.mozilla.focus.helpers.MainActivityIntentsTestRule
-import org.mozilla.focus.helpers.TestHelper.isPackageInstalled
+import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
+import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.readTestAsset
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 import org.mozilla.focus.testAnnotations.SmokeTest
 import java.io.IOException
 
-// This test verifies the "Open in..." option from the main menu
+// This test opens and verifies the share overlay
 @RunWith(AndroidJUnit4ClassRunner::class)
-class OpenInExternalBrowserDialogueTest {
+class ShareWebsiteTest {
     private lateinit var webServer: MockWebServer
     private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get: Rule
-    var mActivityTestRule = MainActivityIntentsTestRule(showFirstRun = false)
+    var mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
 
     @Before
     fun setUp() {
@@ -52,33 +47,25 @@ class OpenInExternalBrowserDialogueTest {
 
     @After
     fun tearDown() {
-        mActivityTestRule.activity.finishAndRemoveTask()
-        webServer.shutdown()
+        try {
+            webServer.shutdown()
+        } catch (e: IOException) {
+            throw AssertionError("Could not stop web server", e)
+        }
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest
     @Test
-    fun openPageInExternalAppTest() {
-        val pageUrl = webServer.url("").toString()
-
+    fun shareTabTest() {
+        /* Go to a webpage */
         searchScreen {
-        }.loadPage(pageUrl) {
+        }.loadPage(webServer.url("").toString()) {
+            progressBar.waitUntilGone(waitingTime)
         }.openMainMenu {
-            clickOpenInOption()
-            verifyOpenInDialog()
-            clickOpenInChrome()
-            assertChromeOpens()
+        }.openShareScreen {
+            verifyShareAppsListOpened()
+            mDevice.pressBack()
         }
-    }
-}
-
-private fun assertChromeOpens() {
-    val googleChrome = "com.google.android.apps.chrome"
-    if (isPackageInstalled(googleChrome)) {
-        Intents.intended(IntentMatchers.toPackage(googleChrome))
-    } else {
-        val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        mDevice.findObject(UiSelector().textContains("No app found")).waitForExists(waitingTime)
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ShortcutsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ShortcutsTest.kt
@@ -28,7 +28,7 @@ class ShortcutsTest {
 
     @Before
     fun setUp() {
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         webServer = MockWebServer()
         webServer.enqueue(createMockResponseFromAsset("plain_test.html"))
         webServer.start()

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SwitchContextTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SwitchContextTest.kt
@@ -43,7 +43,7 @@ class SwitchContextTest {
 
     @Before
     fun setUp() {
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
         webServer = MockWebServer()
         try {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ThreeDotMainMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ThreeDotMainMenuTest.kt
@@ -37,7 +37,7 @@ class ThreeDotMainMenuTest {
         webServer = MockWebServer()
         webServer.enqueue(createMockResponseFromAsset("tab1.html"))
         webServer.start()
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
     }
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/WebControlsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/WebControlsTest.kt
@@ -36,7 +36,7 @@ class WebControlsTest {
     fun setup() {
         webServer = MockWebServer()
         webServer.start()
-        featureSettingsHelper.setShieldIconCFREnabled(false)
+        featureSettingsHelper.setCfrForTrackingProtectionEnabled(false)
         featureSettingsHelper.setNumberOfTabsOpened(4)
     }
 

--- a/app/src/androidTest/java/org/mozilla/focus/helpers/FeatureSettingsHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/FeatureSettingsHelper.kt
@@ -15,13 +15,13 @@ class FeatureSettingsHelper {
     private val settings = context.settings
 
     // saving default values of feature flags
-    private var shouldShowCfrForShieldToolbarIcon: Boolean = settings.shouldShowCfrForShieldToolbarIcon
+    private var shouldShowCfrForTrackingProtection: Boolean = settings.shouldShowCfrForTrackingProtection
 
     // saving default value of number of tabs opened, which is used for erase tabs cfr
     private var numberOfTabsOpened: Int = settings.numberOfTabsOpened
 
-    fun setShieldIconCFREnabled(enabled: Boolean) {
-        settings.shouldShowCfrForShieldToolbarIcon = enabled
+    fun setCfrForTrackingProtectionEnabled(enabled: Boolean) {
+        settings.shouldShowCfrForTrackingProtection = enabled
     }
 
     fun setNumberOfTabsOpened(tabsOpened: Int) {
@@ -36,7 +36,7 @@ class FeatureSettingsHelper {
     // Use this after each test if you have modified these feature settings
     // to make sure the app goes back to the default state
     fun resetAllFeatureFlags() {
-        settings.shouldShowCfrForShieldToolbarIcon = shouldShowCfrForShieldToolbarIcon
+        settings.shouldShowCfrForTrackingProtection = shouldShowCfrForTrackingProtection
         settings.numberOfTabsOpened = numberOfTabsOpened
         Features.ONBOARDING = AppConstants.isDevOrNightlyBuild
     }

--- a/app/src/androidTest/java/org/mozilla/focus/privacy/LocalSessionStorageTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/privacy/LocalSessionStorageTest.kt
@@ -54,7 +54,7 @@ class LocalSessionStorageTest {
         } catch (e: IOException) {
             throw AssertionError("Could not start web server", e)
         }
-        TestHelper.appContext.settings.shouldShowCfrForShieldToolbarIcon = false
+        TestHelper.appContext.settings.shouldShowCfrForTrackingProtection = false
     }
 
     @After

--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -132,7 +132,7 @@ class Components(
     }
 
     val store by lazy {
-        val cfrMiddleware = if (Features.SHOW_ERASE_CFR) {
+        val cfrMiddleware = if (Features.IS_ERASE_CFR_ENABLED || Features.IS_TRACKING_PROTECTION_CFR_ENABLED) {
             listOf(CfrMiddleware(context.components))
         } else {
             listOf()

--- a/app/src/main/java/org/mozilla/focus/cfr/CfrMiddleware.kt
+++ b/app/src/main/java/org/mozilla/focus/cfr/CfrMiddleware.kt
@@ -4,6 +4,7 @@
 package org.mozilla.focus.cfr
 
 import mozilla.components.browser.state.action.BrowserAction
+import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.lib.state.Middleware
@@ -11,22 +12,46 @@ import mozilla.components.lib.state.MiddlewareContext
 import org.mozilla.focus.Components
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.utils.ERASE_CFR_LIMIT
+import org.mozilla.focus.utils.Features
 
 /**
  * Middleware used to intercept browser store actions in order to decide when should we display a specific CFR
  */
 class CfrMiddleware(private val components: Components) : Middleware<BrowserState, BrowserAction> {
+
     override fun invoke(
         context: MiddlewareContext<BrowserState, BrowserAction>,
         next: (BrowserAction) -> Unit,
         action: BrowserAction
     ) {
         next(action)
-        if (action is TabListAction.AddTabAction) {
+
+        if (action is TabListAction.AddTabAction &&
+            Features.IS_ERASE_CFR_ENABLED &&
+            !components.appStore.state.showTrackingProtectionCfr
+        ) {
             components.settings.numberOfTabsOpened++
             if (components.settings.numberOfTabsOpened == ERASE_CFR_LIMIT) {
                 components.appStore.dispatch(AppAction.ShowEraseTabsCfrChange(true))
             }
         }
+
+        if (shouldShowCfrForTrackingProtection(action = action)) {
+            components.appStore.dispatch(AppAction.ShowTrackingProtectionCfrChange(true))
+        }
     }
+
+    private fun isActionSecure(action: BrowserAction) = (
+        action is ContentAction.UpdateSecurityInfoAction &&
+            action.securityInfo.secure
+        )
+
+    private fun shouldShowCfrForTrackingProtection(
+        action: BrowserAction
+    ) = (
+        isActionSecure(action = action) &&
+            Features.IS_TRACKING_PROTECTION_CFR_ENABLED &&
+            components.settings.shouldShowCfrForTrackingProtection &&
+            !components.appStore.state.showEraseTabsCfr
+        )
 }

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -64,7 +64,6 @@ import org.mozilla.focus.browser.integration.BrowserMenuController
 import org.mozilla.focus.browser.integration.BrowserToolbarIntegration
 import org.mozilla.focus.browser.integration.FindInPageIntegration
 import org.mozilla.focus.browser.integration.FullScreenIntegration
-import org.mozilla.focus.compose.CFRPopup
 import org.mozilla.focus.contextmenu.ContextMenuCandidates
 import org.mozilla.focus.databinding.FragmentBrowserBinding
 import org.mozilla.focus.downloads.DownloadService
@@ -88,7 +87,6 @@ import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.topsites.DefaultTopSitesStorage.Companion.TOP_SITES_MAX_LIMIT
 import org.mozilla.focus.topsites.DefaultTopSitesView
-import org.mozilla.focus.utils.Features
 import org.mozilla.focus.utils.FocusSnackbar
 import org.mozilla.focus.utils.FocusSnackbarDelegate
 import org.mozilla.focus.utils.IntentUtils
@@ -341,24 +339,6 @@ class BrowserFragment :
         setSitePermissions(view)
     }
 
-    private fun showCfrForShieldToolbarIcon() {
-        if (Features.SHOULD_SHOW_CFR_FOR_SHIELD_TOOLBAR_ICON &&
-            requireContext().settings.shouldShowCfrForShieldToolbarIcon &&
-            tab.content.securityInfo.secure
-        ) {
-            CFRPopup(
-                container = binding.root,
-                text = getString(R.string.cfr_for_toolbar_shield_icon),
-                anchor = binding.browserToolbar.rootView.findViewById(
-                    R.id.mozac_browser_toolbar_tracking_protection_indicator
-                ),
-                onDismiss = { requireContext().settings.shouldShowCfrForShieldToolbarIcon = false }
-            ).apply {
-                show()
-            }
-        }
-    }
-
     private fun setSitePermissions(rootView: View) {
         sitePermissionsFeature.set(
             feature = SitePermissionsFeature(
@@ -443,8 +423,7 @@ class BrowserFragment :
                 sessionUseCases = requireComponents.sessionUseCases,
                 onUrlLongClicked = ::onUrlLongClicked,
                 eraseActionListener = { erase(shouldEraseAllTabs = true) },
-                tabCounterListener = ::tabCounterListener,
-                onTrackingProtectionShown = ::showCfrForShieldToolbarIcon
+                tabCounterListener = ::tabCounterListener
             ),
             owner = this,
             view = binding.browserToolbar

--- a/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -353,7 +353,7 @@ class UrlInputFragment :
 
         binding.browserToolbar.editMode()
         setHomeMenu()
-        if (Features.SHOULD_SHOW_HOME_PAGE_PRO_TIPS) {
+        if (Features.ARE_HOME_PAGE_PRO_TIPS_ENABLED) {
             updateTipsLabel()
         } else {
             binding.homeTips.visibility = View.GONE

--- a/app/src/main/java/org/mozilla/focus/settings/privacy/PrivacySecuritySettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/privacy/PrivacySecuritySettingsFragment.kt
@@ -42,7 +42,7 @@ class PrivacySecuritySettingsFragment :
         ) {
             preferenceScreen.removePreference(biometricPreference)
         }
-        if (!Features.SHOULD_SHOW_TOOLTIP_FOR_PRIVACY_SECURITY_SETTINGS_SCREEN ||
+        if (!Features.IS_TOOLTIP_FOR_PRIVACY_SECURITY_SETTINGS_SCREEN_ENABLED ||
             !requireContext().settings.shouldShowPrivacySecuritySettingsToolTip
         ) {
             preferenceScreen.removePreference(findPreference(getString(R.string.pref_key_tool_tip)))

--- a/app/src/main/java/org/mozilla/focus/state/AppAction.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppAction.kt
@@ -90,4 +90,9 @@ sealed class AppAction : Action {
      * State of erase tabs CFR has changed
      */
     data class ShowEraseTabsCfrChange(val value: Boolean) : AppAction()
+
+    /**
+     * State of show Tracking Protection CFR has changed
+     */
+    data class ShowTrackingProtectionCfrChange(val value: Boolean) : AppAction()
 }

--- a/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
@@ -35,6 +35,7 @@ object AppReducer : Reducer<AppState, AppAction> {
                 action
             )
             is AppAction.ShowEraseTabsCfrChange -> showEraseTabsCfrChanged(state, action)
+            is AppAction.ShowTrackingProtectionCfrChange -> showTrackingProtectionCfrChanged(state, action)
         }
     }
 }
@@ -170,6 +171,16 @@ private fun secretSettingsStateChanged(state: AppState, action: AppAction.Secret
  */
 private fun showEraseTabsCfrChanged(state: AppState, action: AppAction.ShowEraseTabsCfrChange): AppState {
     return state.copy(showEraseTabsCfr = action.value)
+}
+
+/**
+ * The state of tracking protection CFR changed
+ */
+private fun showTrackingProtectionCfrChanged(
+    state: AppState,
+    action: AppAction.ShowTrackingProtectionCfrChange
+): AppState {
+    return state.copy(showTrackingProtectionCfr = action.value)
 }
 
 @Suppress("ComplexMethod")

--- a/app/src/main/java/org/mozilla/focus/state/AppState.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppState.kt
@@ -23,7 +23,8 @@ data class AppState(
     val topSites: List<TopSite> = emptyList(),
     val autoplayRulesChanged: Boolean = false,
     val secretSettingsEnabled: Boolean = false,
-    val showEraseTabsCfr: Boolean = false
+    val showEraseTabsCfr: Boolean = false,
+    val showTrackingProtectionCfr: Boolean = false
 ) : State
 
 /**

--- a/app/src/main/java/org/mozilla/focus/utils/Features.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Features.kt
@@ -9,14 +9,14 @@ package org.mozilla.focus.utils
  */
 object Features {
     const val SEARCH_TERMS_OR_URL: Boolean = true
-    val SHOULD_SHOW_CFR_FOR_SHIELD_TOOLBAR_ICON = AppConstants.isDevOrNightlyBuild
-    val SHOULD_SHOW_TOOLTIP_FOR_PRIVACY_SECURITY_SETTINGS_SCREEN = AppConstants.isDevOrNightlyBuild
-    const val SHOULD_SHOW_HOME_PAGE_PRO_TIPS = true
+    val IS_TRACKING_PROTECTION_CFR_ENABLED = AppConstants.isDevOrNightlyBuild
+    val IS_TOOLTIP_FOR_PRIVACY_SECURITY_SETTINGS_SCREEN_ENABLED = AppConstants.isDevOrNightlyBuild
+    const val ARE_HOME_PAGE_PRO_TIPS_ENABLED = true
 
     /**
      * Erase tabs CFR
      */
-    var SHOW_ERASE_CFR = AppConstants.isDevOrNightlyBuild
+    var IS_ERASE_CFR_ENABLED = AppConstants.isDevOrNightlyBuild
 
     /**
      * Replace the current [FirstrunFragment.kt] which has multiple cards with

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -178,11 +178,11 @@ class Settings(
                 .commit()
         }
 
-    var shouldShowCfrForShieldToolbarIcon: Boolean
-        get() = preferences.getBoolean(getPreferenceKey(R.string.pref_cfr_visibility_for_shield_toolbar_icon), true)
+    var shouldShowCfrForTrackingProtection: Boolean
+        get() = preferences.getBoolean(getPreferenceKey(R.string.pref_cfr_visibility_for_tracking_protection), true)
         set(value) {
             preferences.edit()
-                .putBoolean(getPreferenceKey(R.string.pref_cfr_visibility_for_shield_toolbar_icon), value)
+                .putBoolean(getPreferenceKey(R.string.pref_cfr_visibility_for_tracking_protection), value)
                 .apply()
         }
 

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -80,7 +80,7 @@
     <string name="pref_key_screen_exceptions" translatable="false">
         <xliff:g id="preference_key">pref_screen_exceptions</xliff:g>
     </string>
-    <string name="pref_cfr_visibility_for_shield_toolbar_icon" translatable="false"><xliff:g id="preference_key">pref_cfr_visibility_for_shield_toolbar_icon</xliff:g></string>
+    <string name="pref_cfr_visibility_for_tracking_protection" translatable="false"><xliff:g id="preference_key">pref_cfr_visibility_for_tracking_protection</xliff:g></string>
     <string name="pref_tool_tip_privacy_security_settings" translatable="false"><xliff:g id="preference_key">pref_tool_tip_privacy_security_settings</xliff:g></string>
     <!-- Theme Settings -->
     <string name="pref_key_light_theme" translatable="false">pref_key_light_theme</string>

--- a/app/src/test/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegrationTest.kt
+++ b/app/src/test/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegrationTest.kt
@@ -85,8 +85,7 @@ class BrowserToolbarIntegrationTest {
                 onUrlLongClicked = { false },
                 eraseActionListener = {},
                 tabCounterListener = {},
-                inTesting = true,
-                onTrackingProtectionShown = {},
+                inTesting = true
             )
         )
     }
@@ -110,11 +109,40 @@ class BrowserToolbarIntegrationTest {
     @Test
     fun `WHEN start method is called THEN observe erase tabs CFR changes`() {
         doNothing().`when`(browserToolbarIntegration).observeEraseCfr()
-        Features.SHOW_ERASE_CFR = true
+        Features.IS_ERASE_CFR_ENABLED = true
 
         browserToolbarIntegration.start()
 
         verify(browserToolbarIntegration).observeEraseCfr()
+    }
+
+    @Test
+    fun `WHEN start method is called THEN observe tracking protection CFR changes`() {
+        doNothing().`when`(browserToolbarIntegration).observeTrackingProtectionCfr()
+
+        browserToolbarIntegration.start()
+
+        verify(browserToolbarIntegration).observeTrackingProtectionCfr()
+    }
+
+    @Test
+    fun `WHEN stopping THEN stop tracking protection CFR changes`() {
+
+        doNothing().`when`(browserToolbarIntegration).stopObserverTrackingProtectionCfrChanges()
+
+        browserToolbarIntegration.stop()
+
+        verify(browserToolbarIntegration).stopObserverTrackingProtectionCfrChanges()
+    }
+
+    @Test
+    fun `WHEN stopping THEN stop erase tabs CFR changes`() {
+
+        doNothing().`when`(browserToolbarIntegration).stopObserverEraseTabsCfrChanges()
+
+        browserToolbarIntegration.stop()
+
+        verify(browserToolbarIntegration).stopObserverEraseTabsCfrChanges()
     }
 
     @Test


### PR DESCRIPTION
I changed how the CfrForTrackingProtection is shown. I implemented the same like EraseTabsCfr with Fenix architecture. 
I fixed the bugs :
https://github.com/mozilla-mobile/focus-android/issues/6526,
https://github.com/mozilla-mobile/focus-android/issues/6525,
https://github.com/mozilla-mobile/focus-android/issues/6524
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
