### PR TITLE
No issue: Revert group sharding to fix reporting

### DIFF
--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -49,7 +49,7 @@ flank:
   project: GOOGLE_PROJECT
   # test shards - the amount of groups to split the test suite into
   # set to -1 to use one shard per test. default: 1
-  max-test-shards: 36
+  max-test-shards: -1
   # num-test-runs: the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
   num-test-runs: 1

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -57,7 +57,7 @@ jobs:
         description: 'UI tests with firebase'
         run:
             commands:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86', 'app.apk', 'android-test.apk', '36']
+                - ['automation/taskcluster/androidTest/ui-test.sh', 'x86', 'app.apk', 'android-test.apk', '-1']
         treeherder:
             symbol: debug(ui-test-x86)
     x86-nightly:


### PR DESCRIPTION
I think by splitting the tests into shards it broke my daily reporting for flaky and failures. I didn't see too much of a difference in shard splitting times so let's revert it to fix my reporting.