### PR TITLE
For #6522 Focus Nightly crashes when accessing Your Rights page

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/MozillaSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/MozillaSettingsFragment.kt
@@ -88,10 +88,12 @@ class MozillaSettingsFragment :
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
-        ProTips.tipsSettingChanged.record(
-            ProTips.TipsSettingChangedExtra(sharedPreferences.all[key] as Boolean)
-        )
+        if (isAdded && key == requireContext().getString(R.string.pref_key_homescreen_tips)) {
+            TelemetryWrapper.settingsEvent(key, sharedPreferences.all[key].toString())
+            ProTips.tipsSettingChanged.record(
+                ProTips.TipsSettingChangedExtra(sharedPreferences.all[key] as Boolean)
+            )
+        }
     }
 
     companion object {


### PR DESCRIPTION
I made a check sharedPreference Key to be different than  the key that is used to show Cfr for Erase Tabs . 
The value  for the key "number_of_opened_tabs" is int and it will crash the app at this line   ProTips.tipsSettingChanged.record(ProTips.TipsSettingChangedExtra(sharedPreferences.all[key] as Boolean)).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
