### PR TITLE
For #6036 - Use app defined string for the cancel button

### DIFF
--- a/app/src/main/res/xml/privacy_security_settings.xml
+++ b/app/src/main/res/xml/privacy_security_settings.xml
@@ -84,7 +84,8 @@
             android:key="@string/pref_key_performance_enable_cookies"
             android:defaultValue="@string/preference_privacy_should_block_cookies_cross_site_option"
             android:layout="@layout/cookies_preference"
-            android:title="@string/preference_privacy_category_cookies" />
+            android:title="@string/preference_privacy_category_cookies"
+            android:negativeButtonText="@string/action_cancel"/>
         <androidx.preference.Preference
             android:key="@string/pref_key_site_permissions"
             android:layout="@layout/focus_preference_no_icon"


### PR DESCRIPTION
This overrides the platform default and allows for the app to provide
translations for languages which don't have a translation for the cancel button
text in platform.

Will now use https://pontoon.mozilla.org/ro/focus-for-android/mozilla-mobile/focus-android/app/src/main/res/values/strings.xml/?search=action_cancel&string=223930

<img src="https://user-images.githubusercontent.com/11428869/158215124-1719b4bb-afb2-4579-83ce-0b6d2f74096e.png" width="33%" />




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
