### PR TITLE
For #6531 improve turnOffHomeScreenTipsTest UI smoke test coverage

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/FirstRunTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/FirstRunTest.kt
@@ -27,6 +27,11 @@ import org.mozilla.focus.testAnnotations.SmokeTest
 class FirstRunTest {
     private lateinit var webServer: MockWebServer
     private val featureSettingsHelper = FeatureSettingsHelper()
+    private val firstTipText = getStringResource(R.string.tip_fresh_look)
+    private val secondTipText = getStringResource(R.string.tip_about_shortcuts)
+    private val thirdTipText = getStringResource(R.string.tip_explain_allowlist3)
+    private val fourthTipText = getStringResource(R.string.tip_disable_tracking_protection3)
+    private val fifthTipText = getStringResource(R.string.tip_request_desktop2)
 
     @get: Rule
     val mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = true)
@@ -79,23 +84,23 @@ class FirstRunTest {
             skipFirstRun()
             closeSoftKeyboard()
             verifyTipsCarouselIsDisplayed(true)
-            verifyTipText(getStringResource(R.string.tip_fresh_look))
+            verifyTipText(firstTipText)
             scrollLeftTipsCarousel()
-            verifyTipText(getStringResource(R.string.tip_about_shortcuts))
+            verifyTipText(secondTipText)
             scrollLeftTipsCarousel()
-            verifyTipText(getStringResource(R.string.tip_explain_allowlist3))
+            verifyTipText(thirdTipText)
             scrollLeftTipsCarousel()
-            verifyTipText(getStringResource(R.string.tip_disable_tracking_protection3))
+            verifyTipText(fourthTipText)
             scrollLeftTipsCarousel()
-            verifyTipText(getStringResource(R.string.tip_request_desktop2))
+            verifyTipText(fifthTipText)
             scrollRightTipsCarousel()
-            verifyTipText(getStringResource(R.string.tip_disable_tracking_protection3))
+            verifyTipText(fourthTipText)
             scrollRightTipsCarousel()
-            verifyTipText(getStringResource(R.string.tip_explain_allowlist3))
+            verifyTipText(thirdTipText)
             scrollRightTipsCarousel()
-            verifyTipText(getStringResource(R.string.tip_about_shortcuts))
+            verifyTipText(secondTipText)
             scrollRightTipsCarousel()
-            verifyTipText(getStringResource(R.string.tip_fresh_look))
+            verifyTipText(firstTipText)
         }
     }
 
@@ -106,7 +111,7 @@ class FirstRunTest {
             skipFirstRun()
             closeSoftKeyboard()
             verifyTipsCarouselIsDisplayed(true)
-            verifyTipText(getStringResource(R.string.tip_fresh_look))
+            verifyTipText(firstTipText)
         }.clickLinkFromTips("Read more") {
             verifyPageURL("whats-new-firefox-focus-android")
         }
@@ -152,9 +157,9 @@ class FirstRunTest {
             skipFirstRun()
             closeSoftKeyboard()
             verifyTipsCarouselIsDisplayed(true)
-            verifyTipText(getStringResource(R.string.tip_fresh_look))
+            verifyTipText(firstTipText)
             scrollLeftTipsCarousel()
-            verifyTipText(getStringResource(R.string.tip_about_shortcuts))
+            verifyTipText(secondTipText)
         }
         searchScreen {
         }.loadPage(pageUrl) {
@@ -163,7 +168,7 @@ class FirstRunTest {
         homeScreen {
             closeSoftKeyboard()
             waitUntilSnackBarGone()
-            verifyTipText(getStringResource(R.string.tip_fresh_look))
+            verifyTipText(firstTipText)
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MozillaSupportPagesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MozillaSupportPagesTest.kt
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.focus.activity
 
+import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import org.junit.After
 import org.junit.Before
@@ -15,12 +16,18 @@ import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
 import org.mozilla.focus.helpers.TestHelper.appContext
 import org.mozilla.focus.helpers.TestHelper.exitToTop
+import org.mozilla.focus.helpers.TestHelper.getStringResource
 import org.mozilla.focus.testAnnotations.SmokeTest
 
 // This test visits each About page and checks whether some essential elements are being displayed
 @RunWith(AndroidJUnit4ClassRunner::class)
 class MozillaSupportPagesTest {
     private val featureSettingsHelper = FeatureSettingsHelper()
+    private val firstTipText = getStringResource(R.string.tip_fresh_look)
+    private val secondTipText = getStringResource(R.string.tip_about_shortcuts)
+    private val thirdTipText = getStringResource(R.string.tip_explain_allowlist3)
+    private val fourthTipText = getStringResource(R.string.tip_disable_tracking_protection3)
+    private val fifthTipText = getStringResource(R.string.tip_request_desktop2)
 
     @get: Rule
     val mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
@@ -117,7 +124,7 @@ class MozillaSupportPagesTest {
 
     @SmokeTest
     @Test
-    fun turnOffHomeScreenTipsTest() {
+    fun turnOffAndOnHomeScreenTipsTest() {
         homeScreen {
         }.openMainMenu {
         }.openSettings {
@@ -127,6 +134,32 @@ class MozillaSupportPagesTest {
         }
         homeScreen {
             verifyTipsCarouselIsDisplayed(false)
+        }.openMainMenu {
+        }.openSettings {
+        }.openMozillaSettingsMenu {
+            switchHomeScreenTips()
+            exitToTop()
+        }
+        homeScreen {
+            closeSoftKeyboard()
+            verifyTipsCarouselIsDisplayed(true)
+            verifyTipText(firstTipText)
+            scrollLeftTipsCarousel()
+            verifyTipText(secondTipText)
+            scrollLeftTipsCarousel()
+            verifyTipText(thirdTipText)
+            scrollLeftTipsCarousel()
+            verifyTipText(fourthTipText)
+            scrollLeftTipsCarousel()
+            verifyTipText(fifthTipText)
+            scrollRightTipsCarousel()
+            verifyTipText(fourthTipText)
+            scrollRightTipsCarousel()
+            verifyTipText(thirdTipText)
+            scrollRightTipsCarousel()
+            verifyTipText(secondTipText)
+            scrollRightTipsCarousel()
+            verifyTipText(firstTipText)
         }
     }
 }


### PR DESCRIPTION
• For https://github.com/mozilla-mobile/focus-android/issues/6531 `turnOffHomeScreenTipsTest` UI smoke test coverage ✅ Successfully passed 40x on Firebase

• Other refactoring work

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
