### PR TITLE
Displays the onboarding screen in correct order for both RTL and LTR

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingFragment.kt
@@ -98,15 +98,15 @@ class OnboardingFragment : Fragment() {
                     style = focusTypography.onboardingTitle,
                     modifier = Modifier.padding(top = 16.dp, bottom = 20.dp)
                 )
+                Text(
+                    text = stringResource(id = R.string.onboarding_description),
+                    style = focusTypography.onboardingDescription,
+                    modifier = Modifier.padding(bottom = 20.dp)
+                )
                 Column(
                     verticalArrangement = Arrangement.spacedBy(20.dp),
                     modifier = Modifier.padding(bottom = 36.dp)
                 ) {
-                    Text(
-                        text = stringResource(id = R.string.onboarding_description),
-                        style = focusTypography.onboardingDescription,
-                        modifier = Modifier.padding(start = 8.dp)
-                    )
                     KeyFeatureCard(
                         iconId = R.drawable.mozac_ic_private_browsing,
                         titleId = R.string.onboarding_incognito_title,
@@ -155,7 +155,10 @@ class OnboardingFragment : Fragment() {
                 painter = painterResource(iconId),
                 colorFilter = ColorFilter.tint(color = focusColors.onboardingKeyFeatureImageTint),
                 contentDescription = getString(R.string.app_name),
-                modifier = Modifier.constrainAs(image) { top.linkTo(parent.top) }
+                modifier = Modifier.constrainAs(image) {
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                }
             )
             Text(
                 text = stringResource(id = titleId),


### PR DESCRIPTION
For #6639
Onboarding description should be aligned center horizontally



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
