### PR TITLE
For #6531 Improve settings menu elements UI tests coverage

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/SearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SearchTest.kt
@@ -79,7 +79,7 @@ class SearchTest {
         }.openMainMenu {
         }.openSettings {
         }.openSearchSettingsMenu {
-            verifySearchSuggestionsEnabled(true)
+            verifySearchSuggestionsSwitchState(true)
         }
     }
 
@@ -98,7 +98,7 @@ class SearchTest {
         }.openMainMenu {
         }.openSettings {
         }.openSearchSettingsMenu {
-            verifySearchSuggestionsEnabled(false)
+            verifySearchSuggestionsSwitchState(false)
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsAdvancedMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsAdvancedMenuRobot.kt
@@ -24,7 +24,11 @@ import org.mozilla.focus.helpers.TestHelper.waitingTime
 class SettingsAdvancedMenuRobot {
     fun verifyAdvancedSettingsItems() {
         advancedSettingsList.waitForExists(waitingTime)
-        remoteDebuggingSwitch.check(matches(isDisplayed()))
+        developerToolsHeading().check(matches(isDisplayed()))
+        remoteDebuggingSwitch().check(matches(isDisplayed()))
+        assertRemoteDebuggingSwitchState()
+        openLinksInAppsButton().check(matches(isDisplayed()))
+        assertOpenLinksInAppsSwitchState()
     }
 
     fun verifyOpenLinksInAppsSwitchState(enabled: Boolean) = assertOpenLinksInAppsSwitchState(enabled)
@@ -41,7 +45,7 @@ class SettingsAdvancedMenuRobot {
 
 private fun openLinksInAppsButton() = onView(withText(R.string.preferences_open_links_in_apps))
 
-private fun assertOpenLinksInAppsSwitchState(enabled: Boolean) {
+private fun assertOpenLinksInAppsSwitchState(enabled: Boolean = false) {
     if (enabled) {
         openLinksInAppsButton()
             .check(
@@ -72,4 +76,34 @@ private fun assertOpenLinksInAppsSwitchState(enabled: Boolean) {
 private val advancedSettingsList =
     UiScrollable(UiSelector().resourceId("$packageName:id/recycler_view"))
 
-private val remoteDebuggingSwitch = onView(withText("Remote debugging via USB/Wi-Fi"))
+private fun developerToolsHeading() = onView(withText(R.string.preference_advanced_summary))
+
+private fun remoteDebuggingSwitch() = onView(withText("Remote debugging via USB/Wi-Fi"))
+
+private fun assertRemoteDebuggingSwitchState(enabled: Boolean = false) {
+    if (enabled) {
+        remoteDebuggingSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        remoteDebuggingSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsGeneralMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsGeneralMenuRobot.kt
@@ -22,6 +22,7 @@ import junit.framework.TestCase.assertTrue
 import org.hamcrest.Matchers.allOf
 import org.junit.Assert.assertFalse
 import org.mozilla.focus.R
+import org.mozilla.focus.helpers.EspressoHelper.hasCousin
 import org.mozilla.focus.helpers.TestHelper.appName
 import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.waitingTime
@@ -31,13 +32,15 @@ class SettingsGeneralMenuRobot {
         const val ACTION_REQUEST_ROLE = "android.app.role.action.REQUEST_ROLE"
     }
 
-    fun verifyGeneralSettingsItems() {
-        defaultBrowserSwitch.check(matches(isDisplayed()))
+    fun verifyGeneralSettingsItems(defaultBrowserSwitchState: Boolean = false) {
+        verifyThemesList()
         languageMenuButton().check(matches(isDisplayed()))
+        defaultBrowserSwitch().check(matches(isDisplayed()))
+        assertDefaultBrowserSwitchState(defaultBrowserSwitchState)
     }
 
     fun clickSetDefaultBrowser() {
-        defaultBrowserSwitch
+        defaultBrowserSwitch()
             .check(matches(isDisplayed()))
             .perform(click())
     }
@@ -112,7 +115,35 @@ class SettingsGeneralMenuRobot {
     }
 }
 
-private val defaultBrowserSwitch = onView(withText("Make $appName default browser"))
+private fun defaultBrowserSwitch() = onView(withText("Make $appName default browser"))
+
+private fun assertDefaultBrowserSwitchState(enabled: Boolean) {
+    if (enabled) {
+        defaultBrowserSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switch_widget),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        defaultBrowserSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switch_widget),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
+}
 
 private val openWithDialogTitle = mDevice.findObject(
     UiSelector()

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsMozillaMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsMozillaMenuRobot.kt
@@ -7,22 +7,33 @@ package org.mozilla.focus.activity.robots
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isNotChecked
+import androidx.test.espresso.matcher.ViewMatchers.withClassName
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import junit.framework.TestCase.assertTrue
-import org.mozilla.focus.helpers.TestHelper
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.endsWith
+import org.mozilla.focus.R
+import org.mozilla.focus.helpers.EspressoHelper.hasCousin
 import org.mozilla.focus.helpers.TestHelper.appName
 import org.mozilla.focus.helpers.TestHelper.mDevice
+import org.mozilla.focus.helpers.TestHelper.packageName
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 import org.mozilla.focus.idlingResources.SessionLoadedIdlingResource
 
 class SettingsMozillaMenuRobot {
     fun verifyMozillaMenuItems() {
         mozillaSettingsList.waitForExists(waitingTime)
-        showTipsSwitch.check(matches(isDisplayed()))
+        showTipsSwitch().check(matches(isDisplayed()))
+        assertShowTipsSwitchState()
         aboutFocusPageLink.check(matches(isDisplayed()))
         helpPageLink.check(matches(isDisplayed()))
         yourRightsLink.check(matches(isDisplayed()))
@@ -30,7 +41,7 @@ class SettingsMozillaMenuRobot {
     }
 
     fun switchHomeScreenTips() {
-        showTipsSwitch
+        showTipsSwitch()
             .check(matches(isDisplayed()))
             .perform(click())
     }
@@ -111,14 +122,66 @@ class SettingsMozillaMenuRobot {
 }
 
 private val mozillaSettingsList =
-    UiScrollable(UiSelector().resourceId("${TestHelper.packageName}:id/recycler_view"))
+    UiScrollable(UiSelector().resourceId("$packageName:id/recycler_view"))
 
-private val showTipsSwitch = onView(withText("Show home screen tips"))
+private fun showTipsSwitch() = onView(withText("Show home screen tips"))
+
+private fun assertShowTipsSwitchState(enabled: Boolean = true) {
+    if (enabled) {
+        showTipsSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withClassName(endsWith("Switch")),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        showTipsSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withClassName(endsWith("Switch")),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
+}
 
 private val aboutFocusPageLink = onView(withText("About $appName"))
 
-private val helpPageLink = onView(withText("Help"))
+private val helpPageLink =
+    onView(
+        allOf(
+            withText("Help"),
+            withParent(
+                hasSibling(withId(R.id.icon_frame))
+            )
+        )
+    )
 
-private val yourRightsLink = onView(withText("Your Rights"))
+private val yourRightsLink =
+    onView(
+        allOf(
+            withText("Your Rights"),
+            withParent(
+                hasSibling(withId(R.id.icon_frame))
+            )
+        )
+    )
 
-private val privacyNoticeLink = onView(withText("Privacy Notice"))
+private val privacyNoticeLink =
+    onView(
+        allOf(
+            withText("Privacy Notice"),
+            withParent(
+                hasSibling(withId(R.id.icon_frame))
+            )
+        )
+    )

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsPrivacyMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsPrivacyMenuRobot.kt
@@ -19,9 +19,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Matchers
-import org.hamcrest.Matchers.allOf
-import org.hamcrest.Matchers.containsString
 import org.junit.Assert.assertTrue
 import org.mozilla.focus.R
 import org.mozilla.focus.helpers.EspressoHelper.hasCousin
@@ -37,19 +37,34 @@ class SettingsPrivacyMenuRobot {
     fun verifyPrivacySettingsItems() {
         privacySettingsList.waitForExists(waitingTime)
         adTrackersBlockSwitch().check(matches(isDisplayed()))
+        assertAdTrackersBlockSwitchState()
         analyticTrackersBlockSwitch().check(matches(isDisplayed()))
+        assertAnalyticTrackersBlockSwitchState()
         socialTrackersBlockSwitch().check(matches(isDisplayed()))
+        assertSocialTrackersBlockSwitchState()
         otherContentTrackersBlockSwitch().check(matches(isDisplayed()))
+        assertOtherContentTrackersBlockSwitchState()
         blockWebFontsSwitch().check(matches(isDisplayed()))
+        assertBlockWebFontsSwitchState()
         blockJavaScriptSwitch().check(matches(isDisplayed()))
+        assertBlockJavaScriptSwitchState()
         cookiesAndSiteDataSection().check(matches(isDisplayed()))
         blockCookies().check(matches(isDisplayed()))
         blockCookiesDefaultOption().check(matches(isDisplayed()))
         sitePermissions().check(matches(isDisplayed()))
+        verifyExceptionsListDisabled()
         useFingerprintSwitch().check(matches(isDisplayed()))
+        assertUseFingerprintSwitchState()
         stealthModeSwitch().check(matches(isDisplayed()))
+        assertStealthModeSwitchState()
         safeBrowsingSwitch().check(matches(isDisplayed()))
+        assertSafeBrowsingSwitchState()
+        httpsOnlyModeSwitch().check(matches(isDisplayed()))
+        assertHttpsOnlyModeSwitchState()
         sendDataSwitch().check(matches(isDisplayed()))
+        assertSendDataSwitchState()
+        studiesOption().check(matches(isDisplayed()))
+        studiesDefaultOption().check(matches(isDisplayed()))
     }
 
     fun verifyCookiesAndSiteDataSection() {
@@ -269,10 +284,66 @@ private fun adTrackersBlockSwitch(): ViewInteraction {
     return onView(withText("Block ad trackers"))
 }
 
+private fun assertAdTrackersBlockSwitchState(enabled: Boolean = true) {
+    if (enabled) {
+        adTrackersBlockSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        adTrackersBlockSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
+}
+
 private fun analyticTrackersBlockSwitch(): ViewInteraction {
     privacySettingsList
         .scrollTextIntoView("Block analytic trackers")
     return onView(withText("Block analytic trackers"))
+}
+
+private fun assertAnalyticTrackersBlockSwitchState(enabled: Boolean = true) {
+    if (enabled) {
+        analyticTrackersBlockSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        analyticTrackersBlockSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
 }
 
 private fun socialTrackersBlockSwitch(): ViewInteraction {
@@ -281,10 +352,66 @@ private fun socialTrackersBlockSwitch(): ViewInteraction {
     return onView(withText("Block social trackers"))
 }
 
+private fun assertSocialTrackersBlockSwitchState(enabled: Boolean = true) {
+    if (enabled) {
+        socialTrackersBlockSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        socialTrackersBlockSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
+}
+
 private fun otherContentTrackersBlockSwitch(): ViewInteraction {
     privacySettingsList
         .scrollTextIntoView("Block other content trackers")
     return onView(withText("Block other content trackers"))
+}
+
+private fun assertOtherContentTrackersBlockSwitchState(enabled: Boolean = false) {
+    if (enabled) {
+        otherContentTrackersBlockSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        otherContentTrackersBlockSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
 }
 
 private fun blockWebFontsSwitch(): ViewInteraction {
@@ -293,10 +420,66 @@ private fun blockWebFontsSwitch(): ViewInteraction {
     return onView(withText("Block web fonts"))
 }
 
+private fun assertBlockWebFontsSwitchState(enabled: Boolean = false) {
+    if (enabled) {
+        blockWebFontsSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        blockWebFontsSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
+}
+
 private fun blockJavaScriptSwitch(): ViewInteraction {
     privacySettingsList
         .scrollTextIntoView("Block JavaScript")
     return onView(withText("Block JavaScript"))
+}
+
+private fun assertBlockJavaScriptSwitchState(enabled: Boolean = false) {
+    if (enabled) {
+        blockJavaScriptSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        blockJavaScriptSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
 }
 
 private fun cookiesAndSiteDataSection(): ViewInteraction {
@@ -329,22 +512,180 @@ private fun useFingerprintSwitch(): ViewInteraction {
     return onView(withText(useFingerprintSwitchSummary))
 }
 
+private fun assertUseFingerprintSwitchState(enabled: Boolean = false) {
+    if (enabled) {
+        useFingerprintSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        useFingerprintSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
+}
+
 private fun stealthModeSwitch(): ViewInteraction {
     val stealthModeSwitchSummary = getStringResource(R.string.preference_privacy_stealth_summary)
     privacySettingsList.scrollTextIntoView(stealthModeSwitchSummary)
     return onView(withText(stealthModeSwitchSummary))
 }
 
+private fun assertStealthModeSwitchState(enabled: Boolean = false) {
+    if (enabled) {
+        stealthModeSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        stealthModeSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
+}
+
 private fun safeBrowsingSwitch(): ViewInteraction {
     val safeBrowsingSwitchText = getStringResource(R.string.preference_safe_browsing_summary)
-    privacySettingsList.scrollTextIntoView("Data Choices")
+    privacySettingsList.scrollTextIntoView(safeBrowsingSwitchText)
     return onView(withText(safeBrowsingSwitchText))
+}
+
+private fun assertSafeBrowsingSwitchState(enabled: Boolean = true) {
+    if (enabled) {
+        safeBrowsingSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        safeBrowsingSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
+}
+
+private fun httpsOnlyModeSwitch(): ViewInteraction {
+    val httpsOnlyModeSwitchText = getStringResource(R.string.preference_https_only_title)
+    privacySettingsList.scrollTextIntoView(httpsOnlyModeSwitchText)
+    return onView(withText(httpsOnlyModeSwitchText))
+}
+
+private fun assertHttpsOnlyModeSwitchState(enabled: Boolean = true) {
+    if (enabled) {
+        httpsOnlyModeSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        httpsOnlyModeSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
 }
 
 private fun sendDataSwitch(): ViewInteraction {
     val sendDataSwitchSummary = getStringResource(R.string.preference_mozilla_telemetry_summary2)
     privacySettingsList.scrollTextIntoView(sendDataSwitchSummary)
     return onView(withText(sendDataSwitchSummary))
+}
+
+private fun assertSendDataSwitchState(enabled: Boolean = false) {
+    if (enabled) {
+        sendDataSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isChecked()
+                        )
+                    )
+                )
+            )
+    } else {
+        sendDataSwitch()
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withId(R.id.switchWidget),
+                            isNotChecked()
+                        )
+                    )
+                )
+            )
+    }
+}
+
+private fun studiesOption(): ViewInteraction {
+    val studies = getStringResource(R.string.preference_studies)
+    privacySettingsList.scrollTextIntoView(studies)
+    return onView(withText(R.string.preference_studies))
+}
+
+private fun studiesDefaultOption(): ViewInteraction {
+    val studies = getStringResource(R.string.preference_state_on)
+    privacySettingsList.scrollTextIntoView(studies)
+    return onView(withText(R.string.preference_state_on))
 }
 
 private fun exceptionsList(): ViewInteraction {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsSearchMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsSearchMenuRobot.kt
@@ -28,8 +28,13 @@ class SearchSettingsRobot {
 
     fun verifySearchSettingsItems() {
         assertTrue(searchEngineSubMenu.exists())
-        assertTrue(searchSuggestionsSwitch.exists())
+        assertTrue(searchEngineDefaultOption.exists())
+        assertTrue(searchSuggestionsHeading.exists())
+        assertTrue(searchSuggestionDescription.exists())
+        verifySearchSuggestionsSwitchState()
+        assertTrue(searchSuggestionLearnMoreLink.exists())
         assertTrue(urlAutocompleteSubMenu.exists())
+        assertTrue(urlAutocompleteDefaultOption.exists())
     }
 
     fun openSearchEngineSubMenu() {
@@ -49,7 +54,7 @@ class SearchSettingsRobot {
         searchSuggestionsSwitch.click()
     }
 
-    fun verifySearchSuggestionsEnabled(enabled: Boolean) {
+    fun verifySearchSuggestionsSwitchState(enabled: Boolean = false) {
         if (enabled) {
             assertTrue(searchSuggestionsSwitch.isChecked)
         } else {
@@ -109,10 +114,31 @@ private val searchEngineSubMenu =
     UiScrollable(UiSelector().resourceId("$packageName:id/recycler_view"))
         .getChild(UiSelector().text(getStringResource(R.string.preference_search_engine_label)))
 
+private val searchEngineDefaultOption =
+    mDevice.findObject(UiSelector().textContains("Google"))
+
 private val searchEngineList = UiScrollable(
     UiSelector()
         .resourceId("$packageName:id/search_engine_group").enabled(true)
 )
+
+private val searchSuggestionsHeading: UiObject =
+    mDevice.findObject(
+        UiSelector()
+            .textContains(getStringResource(R.string.preference_show_search_suggestions))
+    )
+
+private val searchSuggestionDescription: UiObject =
+    mDevice.findObject(
+        UiSelector()
+            .textContains(getStringResource(R.string.preference_show_search_suggestions_summary))
+    )
+
+private val searchSuggestionLearnMoreLink: UiObject =
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("$packageName:id/link")
+    )
 
 private val searchSuggestionsSwitch: UiObject =
     mDevice.findObject(
@@ -126,6 +152,12 @@ private val urlAutocompleteSubMenu =
             UiSelector().text(getStringResource(R.string.preference_subitem_autocomplete)),
             getStringResource(R.string.preference_subitem_autocomplete), true,
         )
+
+private val urlAutocompleteDefaultOption =
+    mDevice.findObject(
+        UiSelector()
+            .textContains(getStringResource(R.string.preference_state_on))
+    )
 
 private val manageSitesSubMenu = onView(withText(R.string.preference_autocomplete_subitem_manage_sites))
 


### PR DESCRIPTION
For #6531 Improve settings menu elements UI tests coverage
✔️  `verifyGeneralSettingsMenuTest` Successfully passed 40x on Firebase
✔️  `verifyPrivacySettingsMenuTest` Successfully passed 40x on Firebase
✔️  `verifySearchSettingsMenuTest` Successfully passed 40x on Firebase
✔️  `verifyAdvancedSettingsMenuTest` Successfully passed 40x on Firebase
✔️  `verifyMozillaMenuTest` Successfully passed 40x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
