### PR TITLE
For #6709 and #6708 re-enable MultitaskingTests UI tests

### DIFF
--- a/app/src/androidTest/assets/tab1.html
+++ b/app/src/androidTest/assets/tab1.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
 </head>
-<title>Tab 1</title>
 <body>
     <h1 id="content">Tab 1</h1>
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MultitaskingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MultitaskingTest.kt
@@ -11,7 +11,6 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -68,7 +67,6 @@ class MultitaskingTest {
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/focus-android/issues/6538")
     @SmokeTest
     @Test
     fun testVisitingMultipleSites() {
@@ -114,7 +112,6 @@ class MultitaskingTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/focus-android/issues/6600")
     @SmokeTest
     @Test
     fun closeTabButtonTest() {


### PR DESCRIPTION
The tests were failing because `title` was  added to tab1 in [#6697](https://github.com/mozilla-mobile/focus-android/pull/6697/files#diff-44888b0f637bba7fc1571677b81798a658464547881312067a6b41b432cfd032R7
) causing failures when verifying the open tabs order.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
