### PR TITLE
Add condition for verifying send data switch state in UI tests based on build variant

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsPrivacyMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsPrivacyMenuRobot.kt
@@ -62,7 +62,11 @@ class SettingsPrivacyMenuRobot {
         httpsOnlyModeSwitch().check(matches(isDisplayed()))
         assertHttpsOnlyModeSwitchState()
         sendDataSwitch().check(matches(isDisplayed()))
-        assertSendDataSwitchState()
+        if (packageName != "org.mozilla.focus.debug") {
+            assertSendDataSwitchState(true)
+        } else {
+            assertSendDataSwitchState()
+        }
         studiesOption().check(matches(isDisplayed()))
         studiesDefaultOption().check(matches(isDisplayed()))
     }


### PR DESCRIPTION
Added a condition for verifying send data switch state.
Noticed on our latest Beta run that the "Send usage data" toggle is disabled by default on Debug and enabled on Nightly and Beta builds.

✅  Successfully passed 10x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
