### PR TITLE
Override updateToolbarBackground

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
@@ -162,7 +162,8 @@ class BrowserToolbarIntegration(
                 useCases = customTabsUseCases,
                 menuBuilder = menu.menuBuilder,
                 menuItemIndex = menu.menuBuilder.items.size - 1,
-                closeListener = { fragment.closeCustomTab() }
+                closeListener = { fragment.closeCustomTab() },
+                updateToolbarBackground = false
             )
         }
 


### PR DESCRIPTION
For #5212
Override updateToolbarBackground to not be changed based on customTabConfig.toolbarColor
#### Dark
<image src="https://user-images.githubusercontent.com/11731652/159486848-66d05e62-13a8-4a97-bef5-f81f7223a528.png" width="50%"/>

#### Light
<image src="https://user-images.githubusercontent.com/11731652/159486857-bdf99af2-e6a8-447b-989d-f2885499cdc5.png" width="50%"/>



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
