### PR TITLE
Remove navigation actions from custom tab

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
@@ -162,12 +162,13 @@ class BrowserToolbarIntegration(
                 useCases = customTabsUseCases,
                 menuBuilder = menu.menuBuilder,
                 menuItemIndex = menu.menuBuilder.items.size - 1,
-                closeListener = { fragment.closeCustomTab() },
-                updateToolbarBackground = false
+                closeListener = { fragment.closeCustomTab() }
             )
         }
 
-        if (HardwareUtils.isTablet(context)) {
+        val isCustomTab = store.state.findCustomTabOrSelectedTab(customTabId)?.isCustomTab()
+
+        if (HardwareUtils.isTablet(context) && isCustomTab == false) {
             navigationButtonsIntegration = NavigationButtonsIntegration(
                 context,
                 store,
@@ -176,7 +177,8 @@ class BrowserToolbarIntegration(
                 customTabId
             )
         }
-        if (store.state.findCustomTabOrSelectedTab(customTabId)?.isCustomTab() == false) {
+
+        if (isCustomTab == false) {
             toolbar.addNavigationAction(eraseAction)
             if (!inTesting) {
                 setUrlBackground()


### PR DESCRIPTION
For #6718
Remove back, forward actions
Revert updateToolbarBackground to true to get the background color from config

Testing again the same scenario in Fenix I noticed that we don't have consistency(different toolbar color in the same scenario) and the background is set based on toolbar background from config.
This pr reverts https://github.com/mozilla-mobile/focus-android/pull/6717 to keep the same behaviour as in Fenix

![focus_custom_tab](https://user-images.githubusercontent.com/11731652/160129760-9e9ba393-d253-4a68-a1bf-e8a592ae77ba.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
