### PR TITLE
For #6531 improve coverage for download file types UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
@@ -161,4 +161,27 @@ class DownloadFileTest {
             assertNativeAppOpens(GOOGLE_DRIVE)
         }
     }
+
+    @SmokeTest
+    @Test
+    fun downloadAndOpenWebmFileTest() {
+        downloadFileName = "videoSample.webm"
+
+        searchScreen {
+        }.loadPage(downloadTestPage) {
+            progressBar.waitUntilGone(waitingTime)
+            clickLinkMatchingText(downloadFileName)
+        }
+        // If permission dialog appears on devices with API<30, grant it
+        if (permAllowBtn.waitForExists(waitingTime)) {
+            permAllowBtn.click()
+        }
+        downloadRobot {
+            verifyDownloadDialog(downloadFileName)
+            clickDownloadButton()
+            verifyDownloadConfirmationMessage(downloadFileName)
+            openDownloadedFile()
+            assertNativeAppOpens(GOOGLE_PHOTOS)
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
@@ -20,10 +20,10 @@ import org.mozilla.focus.helpers.MockWebServerHelper
 import org.mozilla.focus.helpers.RetryTestRule
 import org.mozilla.focus.helpers.StringsHelper.GOOGLE_PHOTOS
 import org.mozilla.focus.helpers.TestAssetHelper.getImageTestAsset
-import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.assertNativeAppOpens
 import org.mozilla.focus.helpers.TestHelper.getTargetContext
 import org.mozilla.focus.helpers.TestHelper.mDevice
+import org.mozilla.focus.helpers.TestHelper.permAllowBtn
 import org.mozilla.focus.helpers.TestHelper.verifySnackBarText
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 import org.mozilla.focus.testAnnotations.SmokeTest
@@ -33,6 +33,8 @@ import java.io.IOException
 class DownloadFileTest {
     private lateinit var webServer: MockWebServer
     private val featureSettingsHelper = FeatureSettingsHelper()
+    private val downloadTestPage = "https://storage.googleapis.com/mobile_test_assets/test_app/downloads.html"
+    private var downloadFileName: String = ""
 
     @get:Rule
     var mActivityTestRule = MainActivityIntentsTestRule(showFirstRun = false)
@@ -58,7 +60,7 @@ class DownloadFileTest {
         } catch (e: IOException) {
             throw AssertionError("Could not stop web server", e)
         }
-        deleteFileUsingDisplayName(getTargetContext.applicationContext, "download.jpg")
+        deleteFileUsingDisplayName(getTargetContext.applicationContext, downloadFileName)
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
@@ -66,7 +68,7 @@ class DownloadFileTest {
     @Test
     fun downloadNotificationTest() {
         val downloadPageUrl = getImageTestAsset(webServer).url
-        val downloadFileName = "download.jpg"
+        downloadFileName = "download.jpg"
 
         notificationTray {
             mDevice.openNotification()
@@ -80,8 +82,8 @@ class DownloadFileTest {
         downloadRobot {
             clickDownloadIconAsset()
             // If permission dialog appears, grant it
-            if (TestHelper.permAllowBtn.waitForExists(waitingTime)) {
-                TestHelper.permAllowBtn.click()
+            if (permAllowBtn.waitForExists(waitingTime)) {
+                permAllowBtn.click()
             }
             verifyDownloadDialog(downloadFileName)
             clickDownloadButton()
@@ -104,8 +106,8 @@ class DownloadFileTest {
         downloadRobot {
             clickDownloadIconAsset()
             // If permission dialog appears, grant it
-            if (TestHelper.permAllowBtn.waitForExists(waitingTime)) {
-                TestHelper.permAllowBtn.click()
+            if (permAllowBtn.waitForExists(waitingTime)) {
+                permAllowBtn.click()
             }
             clickCancelDownloadButton()
             verifyDownloadDialogGone()
@@ -114,9 +116,9 @@ class DownloadFileTest {
 
     @SmokeTest
     @Test
-    fun openDownloadFileTest() {
+    fun downloadAndOpenJpgFileTest() {
         val downloadPageUrl = getImageTestAsset(webServer).url
-        val downloadFileName = "download.jpg"
+        downloadFileName = "download.jpg"
 
         // Load website with service worker
         searchScreen {
@@ -125,8 +127,8 @@ class DownloadFileTest {
         downloadRobot {
             clickDownloadIconAsset()
             // If permission dialog appears on devices with API<30, grant it
-            if (TestHelper.permAllowBtn.waitForExists(waitingTime)) {
-                TestHelper.permAllowBtn.click()
+            if (permAllowBtn.waitForExists(waitingTime)) {
+                permAllowBtn.click()
             }
             verifyDownloadDialog(downloadFileName)
             clickDownloadButton()

--- a/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
@@ -18,6 +18,7 @@ import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityIntentsTestRule
 import org.mozilla.focus.helpers.MockWebServerHelper
 import org.mozilla.focus.helpers.RetryTestRule
+import org.mozilla.focus.helpers.StringsHelper.GOOGLE_DRIVE
 import org.mozilla.focus.helpers.StringsHelper.GOOGLE_PHOTOS
 import org.mozilla.focus.helpers.TestAssetHelper.getImageTestAsset
 import org.mozilla.focus.helpers.TestHelper.assertNativeAppOpens
@@ -135,6 +136,29 @@ class DownloadFileTest {
             verifyDownloadConfirmationMessage(downloadFileName)
             openDownloadedFile()
             assertNativeAppOpens(GOOGLE_PHOTOS)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun downloadAndOpenPdfFileTest() {
+        downloadFileName = "washington.pdf"
+
+        searchScreen {
+        }.loadPage(downloadTestPage) {
+            progressBar.waitUntilGone(waitingTime)
+            clickLinkMatchingText(downloadFileName)
+        }
+        // If permission dialog appears on devices with API<30, grant it
+        if (permAllowBtn.waitForExists(waitingTime)) {
+            permAllowBtn.click()
+        }
+        downloadRobot {
+            verifyDownloadDialog(downloadFileName)
+            clickDownloadButton()
+            verifyDownloadConfirmationMessage(downloadFileName)
+            openDownloadedFile()
+            assertNativeAppOpens(GOOGLE_DRIVE)
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
@@ -25,6 +25,7 @@ import org.mozilla.focus.helpers.TestHelper.assertNativeAppOpens
 import org.mozilla.focus.helpers.TestHelper.getTargetContext
 import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.permAllowBtn
+import org.mozilla.focus.helpers.TestHelper.verifyDownloadedFileOnStorage
 import org.mozilla.focus.helpers.TestHelper.verifySnackBarText
 import org.mozilla.focus.helpers.TestHelper.waitingTime
 import org.mozilla.focus.testAnnotations.SmokeTest
@@ -182,6 +183,28 @@ class DownloadFileTest {
             verifyDownloadConfirmationMessage(downloadFileName)
             openDownloadedFile()
             assertNativeAppOpens(GOOGLE_PHOTOS)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun verifyDownloadedFileOnStorageTest() {
+        downloadFileName = "textfile.txt"
+
+        searchScreen {
+        }.loadPage(downloadTestPage) {
+            progressBar.waitUntilGone(waitingTime)
+            clickLinkMatchingText(downloadFileName)
+        }
+        // If permission dialog appears on devices with API<30, grant it
+        if (permAllowBtn.waitForExists(waitingTime)) {
+            permAllowBtn.click()
+        }
+        downloadRobot {
+            verifyDownloadDialog(downloadFileName)
+            clickDownloadButton()
+            verifyDownloadConfirmationMessage(downloadFileName)
+            verifyDownloadedFileOnStorage(downloadFileName)
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/helpers/StringsHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/StringsHelper.kt
@@ -17,4 +17,5 @@ object StringsHelper {
     const val PHONE_APP = "com.android.dialer"
     const val GOOGLE_PHOTOS = "com.google.android.apps.photos"
     const val GOOGLE_CHROME = "com.google.android.apps.chrome"
+    const val GOOGLE_DRIVE = "com.google.android.apps.docs"
 }

--- a/app/src/androidTest/java/org/mozilla/focus/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/TestHelper.kt
@@ -3,9 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.focus.helpers
 
+import android.annotation.TargetApi
 import android.app.PendingIntent
 import android.content.ActivityNotFoundException
 import android.content.ComponentName
+import android.content.ContentResolver
+import android.content.ContentUris
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -13,6 +16,11 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.net.Uri
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
+import android.os.Bundle
+import android.provider.MediaStore
+import android.provider.MediaStore.setIncludePending
 import android.text.format.DateUtils
 import android.util.Log
 import android.view.KeyEvent
@@ -160,6 +168,69 @@ object TestHelper {
             intent.setPackage(null)
             getTargetContext.startActivity(intent)
         }
+    }
+
+    fun verifyDownloadedFileOnStorage(fileName: String) {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val resolver = context.contentResolver
+        val fileUri = queryDownloadMediaStore(fileName)
+
+        val fileExists: Boolean = fileUri?.let {
+            resolver.openInputStream(fileUri).use {
+                it != null
+            }
+        } ?: false
+
+        assertTrue(fileExists)
+    }
+
+    /**
+     * Check the "Downloads" public directory for [fileName] and returns an URI to it.
+     * May be `null` if there is no file with that name in "Downloads".
+     */
+    @TargetApi(Build.VERSION_CODES.Q)
+    private fun queryDownloadMediaStore(fileName: String): Uri? {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val resolver = context.contentResolver
+        val queryProjection = arrayOf(MediaStore.Downloads._ID)
+        val querySelection = "${MediaStore.Downloads.DISPLAY_NAME} = ?"
+        val querySelectionArgs = arrayOf(fileName)
+
+        val queryBundle = Bundle().apply {
+            putString(ContentResolver.QUERY_ARG_SQL_SELECTION, querySelection)
+            putStringArray(ContentResolver.QUERY_ARG_SQL_SELECTION_ARGS, querySelectionArgs)
+        }
+
+        // Query if we have a pending download with the same name. This can happen
+        // if a download was interrupted, failed or cancelled before the file was
+        // written to disk. Our logic above will have generated a unique file name
+        // based on existing files on the device, but we might already have a row
+        // for the download in the content resolver.
+        val collection = MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+        val queryCollection =
+            if (SDK_INT >= Build.VERSION_CODES.R) {
+                queryBundle.putInt(MediaStore.QUERY_ARG_MATCH_PENDING, MediaStore.MATCH_INCLUDE)
+                collection
+            } else {
+                @Suppress("DEPRECATION")
+                setIncludePending(collection)
+            }
+
+        var downloadUri: Uri? = null
+        resolver.query(
+            queryCollection,
+            queryProjection,
+            queryBundle,
+            null
+        )?.use {
+            if (it.count > 0) {
+                val idColumnIndex = it.getColumnIndex(MediaStore.Downloads._ID)
+                it.moveToFirst()
+                downloadUri = ContentUris.withAppendedId(collection, it.getLong(idColumnIndex))
+            }
+        }
+
+        return downloadUri
     }
 
     // wait for web area to be visible


### PR DESCRIPTION
For #6531 improve coverage for download file types UI tests

✅  `downloadAndOpenPDFFileTest` - Successfully passed 40x on Firebase
✅  `downloadAndOpenWEBMFileTest` - Successfully passed 40x on Firebase
✅  `verifyDownloadedFileOnStorageTest` - Successfully passed 40x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
