### PR TITLE
For #5283: Re-enables openCustomTabInFocusTest and ads customTabNavigationButtonsTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
@@ -95,14 +95,13 @@ class CustomTabTest {
 
     @SmokeTest
     @Test
-    @Ignore("Crashing, see: https://github.com/mozilla-mobile/focus-android/issues/5283")
     fun openCustomTabInFocusTest() {
         val browserPage = getPlainPageAsset(webServer)
         val customTabPage = getGenericTabAsset(webServer, 1)
 
         launchActivity<IntentReceiverActivity>()
         homeScreen {
-            skipFirstRun()
+            clickStartBrowsing()
         }
 
         searchScreen {
@@ -119,6 +118,30 @@ class CustomTabTest {
             verifyPageURL(customTabPage.url)
             mDevice.pressBack()
             verifyPageURL(browserPage.url)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun customTabNavigationButtonsTest() {
+        val firstPage = getGenericTabAsset(webServer, 1)
+        val secondPage = getGenericTabAsset(webServer, 2)
+
+        launchActivity<IntentReceiverActivity>(createCustomTabIntent(firstPage.url))
+        customTab {
+            verifyPageContent(firstPage.content)
+            clickLinkMatchingText("Tab 2")
+            verifyPageURL(secondPage.url)
+        }.openCustomTabMenu {
+        }.pressBack {
+            progressBar.waitUntilGone(waitingTime)
+            verifyPageURL(firstPage.url)
+        }.openMainMenu {
+        }.pressForward {
+            verifyPageURL(secondPage.url)
+        }.openMainMenu {
+        }.clickReloadButton {
+            verifyPageContent(secondPage.content)
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/CustomTabRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/CustomTabRobot.kt
@@ -15,11 +15,12 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.UiObject
 import androidx.test.uiautomator.UiSelector
 import junit.framework.TestCase.assertTrue
+import org.junit.Assert
 import org.mozilla.focus.R
-import org.mozilla.focus.helpers.TestHelper
 import org.mozilla.focus.helpers.TestHelper.appName
 import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.packageName
+import org.mozilla.focus.helpers.TestHelper.waitingTime
 import org.mozilla.focus.idlingResources.SessionLoadedIdlingResource
 
 class CustomTabRobot {
@@ -60,13 +61,32 @@ class CustomTabRobot {
     fun verifyPageURL(expectedText: String) {
         val sessionLoadedIdlingResource = SessionLoadedIdlingResource()
 
-        customTabUrl.waitForExists(TestHelper.waitingTime)
-
         runWithIdleRes(sessionLoadedIdlingResource) {
+            mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
             assertTrue(
+                "Actual url: ${customTabUrl.text}",
                 customTabUrl.text.contains(expectedText)
             )
         }
+    }
+
+    fun verifyPageContent(expectedText: String) {
+        val sessionLoadedIdlingResource = SessionLoadedIdlingResource()
+
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView"))
+            .waitForExists(waitingTime)
+
+        runWithIdleRes(sessionLoadedIdlingResource) {
+            Assert.assertTrue(
+                mDevice.findObject(UiSelector().textContains(expectedText))
+                    .waitForExists(waitingTime)
+            )
+        }
+    }
+
+    fun clickLinkMatchingText(expectedText: String) {
+        mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().textContains(expectedText)).also { it.click() }
     }
 
     class Transition {
@@ -77,6 +97,13 @@ class CustomTabRobot {
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()
+        }
+
+        fun openCustomTabMenu(interact: ThreeDotMainMenuRobot.() -> Unit): ThreeDotMainMenuRobot.Transition {
+            menuButton.perform(click())
+
+            ThreeDotMainMenuRobot().interact()
+            return ThreeDotMainMenuRobot.Transition()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/HomeScreenRobot.kt
@@ -32,6 +32,8 @@ class HomeScreenRobot {
 
     fun skipFirstRun() = onView(withId(R.id.skip)).perform(click())
 
+    fun clickStartBrowsing() = mDevice.findObject(UiSelector().text("Start browsing")).click()
+
     fun verifyOnboardingFirstSlide() {
         firstSlide.check(matches(isDisplayed()))
     }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/ThreeDotMainMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/ThreeDotMainMenuRobot.kt
@@ -143,6 +143,20 @@ class ThreeDotMainMenuRobot {
             BrowserRobot().interact()
             return BrowserRobot.Transition()
         }
+
+        fun pressBack(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            backButton.click()
+
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
+
+        fun pressForward(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            forwardButton.click()
+
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
     }
 }
 
@@ -195,4 +209,16 @@ private val requestDesktopSiteButton =
     mDevice.findObject(
         UiSelector()
             .resourceId("$packageName:id/switch_widget")
+    )
+
+private val backButton =
+    mDevice.findObject(
+        UiSelector()
+            .description("Navigate back")
+    )
+
+private val forwardButton =
+    mDevice.findObject(
+        UiSelector()
+            .description("Navigate forward")
     )


### PR DESCRIPTION
Ran on Firebase 50 times, all passed: https://github.com/mozilla-mobile/focus-android/runs/5788391758

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
