### PR TITLE
Close PiP when the video is not in fullscreen anymore

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/integration/FullScreenIntegration.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/integration/FullScreenIntegration.kt
@@ -58,6 +58,11 @@ class FullScreenIntegration(
 
             switchToImmersiveMode()
         } else {
+            // If the video is in PiP, but is not in fullscreen anymore we should move the task containing
+            // this activity to the back of the activity stack
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity.isInPictureInPictureMode) {
+                activity.moveTaskToBack(false)
+            }
             statusBar.visibility = View.VISIBLE
             exitBrowserFullscreen()
 


### PR DESCRIPTION
For #6804
If the app goes in PiP, but the video is not in fullscreen anymore we should close the PiP, otherwise we will see the page in PiP and not the video

https://user-images.githubusercontent.com/11731652/161529861-9810e08e-8584-4532-b1cd-c04156fd6149.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
