### PR TITLE
For #6762 Fixed different theme for system insets when coming back to the app

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/CustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/CustomTabActivity.kt
@@ -25,6 +25,7 @@ class CustomTabActivity : LocaleAwareAppCompatActivity() {
     private lateinit var browserFragment: BrowserFragment
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        updateSecureWindowFlags()
         super.onCreate(savedInstanceState)
 
         val intent = SafeIntent(intent)
@@ -59,12 +60,6 @@ class CustomTabActivity : LocaleAwareAppCompatActivity() {
         if (isFinishing) {
             components.customTabsUseCases.remove(customTabId)
         }
-    }
-
-    override fun onResume() {
-        super.onResume()
-
-        updateSecureWindowFlags()
     }
 
     override fun onBackPressed() {

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -55,6 +55,7 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
         get() = components.store.state.privateTabs.size
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        updateSecureWindowFlags()
         super.onCreate(savedInstanceState)
 
         if (!isTaskRoot) {
@@ -125,7 +126,6 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
 
         TelemetryWrapper.startSession()
         checkBiometricStillValid()
-        updateSecureWindowFlags()
     }
 
     override fun onPause() {


### PR DESCRIPTION
I moved updateSecureWindowFlags() from onResume to onCreate the same like on Fenix. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
