### PR TITLE
for #6166 Fingerprint auth  protects the home screen (shortcuts)

### DIFF
--- a/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationDialogFragment.kt
@@ -20,6 +20,7 @@ import org.mozilla.focus.R
 import org.mozilla.focus.databinding.BiometricPromptDialogContentBinding
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.state.AppAction
+import org.mozilla.focus.topsites.TopSitesIntegration
 
 @RequiresApi(api = Build.VERSION_CODES.M)
 @Suppress("TooManyFunctions")
@@ -27,10 +28,12 @@ class BiometricAuthenticationDialogFragment : AppCompatDialogFragment(), Lifecyc
     private var handler: BiometricAuthenticationHandler? = null
     private var _binding: BiometricPromptDialogContentBinding? = null
     private val binding get() = _binding!!
+    private val topSitesIntegration by lazy { TopSitesIntegration(requireComponents.topSitesStorage) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setStyle(DialogFragment.STYLE_NORMAL, R.style.DialogStyle)
+        lifecycle.addObserver(topSitesIntegration)
     }
 
     override fun onCancel(dialog: DialogInterface) {
@@ -63,7 +66,6 @@ class BiometricAuthenticationDialogFragment : AppCompatDialogFragment(), Lifecyc
         binding.newSessionButton.setText(R.string.biometric_auth_new_session)
         binding.newSessionButton.setOnClickListener {
             biometricNewSessionButtonClicked()
-            dismiss()
         }
 
         binding.fingerprintIcon.setImageResource(R.drawable.ic_fingerprint)
@@ -93,6 +95,8 @@ class BiometricAuthenticationDialogFragment : AppCompatDialogFragment(), Lifecyc
 
     private fun biometricNewSessionButtonClicked() {
         requireComponents.tabsUseCases.removePrivateTabs()
+        requireComponents.appStore.dispatch(AppAction.ShowHomeScreen)
+        topSitesIntegration.deleteAllTopSites()
         dismiss()
     }
 

--- a/app/src/main/java/org/mozilla/focus/biometrics/LockObserver.kt
+++ b/app/src/main/java/org/mozilla/focus/biometrics/LockObserver.kt
@@ -7,11 +7,17 @@ package org.mozilla.focus.biometrics
 import android.content.Context
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import mozilla.components.browser.state.selector.privateTabs
 import mozilla.components.browser.state.store.BrowserStore
 import org.mozilla.focus.GleanMetrics.TabCount
+import org.mozilla.focus.ext.components
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.AppStore
+import org.mozilla.focus.topsites.DefaultTopSitesStorage
 
 class LockObserver(
     private val context: Context,
@@ -19,18 +25,31 @@ class LockObserver(
     private val appStore: AppStore
 ) : DefaultLifecycleObserver {
 
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+        triggerAppLock()
+    }
+
     override fun onPause(owner: LifecycleOwner) {
         super.onPause(owner)
+        triggerAppLock()
+    }
 
-        val tabCount = browserStore.state.privateTabs.size.toLong()
-        TabCount.appBackgrounded.accumulateSamples(longArrayOf(tabCount))
-
-        if (tabCount == 0L && appStore.state.topSites.isNullOrEmpty()) {
-            return
-        }
-
-        if (Biometrics.isBiometricsEnabled(context)) {
-            appStore.dispatch(AppAction.Lock)
+    @OptIn(DelicateCoroutinesApi::class)
+    private fun triggerAppLock() {
+        GlobalScope.launch(Dispatchers.IO) {
+            val tabCount = browserStore.state.privateTabs.size.toLong()
+            TabCount.appBackgrounded.accumulateSamples(longArrayOf(tabCount))
+            val topSitesList = context.components.topSitesStorage.getTopSites(
+                totalSites = DefaultTopSitesStorage.TOP_SITES_MAX_LIMIT,
+                frecencyConfig = null
+            )
+            if (tabCount == 0L && topSitesList.isNullOrEmpty()) {
+                return@launch
+            }
+            if (Biometrics.isBiometricsEnabled(context)) {
+                appStore.dispatch(AppAction.Lock)
+            }
         }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/state/AppAction.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppAction.kt
@@ -70,6 +70,11 @@ sealed class AppAction : Action {
     internal object ShowFirstRun : AppAction()
 
     /**
+     * Forces showing the home screen.
+     */
+    internal object ShowHomeScreen : AppAction()
+
+    /**
      * Opens the tab with the given [tabId] and actively switches to the browser screen if needed.
      */
     data class OpenTab(val tabId: String) : AppAction()

--- a/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
@@ -37,6 +37,7 @@ object AppReducer : Reducer<AppState, AppAction> {
             is AppAction.ShowEraseTabsCfrChange -> showEraseTabsCfrChanged(state, action)
             is AppAction.ShowTrackingProtectionCfrChange -> showTrackingProtectionCfrChanged(state, action)
             is AppAction.OpenSitePermissionOptionsScreen -> openSitePermissionOptionsScreen(state, action)
+            is AppAction.ShowHomeScreen -> showHomeScreen(state)
         }
     }
 }
@@ -58,10 +59,9 @@ private fun selectionChanged(state: AppState, action: AppAction.SelectionChanged
  * All tabs have been closed.
  */
 private fun noTabs(state: AppState): AppState {
-    if (state.screen is Screen.Home || state.screen is Screen.FirstRun) {
+    if (state.screen is Screen.Home || state.screen is Screen.FirstRun || state.screen is Screen.Locked) {
         return state
     }
-
     return state.copy(screen = Screen.Home)
 }
 
@@ -112,6 +112,12 @@ private fun showFirstRun(state: AppState): AppState {
     return state.copy(screen = Screen.FirstRun)
 }
 
+/**
+ * Force showing the home screen.
+ */
+private fun showHomeScreen(state: AppState): AppState {
+    return state.copy(screen = Screen.Home)
+}
 /**
  * Lock the application.
  */

--- a/app/src/main/java/org/mozilla/focus/topsites/TopSitesIntegration.kt
+++ b/app/src/main/java/org/mozilla/focus/topsites/TopSitesIntegration.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.topsites
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import mozilla.components.support.base.feature.LifecycleAwareFeature
+
+class TopSitesIntegration(private val topSitesStorage: DefaultTopSitesStorage) : LifecycleAwareFeature {
+    private var ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+
+    fun deleteAllTopSites() {
+        ioScope.launch {
+            val topSitesList = topSitesStorage.getTopSites(
+                totalSites = DefaultTopSitesStorage.TOP_SITES_MAX_LIMIT,
+                frecencyConfig = null
+            )
+            topSitesList.forEach {
+                topSitesStorage.removeTopSite(it)
+            }
+        }
+    }
+
+    override fun start() {
+        // Do nothing
+    }
+
+    override fun stop() {
+        ioScope.cancel()
+    }
+}


### PR DESCRIPTION
I fixed the bug when the user closes the app and removed it from background the LockScreen doesn't appear .
When the user clicks on "New Session" button all the shortcuts will be deleted. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
