### PR TITLE
For #6812: Fix and re-enable disabled UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/AddToHomescreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/AddToHomescreenTest.kt
@@ -7,7 +7,6 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -51,7 +50,6 @@ class AddToHomescreenTest {
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @SmokeTest
     @Test
     fun addPageToHomeScreenTest() {
@@ -70,7 +68,6 @@ class AddToHomescreenTest {
         }
     }
 
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @SmokeTest
     @Test
     fun noNameShortcutTest() {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/EnhancedTrackingProtectionSettingsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/EnhancedTrackingProtectionSettingsTest.kt
@@ -162,7 +162,6 @@ class EnhancedTrackingProtectionSettingsTest {
         }
     }
 
-    @Ignore("Failing, see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @SmokeTest
     @Test
     fun blockSocialTrackersTest() {
@@ -225,7 +224,6 @@ class EnhancedTrackingProtectionSettingsTest {
         }
     }
 
-    @Ignore("Failing, see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @SmokeTest
     @Test
     fun blockOtherContentTrackersTest() {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/EraseBrowsingDataTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/EraseBrowsingDataTest.kt
@@ -76,7 +76,6 @@ class EraseBrowsingDataTest {
         }
     }
 
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @SmokeTest
     @Test
     fun notificationEraseAndOpenButtonTest() {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SafeBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SafeBrowsingTest.kt
@@ -6,7 +6,6 @@ package org.mozilla.focus.activity
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.focus.R
@@ -15,7 +14,6 @@ import org.mozilla.focus.activity.robots.searchScreen
 import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
 import org.mozilla.focus.helpers.MockWebServerHelper
-import org.mozilla.focus.helpers.TestAssetHelper.getPermissionsPageAsset
 import org.mozilla.focus.helpers.TestHelper.exitToTop
 import org.mozilla.focus.helpers.TestHelper.getStringResource
 import org.mozilla.focus.testAnnotations.SmokeTest
@@ -98,7 +96,6 @@ class SafeBrowsingTest {
         }
     }
 
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @SmokeTest
     @Test
     fun unblockSafeBrowsingTest() {
@@ -137,17 +134,5 @@ class SafeBrowsingTest {
         }.openSiteSecurityInfoSheet {
             verifySiteConnectionInfoIsSecure(false)
         }.closeSecurityInfoSheet { }
-    }
-
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
-    @Test
-    fun testLocationSharingNotAllowed() {
-        val permissionsPage = getPermissionsPageAsset(webServer)
-
-        searchScreen {
-        }.loadPage(permissionsPage.url) {
-            clickGetLocationButton()
-            verifyPageContent("No location info")
-        }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SearchTest.kt
@@ -6,7 +6,6 @@ package org.mozilla.focus.activity
 import androidx.test.espresso.Espresso.pressBack
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.focus.activity.robots.browserScreen
@@ -64,7 +63,6 @@ class SearchTest {
         }
     }
 
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @SmokeTest
     @Test
     fun enableSearchSuggestionOnFirstRunTest() {
@@ -116,7 +114,6 @@ class SearchTest {
         }
     }
 
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @Test
     fun testSearchBarShowsSearchTermOnEdit() {
         val searchString = "mozilla focus"

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SettingsGeneralTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SettingsGeneralTest.kt
@@ -50,7 +50,6 @@ class SettingsGeneralTest {
         changeLocale("en")
     }
 
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @SmokeTest
     @Test
     fun changeThemeTest() {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SettingsPrivacyTest.kt
@@ -7,7 +7,6 @@ import androidx.core.net.toUri
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -41,7 +40,6 @@ class SettingsPrivacyTest {
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @SmokeTest
     @Test
     fun verifyCookiesAndSiteDataItemsTest() {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SettingsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SettingsTest.kt
@@ -5,7 +5,6 @@
 package org.mozilla.focus.activity
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -29,7 +28,6 @@ class SettingsTest {
         }
     }
 
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @SmokeTest
     @Test
     fun verifyGeneralSettingsMenuTest() {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SwitchContextTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SwitchContextTest.kt
@@ -85,7 +85,6 @@ class SwitchContextTest {
         }
     }
 
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @SmokeTest
     @Test
     fun switchFromSettingsToFocusTest() {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/URLAutocompleteTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/URLAutocompleteTest.kt
@@ -4,7 +4,6 @@
 package org.mozilla.focus.activity
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -100,7 +99,6 @@ class URLAutocompleteTest {
         }
     }
 
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @Test
     // Add custom autocompletion site, then disable autocomplete
     fun disableAutocompleteForCustomSiteTest() {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsPrivacyMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsPrivacyMenuRobot.kt
@@ -10,7 +10,6 @@ import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
 import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.hasSibling
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled
@@ -97,11 +96,11 @@ class SettingsPrivacyMenuRobot {
 
     fun verifyAutoplaySection() {
         privacySettingsList.waitForExists(waitingTime)
-        autoplayAllowAudioAndVideoOption().check(matches(isDisplayed()))
-        autoplayBlockAudioOnlyOption().check(matches(isDisplayed()))
-        recommendedDescription().check(matches(isDisplayed()))
+        assertTrue(autoplayAllowAudioAndVideoOption.exists())
+        assertTrue(autoplayBlockAudioOnlyOption.exists())
+        assertTrue(recommendedDescription.exists())
         assertBlockAudioOnlyIsChecked()
-        blockAudioAndVideoOption().check(matches(isDisplayed()))
+        assertTrue(blockAudioAndVideoOption.exists())
     }
 
     fun verifyBlockAdTrackersEnabled(enabled: Boolean) {
@@ -701,21 +700,25 @@ private fun autoplayOption() = onView(withText(R.string.preference_autoplay))
 
 private fun autoplayDefaultOption() = onView(withText(R.string.preference_block_autoplay_audio_only))
 
-private fun autoplayAllowAudioAndVideoOption() = onView(withText(R.string.preference_allow_audio_video_autoplay))
+private val autoplayAllowAudioAndVideoOption =
+    mDevice.findObject(UiSelector().text(getStringResource(R.string.preference_allow_audio_video_autoplay)))
 
-private fun autoplayBlockAudioOnlyOption() = onView(withText(R.string.preference_block_autoplay_audio_only))
+private val autoplayBlockAudioOnlyOption =
+    mDevice.findObject(UiSelector().text(getStringResource(R.string.preference_block_autoplay_audio_only)))
 
-private fun recommendedDescription() = onView(withText(R.string.preference_block_autoplay_audio_only_summary))
+private val recommendedDescription =
+    mDevice.findObject(UiSelector().text(getStringResource(R.string.preference_block_autoplay_audio_only_summary)))
 
-private fun blockAudioAndVideoOption() = onView(withText(R.string.preference_block_autoplay_audio_video))
+private val blockAudioAndVideoOption =
+    mDevice.findObject(UiSelector().text(getStringResource(R.string.preference_block_autoplay_audio_video)))
 
-private fun assertBlockAudioOnlyIsChecked() =
-    onView(
-        allOf(
-            withId(R.id.radio_button),
-            hasSibling(withText(R.string.preference_block_autoplay_audio_only))
-        )
-    ).check(matches(isChecked()))
+private fun assertBlockAudioOnlyIsChecked() {
+    val radioButton =
+        mDevice.findObject(UiSelector().text(getStringResource(R.string.preference_block_autoplay_audio_only)))
+            .getFromParent(UiSelector().className("android.widget.RadioButton"))
+
+    assertTrue(radioButton.isChecked)
+}
 
 private val blockCookiesPromptHeading =
     mDevice.findObject(

--- a/app/src/androidTest/java/org/mozilla/focus/screenshots/HomeScreenScreenshots.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/screenshots/HomeScreenScreenshots.kt
@@ -19,7 +19,6 @@ import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.UiObject
 import androidx.test.uiautomator.UiSelector
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.focus.R
@@ -60,7 +59,6 @@ class HomeScreenScreenshots : ScreenshotTest() {
         Screengrab.screenshot("Home_View")
     }
 
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @Test
     fun takeScreenshotShortCutsHomeScreen() {
         homeScreen {
@@ -75,7 +73,6 @@ class HomeScreenScreenshots : ScreenshotTest() {
         }
     }
 
-    @Ignore("Failing , see https://github.com/mozilla-mobile/focus-android/issues/6812")
     @Test
     fun openWebsiteFocus() {
         var currentLocale: String = Locale.getDefault().getLanguage()


### PR DESCRIPTION
For #6812: 
A few tests failures were caused by a different a11y issue (already fixed), so there was nothing to fix about that. 
verifyCookiesAndSiteDataItemsTest fixed and re-enabled.
testLocationSharingNotAllowed removed and will be re-written in a following PR.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
