### PR TITLE
Swap the order of two tips to make more sense

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/FirstRunTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/FirstRunTest.kt
@@ -30,8 +30,8 @@ class FirstRunTest {
     private val featureSettingsHelper = FeatureSettingsHelper()
     private val firstTipText = getStringResource(R.string.tip_fresh_look)
     private val secondTipText = getStringResource(R.string.tip_about_shortcuts)
-    private val thirdTipText = getStringResource(R.string.tip_explain_allowlist3)
-    private val fourthTipText = getStringResource(R.string.tip_disable_tracking_protection3)
+    private val thirdTipText = getStringResource(R.string.tip_disable_tracking_protection3)
+    private val fourthTipText = getStringResource(R.string.tip_explain_allowlist3)
     private val fifthTipText = getStringResource(R.string.tip_request_desktop2)
 
     @get: Rule
@@ -127,6 +127,7 @@ class FirstRunTest {
             skipFirstRun()
             closeSoftKeyboard()
             verifyTipsCarouselIsDisplayed(true)
+            scrollLeftTipsCarousel()
             scrollLeftTipsCarousel()
             scrollLeftTipsCarousel()
         }.clickLinkFromTips("Add it to the Allowlist in Settings") {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MozillaSupportPagesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MozillaSupportPagesTest.kt
@@ -25,8 +25,8 @@ class MozillaSupportPagesTest {
     private val featureSettingsHelper = FeatureSettingsHelper()
     private val firstTipText = getStringResource(R.string.tip_fresh_look)
     private val secondTipText = getStringResource(R.string.tip_about_shortcuts)
-    private val thirdTipText = getStringResource(R.string.tip_explain_allowlist3)
-    private val fourthTipText = getStringResource(R.string.tip_disable_tracking_protection3)
+    private val thirdTipText = getStringResource(R.string.tip_disable_tracking_protection3)
+    private val fourthTipText = getStringResource(R.string.tip_explain_allowlist3)
     private val fifthTipText = getStringResource(R.string.tip_request_desktop2)
 
     @get: Rule

--- a/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
+++ b/app/src/main/java/org/mozilla/focus/tips/TipManager.kt
@@ -145,8 +145,8 @@ object TipManager {
     private fun populateListOfTips(context: Context) {
         addFreshLookTip(context)
         addShortcutsTip(context)
-        addAllowlistTip(context)
         addTrackingProtectionTip(context)
+        addAllowlistTip(context)
         addRequestDesktopTip(context)
     }
 


### PR DESCRIPTION
This just reorders things so that we show the tip that explains ETP (enhanced tracking protection) before the tip that explains the ETP Allowlist, instead of after.

Fixes https://github.com/mozilla-mobile/focus-android/issues/6912



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
