### PR TITLE
for #6928 Use a feature flag for fingerprint auth changes that that protect home screen

### DIFF
--- a/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationDialogFragment.kt
@@ -21,6 +21,7 @@ import org.mozilla.focus.databinding.BiometricPromptDialogContentBinding
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.topsites.TopSitesIntegration
+import org.mozilla.focus.utils.Features.DELETE_TOP_SITES_WHEN_NEW_SESSION_BUTTON_CLICKED
 
 @RequiresApi(api = Build.VERSION_CODES.M)
 @Suppress("TooManyFunctions")
@@ -96,7 +97,9 @@ class BiometricAuthenticationDialogFragment : AppCompatDialogFragment(), Lifecyc
     private fun biometricNewSessionButtonClicked() {
         requireComponents.tabsUseCases.removePrivateTabs()
         requireComponents.appStore.dispatch(AppAction.ShowHomeScreen)
-        topSitesIntegration.deleteAllTopSites()
+        if (DELETE_TOP_SITES_WHEN_NEW_SESSION_BUTTON_CLICKED) {
+            topSitesIntegration.deleteAllTopSites()
+        }
         dismiss()
     }
 

--- a/app/src/main/java/org/mozilla/focus/utils/Features.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Features.kt
@@ -25,4 +25,9 @@ object Features {
      * has "firstrun" in their name should be renamed to use "onboarding"
      */
     var ONBOARDING = AppConstants.isDevOrNightlyBuild
+
+    /**
+     * Delete all shortcuts when New Session Button from FingerPrint LockScreen is clicked
+     */
+    var DELETE_TOP_SITES_WHEN_NEW_SESSION_BUTTON_CLICKED: Boolean = AppConstants.isDevOrNightlyBuild
 }


### PR DESCRIPTION
Added a Feature Flag for Delete all shortcuts when New Session Button from FingerPrint LockScreen is clicked

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
