### PR TITLE
for #6979 fixed focus crash when the fingerprint auth is deleted

### DIFF
--- a/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationDialogFragment.kt
@@ -66,7 +66,7 @@ class BiometricAuthenticationDialogFragment : AppCompatDialogFragment(), Lifecyc
         binding.description.setText(R.string.biometric_auth_description)
         binding.newSessionButton.setText(R.string.biometric_auth_new_session)
         binding.newSessionButton.setOnClickListener {
-            biometricNewSessionButtonClicked()
+            triggerNewSession()
         }
 
         binding.fingerprintIcon.setImageResource(R.drawable.ic_fingerprint)
@@ -77,9 +77,12 @@ class BiometricAuthenticationDialogFragment : AppCompatDialogFragment(), Lifecyc
         super.onResume()
 
         resetErrorText()
-
-        handler = BiometricAuthenticationHandler(requireContext(), this)
-        handler?.startAuthentication()
+        if (!Biometrics.hasFingerprintHardware(requireContext())) {
+            triggerNewSession()
+        } else {
+            handler = BiometricAuthenticationHandler(requireContext(), this)
+            handler?.startAuthentication()
+        }
     }
 
     override fun onPause() {
@@ -94,7 +97,7 @@ class BiometricAuthenticationDialogFragment : AppCompatDialogFragment(), Lifecyc
         _binding = null
     }
 
-    private fun biometricNewSessionButtonClicked() {
+    private fun triggerNewSession() {
         requireComponents.tabsUseCases.removePrivateTabs()
         requireComponents.appStore.dispatch(AppAction.ShowHomeScreen)
         if (DELETE_TOP_SITES_WHEN_NEW_SESSION_BUTTON_CLICKED) {


### PR DESCRIPTION
If the user doesn't have any fingerPrints enrolled he can enter in the app the same way like when he presses "new session " button .

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
