### PR TITLE
Set tracking cfr to false on dismiss

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
@@ -266,7 +266,6 @@ class BrowserToolbarIntegration(
                             onDismiss = ::onDismissTrackingProtectionCfr
                         ).apply {
                             show()
-                            fragment.components?.appStore?.dispatch(AppAction.ShowTrackingProtectionCfrChange(false))
                         }
                     }
                 }
@@ -274,6 +273,7 @@ class BrowserToolbarIntegration(
     }
 
     private fun onDismissTrackingProtectionCfr() {
+        fragment.components?.appStore?.dispatch(AppAction.ShowTrackingProtectionCfrChange(false))
         fragment.requireContext().settings.shouldShowCfrForTrackingProtection = false
     }
 


### PR DESCRIPTION
For #7001
Before this commit the state of tracking protection cfr was set to false as soon as the cfr was shown, fact which can lead to a bug.
An event is received to show the cfr but the cfr is already displayed and the app crashes
To solve this I set tracking cfr to false on dismiss, when the preference is also set to false

https://user-images.githubusercontent.com/11731652/168078371-62502aba-931e-41a7-b1f4-ede4534a07bd.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
