### PR TITLE
DO NOT LAND - Test older GV with newest AC

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,14 @@ android {
         multiDexEnabled true
     }
 
+    configurations.all {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'org.mozilla.geckoview') {
+                details.useVersion "102.0.20220513093538"
+            }
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "102.0.20220513190143"
+    const val VERSION = "102.0.20220515225015"
 }


### PR DESCRIPTION
Latest try to update the AC version had many ui test failing - https://github.com/mozilla-mobile/focus-android/pull/7026/checks?check_run_id=6447251975
Let's try the same but with a slightly older GV version.
