### PR TITLE
Update tracking protection cfr visibility conditions

### DIFF
--- a/app/src/test/java/org/mozilla/focus/cfr/CfrMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/focus/cfr/CfrMiddlewareTest.kt
@@ -5,10 +5,13 @@ package org.mozilla.focus.cfr
 
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.action.TrackingProtectionAction
 import mozilla.components.browser.state.state.SecurityInfoState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.content.blocking.Tracker
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.robolectric.testContext
@@ -69,7 +72,17 @@ class CfrMiddlewareTest {
                     issuer = "Test"
                 )
             )
+            val trackerBlockedAction = TrackingProtectionAction.TrackerBlockedAction(
+                tabId = "1",
+                tracker = Tracker(
+                    url = "test.org",
+                    trackingCategories = listOf(EngineSession.TrackingProtectionPolicy.TrackingCategory.CRYPTOMINING),
+                    cookiePolicies = listOf(EngineSession.TrackingProtectionPolicy.CookiePolicy.ACCEPT_NONE)
+                )
+            )
+
             browserStore.dispatch(updateSecurityInfoAction).joinBlocking()
+            browserStore.dispatch(trackerBlockedAction).joinBlocking()
             appStore.waitUntilIdle()
 
             assertTrue(appStore.state.showTrackingProtectionCfr)


### PR DESCRIPTION
For #7011
Show tracking protection cfr only when the tracking protection counter is updated
for the first time with a value greater than zero

https://user-images.githubusercontent.com/11731652/169821571-b75b50f0-357b-4048-97b1-b6f161aa9940.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
