### PR TITLE
Run failing SafeBrowsingTest UI tests without the latest AC upgrades on Firebase

### DIFF
--- a/.github/ISSUE_TEMPLATE/---performance-issue.md
+++ b/.github/ISSUE_TEMPLATE/---performance-issue.md
@@ -1,0 +1,19 @@
+---
+name: "⌛ Performance issue"
+about: Create a performance issue if the app is slow or it uses too much memory, disk space, battery, or network data
+title: ""
+labels: "performance"
+assignees: ''
+
+---
+
+## Steps to reproduce
+
+### Expected behavior
+
+### Actual behavior
+
+### Device information
+
+* Android device: ?
+* Focus version: ?

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SafeBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SafeBrowsingTest.kt
@@ -6,7 +6,6 @@ package org.mozilla.focus.activity
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.focus.R
@@ -99,7 +98,6 @@ class SafeBrowsingTest {
 
     @SmokeTest
     @Test
-    @Ignore("https://github.com/mozilla-mobile/focus-android/issues/6967")
     fun unblockSafeBrowsingTest() {
         val malwareURl = "http://itisatrap.org/firefox/its-an-attack.html"
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SitePermissionsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SitePermissionsTest.kt
@@ -18,6 +18,7 @@ import org.mozilla.focus.activity.robots.searchScreen
 import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
 import org.mozilla.focus.helpers.MockWebServerHelper
+import org.mozilla.focus.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.focus.helpers.TestAssetHelper.getMediaTestAsset
 import org.mozilla.focus.helpers.TestHelper.exitToTop
 import org.mozilla.focus.helpers.TestHelper.getTargetContext
@@ -52,7 +53,6 @@ class SitePermissionsTest {
     }
 
     @Test
-    @Ignore("https://github.com/mozilla-mobile/focus-android/issues/6967")
     fun sitePermissionsSettingsItemsTest() {
         homeScreen {
         }.openMainMenu {
@@ -65,7 +65,6 @@ class SitePermissionsTest {
 
     @SmokeTest
     @Test
-    @Ignore("See https://github.com/mozilla-mobile/focus-android/issues/6958")
     fun autoplayPermissionsSettingsItemsTest() {
         homeScreen {
         }.openMainMenu {
@@ -107,7 +106,6 @@ class SitePermissionsTest {
 
     @SmokeTest
     @Test
-    @Ignore("https://github.com/mozilla-mobile/focus-android/issues/6967")
     // Tests the autoplay setting: Allow audio and video on a video with autoplay attribute and not muted
     fun allowAudioVideoAutoplayPermissionTest() {
         val videoPage = getMediaTestAsset(webServer, "videoPage")
@@ -129,9 +127,9 @@ class SitePermissionsTest {
 
     @SmokeTest
     @Test
-    @Ignore("https://github.com/mozilla-mobile/focus-android/issues/6967")
     // Tests the autoplay setting: Allow audio and video on a video with autoplay and muted attributes
     fun allowAudioVideoAutoplayPermissionOnMutedVideoTest() {
+        val genericPage = getGenericAsset(webServer)
         val mutedVideoPage = getMediaTestAsset(webServer, "mutedVideoPage")
 
         homeScreen {
@@ -144,7 +142,7 @@ class SitePermissionsTest {
             exitToTop()
         }
         searchScreen {
-        }.loadPage("test") {
+        }.loadPage(genericPage.url) {
         }.clearBrowsingData {}
         searchScreen {
         }.loadPage(mutedVideoPage.url) {
@@ -154,7 +152,6 @@ class SitePermissionsTest {
 
     @SmokeTest
     @Test
-    @Ignore("https://github.com/mozilla-mobile/focus-android/issues/6967")
     // Tests the autoplay setting: Block audio and video
     fun blockAudioVideoAutoplayPermissionTest() {
         val videoPage = getMediaTestAsset(webServer, "videoPage")
@@ -177,7 +174,6 @@ class SitePermissionsTest {
 
     @SmokeTest
     @Test
-    @Ignore("See https://github.com/mozilla-mobile/focus-android/issues/6958")
     fun cameraPermissionsSettingsItemsTest() {
         homeScreen {
         }.openMainMenu {
@@ -193,7 +189,6 @@ class SitePermissionsTest {
 
     @SmokeTest
     @Test
-    @Ignore("See https://github.com/mozilla-mobile/focus-android/issues/6958")
     fun locationPermissionsSettingsItemsTest() {
         homeScreen {
         }.openMainMenu {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsPrivacyMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsPrivacyMenuRobot.kt
@@ -50,7 +50,7 @@ class SettingsPrivacyMenuRobot {
         cookiesAndSiteDataSection().check(matches(isDisplayed()))
         blockCookies().check(matches(isDisplayed()))
         blockCookiesDefaultOption().check(matches(isDisplayed()))
-        sitePermissions().check(matches(isDisplayed()))
+        assertTrue(sitePermissions().exists())
         verifyExceptionsListDisabled()
         useFingerprintSwitch().check(matches(isDisplayed()))
         assertUseFingerprintSwitchState()
@@ -75,7 +75,7 @@ class SettingsPrivacyMenuRobot {
         cookiesAndSiteDataSection().check(matches(isDisplayed()))
         blockCookies().check(matches(isDisplayed()))
         blockCookiesDefaultOption().check(matches(isDisplayed()))
-        sitePermissions().check(matches(isDisplayed()))
+        assertTrue(sitePermissions().exists())
     }
 
     fun verifyBlockCookiesPrompt() {
@@ -258,7 +258,8 @@ class SettingsPrivacyMenuRobot {
         }
 
         fun clickSitePermissionsSettings(interact: SettingsSitePermissionsRobot.() -> Unit): SettingsSitePermissionsRobot.Transition {
-            sitePermissions().perform(click())
+            sitePermissions().waitForExists(waitingTime)
+            sitePermissions().click()
 
             SettingsSitePermissionsRobot().interact()
             return SettingsSitePermissionsRobot.Transition()
@@ -491,11 +492,9 @@ private fun blockCookiesDefaultOption(): ViewInteraction {
     return onView(withText(R.string.preference_privacy_should_block_cookies_cross_site_option))
 }
 
-private fun sitePermissions(): ViewInteraction {
+private fun sitePermissions() =
     privacySettingsList
-        .scrollTextIntoView("Cookies and Site Data")
-    return onView(withText(R.string.preference_site_permissions))
-}
+        .getChildByText(UiSelector().text("Site permissions"), "Site permissions", true)
 
 private fun useFingerprintSwitch(): ViewInteraction {
     val useFingerprintSwitchSummary = getStringResource(R.string.preference_security_biometric_summary)
@@ -566,9 +565,15 @@ private fun assertStealthModeSwitchState(enabled: Boolean = false) {
 }
 
 private fun safeBrowsingSwitch(): ViewInteraction {
-    val safeBrowsingSwitchText = getStringResource(R.string.preference_safe_browsing_summary)
-    privacySettingsList.scrollTextIntoView(safeBrowsingSwitchText)
-    return onView(withText(safeBrowsingSwitchText))
+    val safeBrowsingSwitchText =
+        mDevice.findObject(
+            UiSelector().text(
+                getStringResource(R.string.preference_safe_browsing_summary)
+            )
+        )
+    privacySettingsList.scrollToEnd(3)
+    privacySettingsList.scrollIntoView(safeBrowsingSwitchText)
+    return onView(withText(getStringResource(R.string.preference_safe_browsing_summary)))
 }
 
 private fun assertSafeBrowsingSwitchState(enabled: Boolean = true) {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsSitePermissionsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsSitePermissionsRobot.kt
@@ -102,10 +102,13 @@ private val blockAudioAndVideoOption =
     mDevice.findObject(UiSelector().text(getStringResource(R.string.preference_block_autoplay_audio_video)))
 
 private fun assertBlockAudioOnlyIsChecked() {
+    // the childSelector doesn't work anymore, so we are unable to find it by text
     val radioButton =
-        mDevice.findObject(UiSelector().text(getStringResource(R.string.preference_block_autoplay_audio_only)))
-            .getFromParent(UiSelector().className("android.widget.RadioButton"))
-
+        mDevice.findObject(
+            UiSelector()
+                .checkable(true)
+                .index(1)
+        )
     assertTrue(radioButton.isChecked)
 }
 
@@ -145,8 +148,12 @@ private val DRMContentDefaultValue =
         .getFromParent(UiSelector().text("Ask to allow"))
 
 private val askToAllowRadioButton =
-    mDevice.findObject(UiSelector().text("Ask to allow"))
-        .getFromParent(UiSelector().className("android.widget.RadioButton"))
+    // the childSelector doesn't work anymore, so we are unable to find it by text
+    mDevice.findObject(
+        UiSelector()
+            .checkable(true)
+            .index(0)
+    )
 
 private val blockedRadioButton =
     mDevice.findObject(UiSelector().text("Blocked"))

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -633,10 +633,10 @@
     <string name="preference_autocomplete_duplicate_url_error">Le URL existe ja</string>
 
     <!-- Label for the Find in page button -->
-    <string name="find_in_page">Trovar in le pagina</string>
+    <string name="find_in_page">Cercar in le pagina</string>
 
     <!-- Watermark/Hint for the find in page input field -->
-    <string name="find_in_page_input">Trovar in le pagina</string>
+    <string name="find_in_page_input">Cercar in le pagina</string>
 
     <!-- String to show the number of results found in the page and the
         position the user is at. The first argument is the position, the second argument is the total -->

--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -38,8 +38,9 @@ gcloud:
   performance-metrics: true
 
   test-targets:
-    - package org.mozilla.focus.activity
-    - package org.mozilla.focus.privacy
+    - class org.mozilla.focus.activity.SafeBrowsingTest#blockPhishingPageTest
+    - class org.mozilla.focus.activity.SafeBrowsingTest#blockMalwarePageTest
+    - class org.mozilla.focus.activity.SafeBrowsingTest#blockUnwantedSoftwarePageTest
 
   device:
    - model: Pixel3
@@ -52,7 +53,7 @@ flank:
   max-test-shards: -1
   # num-test-runs: the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
-  num-test-runs: 1
+  num-test-runs: 10
   ### Output Style flag
   ## Output style of execution status. May be one of [verbose, multi, single, compact].
   ## For runs with only one test execution the default value is 'verbose', in other cases


### PR DESCRIPTION
Run failing SafeBrowsingTest UI tests without the latest AC upgrades (102.0.20220524015637 and 102.0.20220524143152) on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
