### PR TITLE
For #7113 disable failing SafeBrowsingTest UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
@@ -36,6 +36,7 @@ class ErrorPagesTest {
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
+    @Ignore("Failing, see https://github.com/mozilla-mobile/focus-android/issues/6733")
     @Test
     fun badURLCheckTest() {
         val badURl = "bad.url"

--- a/app/src/androidTest/java/org/mozilla/focus/activity/SafeBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SafeBrowsingTest.kt
@@ -6,6 +6,7 @@ package org.mozilla.focus.activity
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.focus.R
@@ -48,6 +49,7 @@ class SafeBrowsingTest {
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
+    @Ignore("Failing, see https://github.com/mozilla-mobile/focus-android/issues/7113")
     @SmokeTest
     @Test
     fun blockMalwarePageTest() {
@@ -60,6 +62,7 @@ class SafeBrowsingTest {
         }
     }
 
+    @Ignore("Failing, see https://github.com/mozilla-mobile/focus-android/issues/7113")
     @SmokeTest
     @Test
     fun blockPhishingPageTest() {
@@ -72,6 +75,7 @@ class SafeBrowsingTest {
         }
     }
 
+    @Ignore("Failing, see https://github.com/mozilla-mobile/focus-android/issues/7113")
     @SmokeTest
     @Test
     fun blockUnwantedSoftwarePageTest() {
@@ -84,6 +88,7 @@ class SafeBrowsingTest {
         }
     }
 
+    @Ignore("Failing, see https://github.com/mozilla-mobile/focus-android/issues/7113")
     @SmokeTest
     @Test
     fun blockHarmfulPageTest() {


### PR DESCRIPTION
For #7113 disable failing SafeBrowsingTest UI tests.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
