### PR TITLE
Remove redundant record exposure

### DIFF
--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -133,7 +133,6 @@ class Components(
     val store by lazy {
         val onboardingFeature = FocusNimbus.features.onboarding
         val cfrMiddleware = if (onboardingFeature.value(context = context).isCfrEnabled) {
-            onboardingFeature.recordExposure()
             listOf(CfrMiddleware(context))
         } else {
             listOf()


### PR DESCRIPTION
For #7082
We are recording the exposure in cfr middleware, so this one from store is redundant and not relevant
No screenshots, unit tests, accessibility
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
