### PR TITLE
For #7140 : Let A-C handle toolbar expanding when URL changes

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
@@ -27,7 +27,6 @@ import mozilla.components.feature.toolbar.ToolbarPresenter
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.ktx.android.view.hideKeyboard
-import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import org.mozilla.focus.GleanMetrics.TabCount
 import org.mozilla.focus.GleanMetrics.TrackingProtection
@@ -223,7 +222,6 @@ class BrowserToolbarIntegration(
             setBrowserActionButtons()
             observeEraseCfr()
         }
-        expandToolbarOnNavigation()
         observeTrackingProtectionCfr()
     }
 
@@ -273,20 +271,6 @@ class BrowserToolbarIntegration(
                             show()
                         }
                     }
-                }
-        }
-    }
-
-    private fun expandToolbarOnNavigation() {
-        store.flowScoped { flow ->
-            flow.mapNotNull { state ->
-                state.findCustomTabOrSelectedTab(customTabId)
-            }
-                .ifAnyChanged { tab ->
-                    arrayOf(tab.content.url, tab.content.loadRequest)
-                }
-                .collect {
-                    toolbar.expand()
                 }
         }
     }


### PR DESCRIPTION
This fix allows the toolbar to be visible after the user clicks on a link and scrolls


https://user-images.githubusercontent.com/12825812/171129427-eda5b476-3cf5-413b-9db0-4a5d54066f91.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
