### PR TITLE
For #7079 Collect telemetry on how Focus was started and n which state it way

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -309,6 +309,7 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_coroutines
+    testImplementation Dependencies.androidx_work_testing
     testImplementation Dependencies.androidx_arch_core_testing
     testImplementation "org.mozilla.components:support-test:${AndroidComponents.VERSION}"
     testImplementation "org.mozilla.components:support-test-libstate:${AndroidComponents.VERSION}"

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -4,6 +4,10 @@
 ---
 $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
+no_lint:
+  - CATEGORY_GENERIC
+  - COMMON_PREFIX
+
 browser:
   is_default:
     type: boolean
@@ -112,6 +116,82 @@ browser:
     notification_emails:
       - android-probes@mozilla.com
     expires: 107
+
+perf.startup:
+  startup_type:
+    type: labeled_counter
+    description: |
+      Indicates how the browser was started. The label is divided into two
+      variables. `state` is how cached the browser is when started. `path` is
+      what code path we are expected to take. Together, they create a combined
+      label: `state_path`. For brevity, the specific states are documented in
+      the [Fenix perf
+      glossary](https://wiki.mozilla.org/index.php?title=Performance/Fenix/Glossary).
+      <br><br>
+      This implementation is intended to be simple, not comprehensive. We list
+      the implications below.
+
+      <br><br>
+      These ways of opening the app undesirably adds events to our primary
+      buckets (non-`unknown` cases):
+      <br>- App switcher cold/warm: `cold/warm_` + duplicates path from
+      previous launch
+      <br>- An Intent is sent internally that's uses `ACTION_MAIN` or
+      `ACTION_VIEW` could be: `*_main/view` (unknown if this ever happens)
+      <br>- A command-line launch uses `ACTION_MAIN` or `ACTION_VIEW` could be:
+      `*_main/view`
+
+      <br><br>
+      These ways of opening the app undesirably do not add their events to our
+      primary buckets:
+      <br>- Close and reopen the app very quickly: no event is recorded.
+
+      <br><br>
+      These ways of opening the app don't affect our primary buckets:
+      <br>- App switcher hot: `hot_unknown`
+      <br>- PWA (all states): `unknown_unknown`
+      <br>- Custom tab: `unknown_view`
+      <br>- Cold start where a service or other non-activity starts the process
+      (not manually tested) - this seems to happen if you have the homescreen
+      widget: `unknown_*`
+      <br>- Another activity is drawn before MainActivity or CustomTabActivity
+      (e.g. widget voice
+      search): `unknown_*`
+
+      <br>
+      In addition to the events above, the `unknown` state may be chosen when we
+      were unable to determine a cause due to implementation details or the API
+      was used incorrectly. We may be able to record the events listed above
+      into different buckets but we kept the implementation simple for now.
+      <br><br>
+      N.B.: for implementation simplicity, we duplicate the logic in app that
+      determines `path` so it's not perfectly accurate. In one way, we record we
+      is intended to happen rather than what actually happened (e.g. the user
+      may click a link so we record VIEW but the app does a MAIN by going to the
+      homescreen because the link was invalid).
+    labels:
+      - cold_main
+      - cold_view
+      - cold_unknown
+      - warm_main
+      - warm_view
+      - warm_unknown
+      - hot_main
+      - hot_view
+      - hot_unknown
+      - unknown_main
+      - unknown_view
+      - unknown_unknown
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/7079
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - perf-telemetry-alerts@mozilla.com
+      - mleclair@mozilla.com
+    expires: never
 
 activation:
   activation_id:
@@ -1757,3 +1837,45 @@ nimbus_experiments:
     expires: 112
     data_sensitivity:
       - technical
+
+metrics:
+  start_reason_process_error:
+    type: boolean
+    description: |
+      The `AppStartReasonProvider.ProcessLifecycleObserver.onCreate` was
+      unexpectedly called twice. We can use this metric to validate our
+      assumptions about how these APIs are called. This probe can be removed
+      once we validate these assumptions.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/7079
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - perf-telemetry-alerts@mozilla.com
+      - mleclair@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - performance
+  start_reason_activity_error:
+    type: boolean
+    description: |
+      The `AppStartReasonProvider.ActivityLifecycleCallbacks.onActivityCreated`
+      was unexpectedly called twice. We can use this metric to validate our
+      assumptions about how these APIs are called. This probe can be removed
+      once we validate these assumptions.
+    bugs:
+      - https://github.com/mozilla-mobile/focus-android/issues/7079
+    data_reviews:
+      - https://github.com/mozilla-mobile/focus-android/
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - perf-telemetry-alerts@mozilla.com
+      - mleclair@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - performance

--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -71,6 +71,9 @@ import org.mozilla.focus.state.Screen
 import org.mozilla.focus.tabs.MergeTabsMiddleware
 import org.mozilla.focus.telemetry.GleanMetricsService
 import org.mozilla.focus.telemetry.TelemetryMiddleware
+import org.mozilla.focus.telemetry.startuptelemetry.AppStartReasonProvider
+import org.mozilla.focus.telemetry.startuptelemetry.StartupActivityLog
+import org.mozilla.focus.telemetry.startuptelemetry.StartupStateProvider
 import org.mozilla.focus.tips.TipManager
 import org.mozilla.focus.topsites.DefaultTopSitesStorage
 import org.mozilla.focus.utils.Settings
@@ -92,6 +95,12 @@ class Components(
             )
         )
     }
+
+    val appStartReasonProvider by lazy { AppStartReasonProvider() }
+
+    val startupActivityLog by lazy { StartupActivityLog() }
+
+    val startupStateProvider by lazy { StartupStateProvider(startupActivityLog, appStartReasonProvider) }
 
     val settings by lazy { Settings(context) }
 

--- a/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -87,6 +87,9 @@ open class FocusApplication : LocaleAwareApplication(), CoroutineScope {
 
             setupLeakCanary()
 
+            components.appStartReasonProvider.registerInAppOnCreate(this)
+            components.startupActivityLog.registerInAppOnCreate(this)
+
             ProcessLifecycleOwner.get().lifecycle.addObserver(lockObserver)
         }
     }

--- a/app/src/main/java/org/mozilla/focus/activity/CustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/CustomTabActivity.kt
@@ -16,6 +16,8 @@ import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.updateSecureWindowFlags
 import org.mozilla.focus.fragment.BrowserFragment
+import org.mozilla.focus.telemetry.startuptelemetry.StartupPathProvider
+import org.mozilla.focus.telemetry.startuptelemetry.StartupTypeTelemetry
 
 /**
  * The main entry point for "custom tabs" opened by third-party apps.
@@ -23,6 +25,9 @@ import org.mozilla.focus.fragment.BrowserFragment
 class CustomTabActivity : LocaleAwareAppCompatActivity() {
     private lateinit var customTabId: String
     private lateinit var browserFragment: BrowserFragment
+
+    private val startupPathProvider = StartupPathProvider()
+    private lateinit var startupTypeTelemetry: StartupTypeTelemetry
 
     override fun onCreate(savedInstanceState: Bundle?) {
         updateSecureWindowFlags()
@@ -51,6 +56,11 @@ class CustomTabActivity : LocaleAwareAppCompatActivity() {
             supportFragmentManager.beginTransaction()
                 .add(R.id.container, browserFragment)
                 .commit()
+        }
+
+        startupPathProvider.attachOnActivityOnCreate(lifecycle, intent.unsafe)
+        startupTypeTelemetry = StartupTypeTelemetry(components.startupStateProvider, startupPathProvider).apply {
+            attachOnMainActivityOnCreate(lifecycle)
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/telemetry/startuptelemetry/AppStartReasonProvider.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/startuptelemetry/AppStartReasonProvider.kt
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.telemetry.startuptelemetry
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import mozilla.components.support.base.log.logger.Logger
+import org.mozilla.focus.GleanMetrics.Metrics
+import org.mozilla.focus.telemetry.startuptelemetry.AppStartReasonProvider.StartReason
+
+private val logger = Logger("AppStartReasonProvider")
+
+/**
+ * Provides the reason this [Application] instance was started: see [StartReason] for options
+ * and [reason] for details.
+ *
+ * This class relies on specific lifecycle method call orders and main thread Runnable scheduling
+ * that could potentially change between OEMs and OS versions: **be careful when using it.** This
+ * implementation was tested on the Moto G5 Android 8.1.0 and the Pixel 2 Android 11.
+ */
+class AppStartReasonProvider {
+
+    enum class StartReason {
+        /** We don't know yet what caused this [Application] instance to be started. */
+        TO_BE_DETERMINED,
+
+        /** This [Application] instance was started due to an Activity trying to start. */
+        ACTIVITY,
+
+        /**
+         * This [Application] instance was started due to a component that is not an Activity:
+         * this may include Services, BroadcastReceivers, and ContentProviders. It may be possible
+         * to distinguish between these but it hasn't been necessary to do so yet.
+         */
+        NON_ACTIVITY,
+    }
+
+    /**
+     * The reason this [Application] instance was started. This will not be set immediately
+     * but is expected to be available by the time the first frame is drawn for the foreground Activity.
+     */
+    var reason = StartReason.TO_BE_DETERMINED
+        private set
+
+    /**
+     * Registers the handlers needed by this class: this is expected to be called from
+     * [Application.onCreate].
+     */
+    fun registerInAppOnCreate(application: Application) {
+        ProcessLifecycleOwner.get().lifecycle.addObserver(ProcessLifecycleObserver())
+        application.registerActivityLifecycleCallbacks(ActivityLifecycleCallbacks())
+    }
+
+    private inner class ProcessLifecycleObserver : DefaultLifecycleObserver {
+        override fun onCreate(owner: LifecycleOwner) {
+            Handler(Looper.getMainLooper()).post {
+                // If the Application was started by an Activity, this Runnable should execute
+                // after we learn the Activity was created. If the App was started by a Service,
+                // this Runnable should execute before the first Activity is created.
+                reason = when (reason) {
+                    StartReason.TO_BE_DETERMINED -> StartReason.NON_ACTIVITY
+                    StartReason.ACTIVITY -> reason /* the start reason is already known: do nothing. */
+                    StartReason.NON_ACTIVITY -> {
+                        Metrics.startReasonProcessError.set(true)
+                        logger.error("AppStartReasonProvider.Process...onCreate unexpectedly called twice")
+                        reason
+                    }
+                }
+            }
+
+            owner.lifecycle.removeObserver(this) // we don't update the state further.
+        }
+    }
+
+    private inner class ActivityLifecycleCallbacks : DefaultActivityLifecycleCallbacks {
+        override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
+            // See ProcessLifecycleObserver.onCreate for details.
+            reason = when (reason) {
+                StartReason.TO_BE_DETERMINED -> StartReason.ACTIVITY
+                StartReason.NON_ACTIVITY -> reason /* the start reason is already known: do nothing. */
+                StartReason.ACTIVITY -> {
+                    Metrics.startReasonActivityError.set(true)
+                    logger.error("AppStartReasonProvider.Activity...onCreate unexpectedly called twice")
+                    reason
+                }
+            }
+
+            activity.application.unregisterActivityLifecycleCallbacks(this) // we don't update the state further.
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/telemetry/startuptelemetry/DefaultActivityLifecycleCallbacks.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/startuptelemetry/DefaultActivityLifecycleCallbacks.kt
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.telemetry.startuptelemetry
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+
+/**
+ * An inheritance of [Application.ActivityLifecycleCallbacks] where each method has a default
+ * implementation that does nothing. This allows classes that extend this interface to have
+ * more concise definitions if they don't implement some methods; this is in the spirit of
+ * other `Default*` classes, such as [androidx.lifecycle.DefaultLifecycleObserver].
+ */
+interface DefaultActivityLifecycleCallbacks : Application.ActivityLifecycleCallbacks {
+    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {}
+    override fun onActivityStarted(activity: Activity) {}
+    override fun onActivityResumed(activity: Activity) {}
+    override fun onActivityPaused(activity: Activity) {}
+    override fun onActivityStopped(activity: Activity) {}
+    override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) {}
+    override fun onActivityDestroyed(activity: Activity) {}
+}

--- a/app/src/main/java/org/mozilla/focus/telemetry/startuptelemetry/StartupActivityLog.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/startuptelemetry/StartupActivityLog.kt
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.telemetry.startuptelemetry
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.NONE
+import androidx.annotation.VisibleForTesting.PRIVATE
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import mozilla.components.support.base.log.Log
+import mozilla.components.support.base.log.logger.Logger
+
+private val logger = Logger("StartupActivityLog")
+
+/**
+ * A record of the [Activity] created, started, and stopped events as well as [Application]
+ * foreground and background events. See [log] for the log. This class is expected to be
+ * registered in [Application.onCreate] by calling [registerInAppOnCreate].
+ *
+ * To prevent this list from growing infinitely, we clear the list when the application is stopped.
+ * This is acceptable from the current requirements: we never need to inspect more than the current
+ * start up.
+ */
+class StartupActivityLog {
+
+    private val _log = mutableListOf<LogEntry>()
+    val log: List<LogEntry> = _log
+
+    fun registerInAppOnCreate(
+        application: Application,
+        processLifecycleOwner: LifecycleOwner = ProcessLifecycleOwner.get()
+    ) {
+        processLifecycleOwner.lifecycle.addObserver(StartupLogAppLifecycleObserver())
+        application.registerActivityLifecycleCallbacks(StartupLogActivityLifecycleCallbacks())
+    }
+
+    @VisibleForTesting(otherwise = NONE)
+    fun getObserversForTesting() = Pair(StartupLogAppLifecycleObserver(), StartupLogActivityLifecycleCallbacks())
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    fun logEntries(loggerArg: Logger = logger, logLevel: Log.Priority = Log.logLevel) {
+        // Optimization: we want to avoid the potentially expensive conversions
+        // to Strings if we're not going to log anyway.
+        if (logLevel > Log.Priority.DEBUG) {
+            return
+        }
+
+        val transformedEntries = log.map {
+            when (it) {
+                is LogEntry.AppStarted -> "App-STARTED"
+                is LogEntry.AppStopped -> "App-STOPPED"
+                is LogEntry.ActivityCreated -> "${it.activityClass.simpleName}-CREATED"
+                is LogEntry.ActivityStarted -> "${it.activityClass.simpleName}-STARTED"
+                is LogEntry.ActivityStopped -> "${it.activityClass.simpleName}-STOPPED"
+            }
+        }
+
+        loggerArg.debug(transformedEntries.toString())
+    }
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    inner class StartupLogAppLifecycleObserver : DefaultLifecycleObserver {
+        override fun onStart(owner: LifecycleOwner) {
+            _log.add(LogEntry.AppStarted)
+        }
+
+        override fun onStop(owner: LifecycleOwner) {
+            logEntries()
+            _log.clear() // Optimization: see class kdoc for details.
+            _log.add(LogEntry.AppStopped)
+        }
+    }
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    inner class StartupLogActivityLifecycleCallbacks : DefaultActivityLifecycleCallbacks {
+        override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
+            _log.add(LogEntry.ActivityCreated(activity::class.java))
+        }
+
+        override fun onActivityStarted(activity: Activity) {
+            _log.add(LogEntry.ActivityStarted(activity::class.java))
+        }
+
+        override fun onActivityStopped(activity: Activity) {
+            _log.add(LogEntry.ActivityStopped(activity::class.java))
+        }
+    }
+
+    /**
+     * A log entry with its detailed information for the [StartupActivityLog].
+     */
+    sealed class LogEntry {
+        object AppStarted : LogEntry()
+        object AppStopped : LogEntry()
+
+        data class ActivityCreated(val activityClass: Class<out Activity>) : LogEntry()
+        data class ActivityStarted(val activityClass: Class<out Activity>) : LogEntry()
+        data class ActivityStopped(val activityClass: Class<out Activity>) : LogEntry()
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/telemetry/startuptelemetry/StartupPathProvider.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/startuptelemetry/StartupPathProvider.kt
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.telemetry.startuptelemetry
+
+import android.app.Activity
+import android.content.Intent
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.NONE
+import androidx.annotation.VisibleForTesting.PRIVATE
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+
+/**
+ * This should be a member variable of [Activity] because its data is tied to the lifecycle of an
+ * Activity. Call [attachOnActivityOnCreate] & [onIntentReceived] for this class to work correctly.
+ */
+class StartupPathProvider {
+
+    enum class StartupPath {
+        MAIN,
+        VIEW,
+
+        /**
+         * The start up path if we received an Intent but we're unable to categorize it into other buckets.
+         */
+        UNKNOWN,
+
+        /**
+         * The start up path has not been set. This state includes:
+         * - this API is accessed before it is set
+         * - if no intent is received before the activity is STARTED (e.g. app switcher)
+         */
+        NOT_SET
+    }
+
+    /**
+     * Returns the [StartupPath] for the currently started activity. This value will be set
+     * after an [Intent] is received that causes this activity to move into the STARTED state.
+     */
+    var startupPathForActivity = StartupPath.NOT_SET
+        private set
+
+    private var wasResumedSinceStartedState = false
+
+    fun attachOnActivityOnCreate(lifecycle: Lifecycle, intent: Intent?) {
+        lifecycle.addObserver(StartupPathLifecycleObserver())
+        onIntentReceived(intent)
+    }
+
+    // N.B.: this method duplicates the actual logic for determining what page to open.
+    // Unfortunately, it's difficult to re-use that logic because it occurs in many places throughout
+    // the code so we do the simple thing for now and duplicate it. It's noticeably different from
+    // what you might expect: e.g. ACTION_MAIN can open a URL and if ACTION_VIEW provides an invalid
+    // URL, it'll perform a MAIN action. However, it's fairly representative of what users *intended*
+    // to do when opening the app and shouldn't change much because it's based on Android system-wide
+    // conventions, so it's probably fine for our purposes.
+    private fun getStartupPathFromIntent(intent: Intent): StartupPath = when (intent.action) {
+        Intent.ACTION_MAIN -> StartupPath.MAIN
+        Intent.ACTION_VIEW -> StartupPath.VIEW
+        else -> StartupPath.UNKNOWN
+    }
+
+    /**
+     * Expected to be called when a new [Intent] is received by the [Activity]: i.e.
+     * [Activity.onCreate] and [Activity.onNewIntent].
+     */
+    fun onIntentReceived(intent: Intent?) {
+        // We want to set a path only if the intent causes the Activity to move into the STARTED state.
+        // This means we want to discard any intents that are received when the app is foregrounded.
+        // However, we can't use the Lifecycle.currentState to determine this because:
+        // - the app is briefly paused (state becomes STARTED) before receiving the Intent in
+        // the foreground so we can't say <= STARTED
+        // - onIntentReceived can be called from the CREATED or STARTED state so we can't say == CREATED
+        // So we're forced to track this state ourselves.
+        if (!wasResumedSinceStartedState && intent != null) {
+            startupPathForActivity = getStartupPathFromIntent(intent)
+        }
+    }
+
+    @VisibleForTesting(otherwise = NONE)
+    fun getTestCallbacks() = StartupPathLifecycleObserver()
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    inner class StartupPathLifecycleObserver : DefaultLifecycleObserver {
+        override fun onResume(owner: LifecycleOwner) {
+            wasResumedSinceStartedState = true
+        }
+
+        override fun onStop(owner: LifecycleOwner) {
+            // Clear existing state.
+            startupPathForActivity = StartupPath.NOT_SET
+            wasResumedSinceStartedState = false
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/telemetry/startuptelemetry/StartupStateProvider.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/startuptelemetry/StartupStateProvider.kt
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.telemetry.startuptelemetry
+
+import android.app.Activity
+import org.mozilla.focus.telemetry.startuptelemetry.AppStartReasonProvider.StartReason
+import org.mozilla.focus.telemetry.startuptelemetry.StartupActivityLog.LogEntry
+
+/**
+ * Identifies the "state" of start up where state can be COLD/WARM/HOT and possibly others.
+ *
+ * This class is nuanced: **please read the kdoc carefully before using it.** Consider contacting
+ * the perf team with your use case.
+ *
+ * For this class, we use the terminology from the [StartupActivityLog] such as STARTED and STOPPED.
+ * However, we're assuming STARTED means foregrounded and STOPPED means backgrounded. If this
+ * assumption is false, the logic in this class may be incorrect.
+ */
+class StartupStateProvider(
+    private val startupLog: StartupActivityLog,
+    private val startReasonProvider: AppStartReasonProvider
+) {
+
+    enum class StartupState {
+        COLD, WARM, HOT,
+
+        /**
+         * A start up state where we weren't able to bucket it into the other categories.
+         * This includes, but is not limited to:
+         * - if the activity this is called from is not currently started
+         * - if the currently started activity is not the first started activity
+         */
+        UNKNOWN;
+    }
+
+    /**
+     * Returns the [StartupState] for the currently started activity. Note: the state will be
+     * [StartupState.UNKNOWN] if the currently started activity is not the first started activity.
+     *
+     * This method must be called after the foreground Activity is STARTED.
+     */
+    fun getStartupStateForStartedActivity(activityClass: Class<out Activity>): StartupState = when {
+        isColdStartForStartedActivity(activityClass) -> StartupState.COLD
+        isWarmStartForStartedActivity(activityClass) -> StartupState.WARM
+        isHotStartForStartedActivity(activityClass) -> StartupState.HOT
+        else -> StartupState.UNKNOWN
+    }
+
+    /**
+     * Returns true if the current startup state is COLD and the currently started activity is the
+     * first started activity (i.e. we can use it for performance measurements).
+     *
+     * This method must be called after the foreground Activity is STARTED.
+     */
+    fun isColdStartForStartedActivity(activityClass: Class<out Activity>): Boolean {
+        // A cold start means:
+        // - the process was started for the first started activity (e.g. not a service)
+        // - the first started activity ever is still active
+        //
+        // Thus, for the activity log we expect:
+        //   [... Activity-STARTED, App-STARTED]
+        // since if another Activity was started, it would appear after App-STARTED. This is where:
+        // - the app has not been stopped ever
+        if (startReasonProvider.reason != StartReason.ACTIVITY) {
+            return false
+        }
+
+        val isLastStartedActivityStillStarted = startupLog.log.takeLast(2) == listOf(
+            LogEntry.ActivityStarted(activityClass),
+            LogEntry.AppStarted
+        )
+        return !startupLog.log.contains(LogEntry.AppStopped) && isLastStartedActivityStillStarted
+    }
+
+    /**
+     * Returns true if the current startup state is WARM and the currently started activity is the
+     * first started activity for this start up (i.e. we can use it for performance measurements).
+     *
+     * This method must be called after the foreground activity is STARTED.
+     */
+    fun isWarmStartForStartedActivity(activityClass: Class<out Activity>): Boolean {
+        // A warm start means:
+        // - the app was backgrounded and has since been started
+        // - the first started activity since the app was started is still active.
+        // - that activity was created before being started
+        //
+        // For the activity log, we expect:
+        //   [... App-STOPPED, ... Activity-CREATED, Activity-STARTED, App-STARTED]
+        // where:
+        // - App-STOPPED is the last STOPPED seen
+        // - we're assuming App-STARTED will only be last if one activity is started (as observed)
+        if (!startupLog.log.contains(LogEntry.AppStopped)) {
+            return false // if the app hasn't been stopped, it's not a warm start.
+        }
+        val afterLastStopped = startupLog.log.takeLastWhile { it != LogEntry.AppStopped }
+
+        @Suppress("MagicNumber")
+        return afterLastStopped.takeLast(3) == listOf(
+            LogEntry.ActivityCreated(activityClass),
+            LogEntry.ActivityStarted(activityClass),
+            LogEntry.AppStarted
+        )
+    }
+
+    /**
+     * Returns true if the current startup state is HOT and the currently started activity is the
+     * first started activity for this start up (i.e. we can use it for performance measurements).
+     *
+     * This method must be called after the foreground activity is STARTED.
+     */
+    fun isHotStartForStartedActivity(activityClass: Class<out Activity>): Boolean {
+        // A hot start means:
+        // - the app was backgrounded and has since been started
+        // - the first started activity since the app was started is still active.
+        // - that activity was not created before being started
+        //
+        // For the activity log, we expect:
+        //   [... App-STOPPED, ... Activity-STARTED, App-STARTED]
+        // where:
+        // - App-STOPPED is the last STOPPED seen
+        // - App-CREATED is NOT called for this activity
+        // - we're assuming App-STARTED will only be last if one activity is started (as observed)
+        if (!startupLog.log.contains(LogEntry.AppStopped)) {
+            return false // if the app hasn't been stopped, it's not a hot start.
+        }
+        val afterLastStopped = startupLog.log.takeLastWhile { it != LogEntry.AppStopped }
+
+        val isLastActivityStartedStillStarted = afterLastStopped.takeLast(2) == listOf(
+            LogEntry.ActivityStarted(activityClass),
+            LogEntry.AppStarted
+        )
+        return !afterLastStopped.contains(LogEntry.ActivityCreated(activityClass)) &&
+            isLastActivityStartedStillStarted
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/telemetry/startuptelemetry/StartupTypeTelemetry.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/startuptelemetry/StartupTypeTelemetry.kt
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.telemetry.startuptelemetry
+
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.NONE
+import androidx.annotation.VisibleForTesting.PRIVATE
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import mozilla.components.support.base.log.logger.Logger
+import org.mozilla.focus.GleanMetrics.PerfStartup
+import org.mozilla.focus.activity.MainActivity
+import org.mozilla.focus.telemetry.startuptelemetry.StartupPathProvider.StartupPath
+import org.mozilla.focus.telemetry.startuptelemetry.StartupStateProvider.StartupState
+
+private val activityClass = MainActivity::class.java
+
+private val logger = Logger("StartupTypeTelemetry")
+
+/**
+ * Records telemetry for the number of start ups. See the
+ * [Fenix perf glossary](https://wiki.mozilla.org/index.php?title=Performance/Fenix/Glossary)
+ * for specific definitions.
+ *
+ * This should be a member variable of [MainActivity] because its data is tied to the lifecycle of an
+ * Activity. Call [attachOnMainActivityOnCreate] for this class to work correctly.
+ *
+ * N.B.: this class is lightly hardcoded to MainActivity.
+ */
+class StartupTypeTelemetry(
+    private val startupStateProvider: StartupStateProvider,
+    private val startupPathProvider: StartupPathProvider
+) {
+
+    fun attachOnMainActivityOnCreate(lifecycle: Lifecycle) {
+        lifecycle.addObserver(StartupTypeLifecycleObserver())
+    }
+
+    private fun getTelemetryLabel(startupState: StartupState, startupPath: StartupPath): String {
+        // We don't use the enum name directly to avoid unintentional changes when refactoring.
+        val stateLabel = when (startupState) {
+            StartupState.COLD -> "cold"
+            StartupState.WARM -> "warm"
+            StartupState.HOT -> "hot"
+            StartupState.UNKNOWN -> "unknown"
+        }
+
+        val pathLabel = when (startupPath) {
+            StartupPath.MAIN -> "main"
+            StartupPath.VIEW -> "view"
+
+            // To avoid combinatorial explosion in label names, we bucket NOT_SET into UNKNOWN.
+            StartupPath.NOT_SET,
+            StartupPath.UNKNOWN -> "unknown"
+        }
+
+        return "${stateLabel}_$pathLabel"
+    }
+
+    @VisibleForTesting(otherwise = NONE)
+    fun getTestCallbacks() = StartupTypeLifecycleObserver()
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    fun record() {
+        val startupState = startupStateProvider.getStartupStateForStartedActivity(activityClass)
+        val startupPath = startupPathProvider.startupPathForActivity
+        val label = getTelemetryLabel(startupState, startupPath)
+
+        PerfStartup.startupType[label].add(1)
+        logger.info("Recorded start up: $label")
+    }
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    inner class StartupTypeLifecycleObserver : DefaultLifecycleObserver {
+        private var shouldRecordStart = false
+
+        override fun onStart(owner: LifecycleOwner) {
+            shouldRecordStart = true
+        }
+
+        override fun onResume(owner: LifecycleOwner) {
+            // We must record in onResume because the StartupStateProvider can only be called for
+            // STARTED activities and we can't guarantee our onStart is called before its.
+            //
+            // We only record if start was called for this resume to avoid recording
+            // for onPause -> onResume states.
+            if (shouldRecordStart) {
+                record()
+                shouldRecordStart = false
+            }
+        }
+    }
+}

--- a/app/src/test/java/org/mozilla/focus/telemetry/StartupActivityLogTest.kt
+++ b/app/src/test/java/org/mozilla/focus/telemetry/StartupActivityLogTest.kt
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.telemetry
+
+import android.app.Activity
+import android.app.Application
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mozilla.focus.telemetry.startuptelemetry.StartupActivityLog
+import org.mozilla.focus.telemetry.startuptelemetry.StartupActivityLog.LogEntry
+
+class StartupActivityLogTest {
+
+    private lateinit var log: StartupActivityLog
+    private lateinit var appObserver: StartupActivityLog.StartupLogAppLifecycleObserver
+    private lateinit var activityCallbacks: StartupActivityLog.StartupLogActivityLifecycleCallbacks
+
+    @Before
+    fun setUp() {
+        log = StartupActivityLog()
+        val (appObserver, activityCallbacks) = log.getObserversForTesting()
+        this.appObserver = appObserver
+        this.activityCallbacks = activityCallbacks
+    }
+
+    @Test
+    fun `WHEN register is called THEN it is registered`() {
+        val app: Application = mock()
+        val lifecycleOwner: LifecycleOwner = mock()
+        val mLifecycle: Lifecycle = mock()
+        `when`(lifecycleOwner.lifecycle).thenReturn(mLifecycle)
+
+        log.registerInAppOnCreate(app, lifecycleOwner)
+
+        verify(app).registerActivityLifecycleCallbacks(any())
+    }
+
+    @Test // we test start and stop individually due to the clear-on-stop behavior.
+    fun `WHEN app observer start is called THEN it is added directly to the log`() {
+        assertTrue(log.log.isEmpty())
+
+        appObserver.onStart(mock())
+        assertEquals(listOf(LogEntry.AppStarted), log.log)
+
+        appObserver.onStart(mock())
+        assertEquals(listOf(LogEntry.AppStarted, LogEntry.AppStarted), log.log)
+    }
+
+    @Test // we test start and stop individually due to the clear-on-stop behavior.
+    fun `WHEN app observer stop is called THEN it is added directly to the log`() {
+        assertTrue(log.log.isEmpty())
+
+        appObserver.onStop(mock())
+        assertEquals(listOf(LogEntry.AppStopped), log.log)
+    }
+
+    @Test
+    fun `WHEN activity callback methods are called THEN they are added directly to the log`() {
+        assertTrue(log.log.isEmpty())
+        val expected = mutableListOf<LogEntry>()
+
+        val activityClass = mock<Activity>()::class.java // mockk can't mock Class<...>
+
+        activityCallbacks.onActivityCreated(mock(), null)
+        expected.add(LogEntry.ActivityCreated(activityClass))
+        assertEquals(expected, log.log)
+
+        activityCallbacks.onActivityStarted(mock())
+        expected.add(LogEntry.ActivityStarted(activityClass))
+        assertEquals(expected, log.log)
+
+        activityCallbacks.onActivityStopped(mock())
+        expected.add(LogEntry.ActivityStopped(activityClass))
+        assertEquals(expected, log.log)
+    }
+
+    @Test
+    fun `WHEN app STOPPED is called THEN the log is emptied expect for the stop event`() {
+        assertTrue(log.log.isEmpty())
+
+        activityCallbacks.onActivityCreated(mock(), null)
+        activityCallbacks.onActivityStarted(mock())
+        appObserver.onStart(mock())
+        assertEquals(3, log.log.size)
+
+        appObserver.onStop(mock())
+        assertEquals(listOf(LogEntry.AppStopped), log.log)
+    }
+}

--- a/app/src/test/java/org/mozilla/focus/telemetry/StartupPathProviderTest.kt
+++ b/app/src/test/java/org/mozilla/focus/telemetry/StartupPathProviderTest.kt
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.telemetry
+
+import android.content.Intent
+import androidx.lifecycle.Lifecycle
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.mozilla.focus.telemetry.startuptelemetry.StartupPathProvider
+import org.mozilla.focus.telemetry.startuptelemetry.StartupPathProvider.StartupPath
+
+class StartupPathProviderTest {
+
+    private lateinit var provider: StartupPathProvider
+    private lateinit var callbacks: StartupPathProvider.StartupPathLifecycleObserver
+
+    private val intent: Intent = mock()
+
+    @Before
+    fun setUp() {
+        provider = StartupPathProvider()
+        callbacks = provider.getTestCallbacks()
+    }
+
+    @Test
+    fun `WHEN attach is called THEN the provider is registered to the lifecycle`() {
+        val lifecycle = mock<Lifecycle>()
+        provider.attachOnActivityOnCreate(lifecycle, null)
+
+        verify(lifecycle).addObserver(any())
+    }
+
+    @Test
+    fun `WHEN calling attach THEN the intent is passed to on intent received`() {
+        // With this test, we're basically saying, "attach..." does the same thing as
+        // "onIntentReceived" so we don't need to duplicate all the tests we run for
+        // "onIntentReceived".
+        val spyProvider = spy(provider)
+        spyProvider.attachOnActivityOnCreate(mock(), intent)
+
+        verify(spyProvider).onIntentReceived(intent)
+    }
+
+    @Test
+    fun `GIVEN no intent is received and the activity is not started WHEN getting the start up path THEN it is not set`() {
+        assertEquals(StartupPath.NOT_SET, provider.startupPathForActivity)
+    }
+
+    @Test
+    fun `GIVEN a main intent is received but the activity is not started yet WHEN getting the start up path THEN main is returned`() {
+        doReturn(Intent.ACTION_MAIN).`when`(intent).action
+        provider.onIntentReceived(intent)
+        assertEquals(StartupPath.MAIN, provider.startupPathForActivity)
+    }
+
+    @Test
+    fun `GIVEN a main intent is received and the app is started WHEN getting the start up path THEN it is main`() {
+        doReturn(Intent.ACTION_MAIN).`when`(intent).action
+        callbacks.onCreate(mock())
+        provider.onIntentReceived(intent)
+        callbacks.onStart(mock())
+
+        assertEquals(StartupPath.MAIN, provider.startupPathForActivity)
+    }
+
+    @Test
+    fun `GIVEN the app is launched from the homeScreen WHEN getting the start up path THEN it is main`() {
+        // There's technically more to a homeScreen Intent but it's fine for now.
+        doReturn(Intent.ACTION_MAIN).`when`(intent).action
+        launchApp(intent)
+        assertEquals(StartupPath.MAIN, provider.startupPathForActivity)
+    }
+
+    @Test
+    fun `GIVEN the app is launched by app link WHEN getting the start up path THEN it is view`() {
+        // There's technically more to a homeScreen Intent but it's fine for now.
+        doReturn(Intent.ACTION_VIEW).`when`(intent).action
+
+        launchApp(intent)
+
+        assertEquals(StartupPath.VIEW, provider.startupPathForActivity)
+    }
+
+    @Test
+    fun `GIVEN the app is launched by a send action WHEN getting the start up path THEN it is unknown`() {
+        doReturn(Intent.ACTION_SEND).`when`(intent).action
+
+        launchApp(intent)
+
+        assertEquals(StartupPath.UNKNOWN, provider.startupPathForActivity)
+    }
+
+    @Test
+    fun `GIVEN the app is launched by a null intent (is this possible) WHEN getting the start up path THEN it is not set`() {
+        callbacks.onCreate(mock())
+        provider.onIntentReceived(null)
+        callbacks.onStart(mock())
+        callbacks.onResume(mock())
+
+        assertEquals(StartupPath.NOT_SET, provider.startupPathForActivity)
+    }
+
+    @Test
+    fun `GIVEN the app is launched to the homeScreen and stopped WHEN getting the start up path THEN it is not set`() {
+        doReturn(Intent.ACTION_MAIN).`when`(intent).action
+
+        launchApp(intent)
+        stopLaunchedApp()
+
+        assertEquals(StartupPath.NOT_SET, provider.startupPathForActivity)
+    }
+
+    @Test
+    fun `GIVEN the app is launched to the homeScreen, stopped, and relaunched warm from app link WHEN getting the start up path THEN it is view`() {
+        doReturn(Intent.ACTION_MAIN).`when`(intent).action
+
+        launchApp(intent)
+        stopLaunchedApp()
+
+        doReturn(Intent.ACTION_VIEW).`when`(intent).action
+
+        startStoppedApp(intent)
+
+        assertEquals(StartupPath.VIEW, provider.startupPathForActivity)
+    }
+
+    @Test
+    fun `GIVEN the app is launched to the homeScreen, stopped, and relaunched warm from the app switcher WHEN getting the start up path THEN it is not set`() {
+        doReturn(Intent.ACTION_MAIN).`when`(intent).action
+
+        launchApp(intent)
+        stopLaunchedApp()
+        startStoppedAppFromAppSwitcher()
+
+        assertEquals(StartupPath.NOT_SET, provider.startupPathForActivity)
+    }
+
+    @Test
+    fun `GIVEN the app is launched to the homeScreen, paused, and resumed WHEN getting the start up path THEN it returns the initial intent value`() {
+        doReturn(Intent.ACTION_MAIN).`when`(intent).action
+
+        launchApp(intent)
+        callbacks.onPause(mock())
+        callbacks.onResume(mock())
+
+        assertEquals(StartupPath.MAIN, provider.startupPathForActivity)
+    }
+
+    @Test
+    fun `GIVEN the app is launched with an intent and receives an intent while the activity is foregrounded WHEN getting the start up path THEN it returns the initial intent value`() {
+        doReturn(Intent.ACTION_MAIN).`when`(intent).action
+
+        launchApp(intent)
+        doReturn(Intent.ACTION_VIEW).`when`(intent).action
+
+        receiveIntentInForeground(intent)
+
+        assertEquals(StartupPath.MAIN, provider.startupPathForActivity)
+    }
+
+    @Test
+    fun `GIVEN the app is launched, stopped, started from the app switcher and receives an intent in the foreground WHEN getting the start up path THEN it returns not set`() {
+        doReturn(Intent.ACTION_MAIN).`when`(intent).action
+
+        launchApp(intent)
+        stopLaunchedApp()
+        startStoppedAppFromAppSwitcher()
+        doReturn(Intent.ACTION_VIEW).`when`(intent).action
+
+        receiveIntentInForeground(intent)
+
+        assertEquals(StartupPath.NOT_SET, provider.startupPathForActivity)
+    }
+
+    private fun launchApp(intent: Intent) {
+        callbacks.onCreate(mock())
+        provider.onIntentReceived(intent)
+        callbacks.onStart(mock())
+        callbacks.onResume(mock())
+    }
+
+    private fun stopLaunchedApp() {
+        callbacks.onPause(mock())
+        callbacks.onStop(mock())
+    }
+
+    private fun startStoppedApp(intent: Intent) {
+        callbacks.onStart(mock())
+        provider.onIntentReceived(intent)
+        callbacks.onResume(mock())
+    }
+
+    private fun startStoppedAppFromAppSwitcher() {
+        // What makes the app switcher case special is it starts the app without an intent.
+        callbacks.onStart(mock())
+        callbacks.onResume(mock())
+    }
+
+    private fun receiveIntentInForeground(intent: Intent) {
+        // To my surprise, the app is paused before receiving an intent on Pixel 2.
+        callbacks.onPause(mock())
+        provider.onIntentReceived(intent)
+        callbacks.onResume(mock())
+    }
+}

--- a/app/src/test/java/org/mozilla/focus/telemetry/StartupStateProviderTest.kt
+++ b/app/src/test/java/org/mozilla/focus/telemetry/StartupStateProviderTest.kt
@@ -1,0 +1,418 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.telemetry
+
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.mozilla.focus.activity.IntentReceiverActivity
+import org.mozilla.focus.activity.MainActivity
+import org.mozilla.focus.telemetry.startuptelemetry.AppStartReasonProvider
+import org.mozilla.focus.telemetry.startuptelemetry.AppStartReasonProvider.StartReason
+import org.mozilla.focus.telemetry.startuptelemetry.StartupActivityLog
+import org.mozilla.focus.telemetry.startuptelemetry.StartupActivityLog.LogEntry
+import org.mozilla.focus.telemetry.startuptelemetry.StartupStateProvider
+import org.mozilla.focus.telemetry.startuptelemetry.StartupStateProvider.StartupState
+
+class StartupStateProviderTest {
+
+    private lateinit var provider: StartupStateProvider
+    private var startupActivityLog: StartupActivityLog = mock()
+    private var startReasonProvider: AppStartReasonProvider = mock()
+
+    private lateinit var logEntries: MutableList<LogEntry>
+
+    private val mainActivityClass = MainActivity::class.java
+    private val irActivityClass = IntentReceiverActivity::class.java
+
+    @Before
+    fun setUp() {
+
+        provider = StartupStateProvider(startupActivityLog, startReasonProvider)
+
+        logEntries = mutableListOf()
+        Mockito.doReturn(logEntries).`when`(startupActivityLog).log
+        Mockito.doReturn(logEntries).`when`(startupActivityLog).log
+        Mockito.doReturn(StartReason.ACTIVITY).`when`(startReasonProvider).reason
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN is cold start THEN cold start is true`() {
+        forEachColdStartEntries { index ->
+            assertTrue("$index", provider.isColdStartForStartedActivity(mainActivityClass))
+        }
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN warm start THEN cold start is false`() {
+        forEachWarmStartEntries { index ->
+            assertFalse("$index", provider.isColdStartForStartedActivity(mainActivityClass))
+        }
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN hot start THEN cold start is false`() {
+        forEachHotStartEntries { index ->
+            assertFalse("$index", provider.isColdStartForStartedActivity(mainActivityClass))
+        }
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN is cold start THEN warm start is false`() {
+        forEachColdStartEntries { index ->
+            assertFalse("$index", provider.isWarmStartForStartedActivity(mainActivityClass))
+        }
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN is warm start THEN warm start is true`() {
+        forEachWarmStartEntries { index ->
+            assertTrue("$index", provider.isWarmStartForStartedActivity(mainActivityClass))
+        }
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN is hot start THEN warm start is false`() {
+        forEachHotStartEntries { index ->
+            assertFalse("$index", provider.isWarmStartForStartedActivity(mainActivityClass))
+        }
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN is cold start THEN hot start is false`() {
+        forEachColdStartEntries { index ->
+            assertFalse("$index", provider.isHotStartForStartedActivity(mainActivityClass))
+        }
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN is warm start THEN hot start is false`() {
+        forEachWarmStartEntries { index ->
+            assertFalse("$index", provider.isHotStartForStartedActivity(mainActivityClass))
+        }
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN is hot start THEN hot start is true`() {
+        forEachHotStartEntries { index ->
+            assertTrue("$index", provider.isHotStartForStartedActivity(mainActivityClass))
+        }
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN we launched HA through a drawing IntentRA THEN start up is not cold`() {
+        // These entries mimic observed behavior for local code changes.
+        logEntries.addAll(
+            listOf(
+                LogEntry.ActivityCreated(irActivityClass),
+                LogEntry.ActivityStarted(irActivityClass),
+                LogEntry.AppStarted,
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.ActivityStopped(irActivityClass)
+            )
+        )
+        assertFalse(provider.isColdStartForStartedActivity(mainActivityClass))
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN we launched HA through a drawing IntentRA THEN start up is not warm`() {
+        // These entries mimic observed behavior for local code changes.
+        logEntries.addAll(
+            listOf(
+                LogEntry.AppStopped,
+                LogEntry.ActivityStopped(mainActivityClass),
+                LogEntry.ActivityCreated(irActivityClass),
+                LogEntry.ActivityStarted(irActivityClass),
+                LogEntry.AppStarted,
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.ActivityStopped(irActivityClass)
+            )
+        )
+        assertFalse(provider.isWarmStartForStartedActivity(mainActivityClass))
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN we launched HA through a drawing IntentRA THEN start up is not hot`() {
+        // These entries mimic observed behavior for local code changes.
+        logEntries.addAll(
+            listOf(
+                LogEntry.AppStopped,
+                LogEntry.ActivityStopped(mainActivityClass),
+                LogEntry.ActivityCreated(irActivityClass),
+                LogEntry.ActivityStarted(irActivityClass),
+                LogEntry.AppStarted,
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.ActivityStopped(irActivityClass)
+            )
+        )
+        assertFalse(provider.isHotStartForStartedActivity(mainActivityClass))
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN two MainActivities are created THEN start up is not cold`() {
+        // We're making an assumption about how this would work based on previous observed patterns.
+        // AIUI, we should never have more than one MainActivity.
+        logEntries.addAll(
+            listOf(
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted,
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.ActivityStopped(mainActivityClass)
+            )
+        )
+        assertFalse(provider.isColdStartForStartedActivity(mainActivityClass))
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN an activity hasn't been created yet THEN start up is not cold`() {
+        assertFalse(provider.isColdStartForStartedActivity(mainActivityClass))
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN an activity hasn't started yet THEN start up is not cold`() {
+        logEntries.addAll(
+            listOf(
+                LogEntry.ActivityCreated(mainActivityClass)
+            )
+        )
+        assertFalse(provider.isColdStartForStartedActivity(mainActivityClass))
+    }
+
+    @Test
+    fun `GIVEN the app did not start for an activity WHEN is cold is checked THEN it returns false`() {
+        Mockito.doReturn(StartReason.NON_ACTIVITY).`when`(startReasonProvider).reason
+        assertFalse(provider.isColdStartForStartedActivity(mainActivityClass))
+
+        forEachColdStartEntries { index ->
+            assertFalse("$index", provider.isColdStartForStartedActivity(mainActivityClass))
+        }
+    }
+
+    @Test
+    fun `GIVEN the app has not been stopped WHEN an activity has not been created THEN it's not a warm start`() {
+        assertFalse(provider.isWarmStartForStartedActivity(mainActivityClass))
+    }
+
+    @Test
+    fun `GIVEN the app has been stopped WHEN an activity has not been created THEN it's not a warm start`() {
+        logEntries.add(LogEntry.AppStopped)
+        assertFalse(provider.isWarmStartForStartedActivity(mainActivityClass))
+    }
+
+    @Test
+    fun `GIVEN the app has been stopped WHEN an activity has not been started THEN it's not a warm start`() {
+        logEntries.addAll(
+            listOf(
+                LogEntry.AppStopped,
+                LogEntry.ActivityCreated(mainActivityClass)
+            )
+        )
+        assertFalse(provider.isWarmStartForStartedActivity(mainActivityClass))
+    }
+
+    @Test
+    fun `GIVEN the app has not been stopped WHEN an activity has not been created THEN it's not a hot start`() {
+        assertFalse(provider.isHotStartForStartedActivity(mainActivityClass))
+    }
+
+    @Test
+    fun `GIVEN the app has been stopped WHEN an activity has not been created THEN it's not a hot start`() {
+        logEntries.add(LogEntry.AppStopped)
+        assertFalse(provider.isHotStartForStartedActivity(mainActivityClass))
+    }
+
+    @Test
+    fun `GIVEN the app has been stopped WHEN an activity has not been started THEN it's not a hot start`() {
+        logEntries.addAll(
+            listOf(
+                LogEntry.AppStopped,
+                LogEntry.ActivityCreated(mainActivityClass)
+            )
+        )
+        assertFalse(provider.isHotStartForStartedActivity(mainActivityClass))
+    }
+
+    @Test
+    fun `GIVEN the app started for an activity WHEN it is a cold start THEN get startup state is cold`() {
+        forEachColdStartEntries { index ->
+            assertEquals("$index", StartupState.COLD, provider.getStartupStateForStartedActivity(mainActivityClass))
+        }
+    }
+
+    @Test
+    fun `WHEN it is a warm start THEN get startup state is warm`() {
+        forEachWarmStartEntries { index ->
+            assertEquals("$index", StartupState.WARM, provider.getStartupStateForStartedActivity(mainActivityClass))
+        }
+    }
+
+    @Test
+    fun `WHEN it is a hot start THEN get startup state is hot`() {
+        forEachHotStartEntries { index ->
+            assertEquals("$index", StartupState.HOT, provider.getStartupStateForStartedActivity(mainActivityClass))
+        }
+    }
+
+    @Test
+    fun `WHEN two activities are started THEN get startup state is unknown`() {
+        logEntries.addAll(
+            listOf(
+                LogEntry.ActivityCreated(irActivityClass),
+                LogEntry.ActivityStarted(irActivityClass),
+                LogEntry.AppStarted,
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.ActivityStopped(irActivityClass)
+            )
+        )
+
+        assertEquals(StartupState.UNKNOWN, provider.getStartupStateForStartedActivity(mainActivityClass))
+    }
+
+    private fun forEachColdStartEntries(block: (index: Int) -> Unit) {
+        // These entries mimic observed behavior.
+        //
+        // MAIN: open HomeActivity directly.
+        val coldStartEntries = listOf(
+            listOf(
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted
+
+                // VIEW: open non-drawing IntentReceiverActivity, then HomeActivity.
+            ),
+            listOf(
+                LogEntry.ActivityCreated(irActivityClass),
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted
+            )
+        )
+
+        forEachStartEntry(coldStartEntries, block)
+    }
+
+    private fun forEachWarmStartEntries(block: (index: Int) -> Unit) {
+        // These entries mimic observed behavior. We test both truncated (i.e. the current behavior
+        // with the optimization to prevent an infinite log) and untruncated (the behavior without
+        // such an optimization).
+        //
+        // truncated MAIN: open HomeActivity directly.
+        val warmStartEntries = listOf(
+            listOf(
+                LogEntry.AppStopped,
+                LogEntry.ActivityStopped(mainActivityClass),
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted
+
+                // untruncated MAIN: open MainActivity directly.
+            ),
+            listOf(
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted,
+                LogEntry.AppStopped,
+                LogEntry.ActivityStopped(mainActivityClass),
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted
+
+                // truncated VIEW: open non-drawing IntentReceiverActivity, then MainActivity.
+            ),
+            listOf(
+                LogEntry.AppStopped,
+                LogEntry.ActivityStopped(mainActivityClass),
+                LogEntry.ActivityCreated(irActivityClass),
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted
+
+                // untruncated VIEW: open non-drawing IntentReceiverActivity, then MainActivity.
+            ),
+            listOf(
+                LogEntry.ActivityCreated(irActivityClass),
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted,
+                LogEntry.AppStopped,
+                LogEntry.ActivityStopped(mainActivityClass),
+                LogEntry.ActivityCreated(irActivityClass),
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted
+            )
+        )
+
+        forEachStartEntry(warmStartEntries, block)
+    }
+
+    private fun forEachHotStartEntries(block: (index: Int) -> Unit) {
+        // These entries mimic observed behavior. We test both truncated (i.e. the current behavior
+        // with the optimization to prevent an infinite log) and untruncated (the behavior without
+        // such an optimization).
+        //
+        // truncated MAIN: open HomeActivity directly.
+        val hotStartEntries = listOf(
+            listOf(
+                LogEntry.AppStopped,
+                LogEntry.ActivityStopped(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted
+
+                // untruncated MAIN: open HomeActivity directly.
+            ),
+            listOf(
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted,
+                LogEntry.AppStopped,
+                LogEntry.ActivityStopped(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted
+
+                // truncated VIEW: open non-drawing IntentReceiverActivity, then HomeActivity.
+            ),
+            listOf(
+                LogEntry.AppStopped,
+                LogEntry.ActivityStopped(mainActivityClass),
+                LogEntry.ActivityCreated(irActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted
+
+                // untruncated VIEW: open non-drawing IntentReceiverActivity, then HomeActivity.
+            ),
+            listOf(
+                LogEntry.ActivityCreated(irActivityClass),
+                LogEntry.ActivityCreated(mainActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted,
+                LogEntry.AppStopped,
+                LogEntry.ActivityStopped(mainActivityClass),
+                LogEntry.ActivityCreated(irActivityClass),
+                LogEntry.ActivityStarted(mainActivityClass),
+                LogEntry.AppStarted
+            )
+        )
+
+        forEachStartEntry(hotStartEntries, block)
+    }
+
+    private fun forEachStartEntry(entries: List<List<LogEntry>>, block: (index: Int) -> Unit) {
+        entries.forEachIndexed { index, startEntry ->
+            logEntries.clear()
+            logEntries.addAll(startEntry)
+            block(index)
+        }
+    }
+}

--- a/app/src/test/java/org/mozilla/focus/telemetry/StartupTypeTelemetryTest.kt
+++ b/app/src/test/java/org/mozilla/focus/telemetry/StartupTypeTelemetryTest.kt
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.telemetry
+
+import androidx.lifecycle.Lifecycle
+import mozilla.components.support.ktx.kotlin.crossProduct
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.telemetry.glean.private.testHasValue
+import mozilla.telemetry.glean.testing.GleanTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mozilla.focus.GleanMetrics.PerfStartup
+import org.mozilla.focus.activity.MainActivity
+import org.mozilla.focus.telemetry.startuptelemetry.StartupPathProvider
+import org.mozilla.focus.telemetry.startuptelemetry.StartupPathProvider.StartupPath
+import org.mozilla.focus.telemetry.startuptelemetry.StartupStateProvider
+import org.mozilla.focus.telemetry.startuptelemetry.StartupStateProvider.StartupState
+import org.mozilla.focus.telemetry.startuptelemetry.StartupTypeTelemetry
+import org.mozilla.focus.telemetry.startuptelemetry.StartupTypeTelemetry.StartupTypeLifecycleObserver
+import org.robolectric.RobolectricTestRunner
+
+private val validTelemetryLabels = run {
+    val allStates = listOf("cold", "warm", "hot", "unknown")
+    val allPaths = listOf("main", "view", "unknown")
+
+    allStates.crossProduct(allPaths) { state, path -> "${state}_$path" }.toSet()
+}
+
+private val activityClass = MainActivity::class.java
+
+@RunWith(RobolectricTestRunner::class)
+class StartupTypeTelemetryTest {
+
+    private lateinit var telemetry: StartupTypeTelemetry
+    private lateinit var callbacks: StartupTypeLifecycleObserver
+    private var stateProvider: StartupStateProvider = mock()
+    private var pathProvider: StartupPathProvider = mock()
+
+    @get:Rule
+    val gleanTestRule = GleanTestRule(testContext)
+
+    @Before
+    fun setUp() {
+        telemetry = spy(StartupTypeTelemetry(stateProvider, pathProvider))
+        callbacks = telemetry.getTestCallbacks()
+    }
+
+    @Test
+    fun `WHEN attach is called THEN it is registered to the lifecycle`() {
+        val lifecycle = mock<Lifecycle>()
+
+        telemetry.attachOnMainActivityOnCreate(lifecycle)
+
+        verify(lifecycle).addObserver(any())
+    }
+
+    @Test
+    fun `GIVEN all possible path and state combinations WHEN record telemetry THEN the labels are incremented the appropriate number of times`() {
+        val allPossibleInputArgs = StartupState.values().toList().crossProduct(
+            StartupPath.values().toList()
+        ) { state, path ->
+            Pair(state, path)
+        }
+
+        allPossibleInputArgs.forEach { (state, path) ->
+            doReturn(state).`when`(stateProvider).getStartupStateForStartedActivity(activityClass)
+            doReturn(path).`when`(pathProvider).startupPathForActivity
+
+            telemetry.record()
+        }
+
+        validTelemetryLabels.forEach { label ->
+            // Path == NOT_SET gets bucketed with Path == UNKNOWN so we'll increment twice for those.
+            val expected = if (label.endsWith("unknown")) 2 else 1
+            assertEquals("label: $label", expected, PerfStartup.startupType[label].testGetValue())
+        }
+
+        // All invalid labels go to a single bucket: let's verify it has no value.
+        assertFalse(PerfStartup.startupType["__other__"].testHasValue())
+    }
+
+    @Test
+    fun `WHEN record is called THEN telemetry is recorded with the appropriate label`() {
+        doReturn(StartupState.COLD).`when`(stateProvider).getStartupStateForStartedActivity(activityClass)
+        doReturn(StartupPath.MAIN).`when`(pathProvider).startupPathForActivity
+
+        telemetry.record()
+
+        assertEquals(1, PerfStartup.startupType["cold_main"].testGetValue())
+    }
+
+    @Test
+    fun `GIVEN the activity is launched WHEN onResume is called THEN we record the telemetry`() {
+        launchApp()
+        verify(telemetry).record()
+    }
+
+    @Test
+    fun `GIVEN the activity is launched WHEN the activity is paused and resumed THEN record is not called`() {
+        // This part of the test duplicates another test but it's needed to initialize the state of this test.
+        launchApp()
+        verify(telemetry).record()
+
+        callbacks.onPause(mock())
+        callbacks.onResume(mock())
+
+        verify(telemetry).record() // i.e. this shouldn't be called again.
+    }
+
+    @Test
+    fun `GIVEN the activity is launched WHEN the activity is stopped and resumed THEN record is called again`() {
+        // This part of the test duplicates another test but it's needed to initialize the state of this test.
+        launchApp()
+        verify(telemetry).record()
+
+        callbacks.onPause(mock())
+        callbacks.onStop(mock())
+        callbacks.onStart(mock())
+        callbacks.onResume(mock())
+
+        verify(telemetry, times(2)).record()
+    }
+
+    private fun launchApp() {
+        // What these return isn't important.
+        doReturn(StartupState.COLD).`when`(stateProvider).getStartupStateForStartedActivity(activityClass)
+        doReturn(StartupPath.MAIN).`when`(pathProvider).startupPathForActivity
+
+        callbacks.onCreate(mock())
+        callbacks.onStart(mock())
+        callbacks.onResume(mock())
+    }
+}

--- a/app/tags.yaml
+++ b/app/tags.yaml
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Disable line-length rule because the links in the descriptions can be long
+# yamllint disable rule:line-length
+
+---
+$schema: moz://mozilla.org/schemas/glean/tags/1-0-0
+performance:
+  description: Used for data reviews to label metrics related to performance. Corresponds
+    to the [Feature:Performance](https://github.com/mozilla-mobile/focus-android/issues?q=label%3AFeature%3APerformance)
+    label on GitHub.

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -43,6 +43,7 @@ object Versions {
     object Test {
         const val robolectric = "4.6.1"
         const val mockito = "3.11.0"
+        const val androidx_work = "2.7.1"
     }
 }
 
@@ -83,4 +84,5 @@ object Dependencies {
     const val testing_robolectric = "org.robolectric:robolectric:${Versions.Test.robolectric}"
     const val testing_mockito = "org.mockito:mockito-core:${Versions.Test.mockito}"
     const val testing_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.Kotlin.coroutines}"
+    const val androidx_work_testing = "androidx.work:work-testing:${Versions.Test.androidx_work}"
 }


### PR DESCRIPTION
This is basically the same telemetry like in Fenix that was implemented in this task 
 https://github.com/mozilla-mobile/fenix/pull/19028

# Request for data collection review form

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

1) What questions will you answer with this data?

- What are the most common types of start up?
- For users in the 95th percentile of slow start ups – we assume the most likely to leave the app – what are the most common types of start ups?

2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements? Some example responses:

- We want to know the most common types of start up so that we can invest perf resources into only the most common types

3) What alternative methods did you consider to answer these questions? Why were they not sufficient?

None: we need to understand user behaviour in the wild

4) Can current instrumentation answer these questions?

An existing probe `app_opened_all_startup`, tries to measure this but we found one thing wrong with it so I doubt its accuracy. So no.

5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Data_Collection) found on the Mozilla wiki.   

**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**

<table>
  <tr>
    <td>perf.startup.startup_type</td>
    <td>2 - interaction</td>
    <td>#7079</td>
  </tr>
</table>

6) How long will this data be collected?  Choose one of the following:

* This technical data is intended to be collected perpetually.

7) What populations will you measure?

* Which release channels?

All

* Which countries?

All

* Which locales?

All

* Any other filters?  Please describe in detail below.

N/A

8) If this data collection is default on, what is the opt-out mechanism for users?

Telemetry opt out in app

9) Please provide a general description of how you will analyze this data.

- Compare different labels in GLAM
- Write percentile query but filter for 95th percentile slow starts (probable heuristic instead: low-end devices)

10) Where do you intend to share the results of your analysis?

Internally: GLAM, sql.tmo, gdocs

11) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection? If so:

No

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.

