### PR TITLE
For #7190:   App should not be locked in landscape when a tab or custom tab loads while in pip mode

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -361,7 +361,7 @@ class BrowserFragment :
 
         // Feature that handles MediaSession state changes
         fullScreenMediaSessionFeature.set(
-            feature = MediaSessionFullscreenFeature(requireActivity(), requireComponents.store),
+            feature = MediaSessionFullscreenFeature(requireActivity(), requireComponents.store, tryGetCustomTabId()),
             owner = this,
             view = view
         )

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "103.0.20220608143046"
+    const val VERSION = "103.0.20220609143105"
 }


### PR DESCRIPTION
This allows a tab or custom tab to be loaded in device's current orientation while pip mode is active


https://user-images.githubusercontent.com/12825812/172596867-364fb4c7-b3b0-42ac-a9dd-f9715f8e2272.mp4




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
