### PR TITLE
For #7136 Don’t show shield icon CFR for pages with 0 trackers 

### DIFF
--- a/app/src/main/java/org/mozilla/focus/cfr/CfrMiddleware.kt
+++ b/app/src/main/java/org/mozilla/focus/cfr/CfrMiddleware.kt
@@ -44,7 +44,9 @@ class CfrMiddleware(private val appContext: Context) : Middleware<BrowserState, 
 
         if (action is TabListAction.AddTabAction &&
             onboardingConfig.isCfrEnabled &&
-            !components.appStore.state.showTrackingProtectionCfr
+            !components.appStore.state.showTrackingProtectionCfrForTab.getOrDefault(
+                    context.state.selectedTabId, false
+                )
         ) {
             components.settings.numberOfTabsOpened++
             if (components.settings.numberOfTabsOpened == ERASE_CFR_LIMIT) {
@@ -54,8 +56,15 @@ class CfrMiddleware(private val appContext: Context) : Middleware<BrowserState, 
         }
 
         if (shouldShowCfrForTrackingProtection(action = action, browserState = context.state)) {
-            onboardingFeature.recordExposure()
-            components.appStore.dispatch(AppAction.ShowTrackingProtectionCfrChange(true))
+            components.appStore.dispatch(
+                AppAction.ShowTrackingProtectionCfrChange(
+                    mapOf(
+                        (
+                            action as TrackingProtectionAction.TrackerBlockedAction
+                            ).tabId to true
+                    )
+                )
+            )
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/state/AppAction.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppAction.kt
@@ -102,5 +102,5 @@ sealed class AppAction : Action {
     /**
      * State of show Tracking Protection CFR has changed
      */
-    data class ShowTrackingProtectionCfrChange(val value: Boolean) : AppAction()
+    data class ShowTrackingProtectionCfrChange(val value: Map<String, Boolean>) : AppAction()
 }

--- a/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
@@ -187,7 +187,7 @@ private fun showTrackingProtectionCfrChanged(
     state: AppState,
     action: AppAction.ShowTrackingProtectionCfrChange
 ): AppState {
-    return state.copy(showTrackingProtectionCfr = action.value)
+    return state.copy(showTrackingProtectionCfrForTab = action.value)
 }
 
 private fun openSitePermissionOptionsScreen(

--- a/app/src/main/java/org/mozilla/focus/state/AppState.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppState.kt
@@ -25,7 +25,7 @@ data class AppState(
     val sitePermissionOptionChange: Boolean = false,
     val secretSettingsEnabled: Boolean = false,
     val showEraseTabsCfr: Boolean = false,
-    val showTrackingProtectionCfr: Boolean = false
+    val showTrackingProtectionCfrForTab: Map<String, Boolean> = emptyMap()
 ) : State
 
 /**

--- a/app/src/test/java/org/mozilla/focus/cfr/CfrMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/focus/cfr/CfrMiddlewareTest.kt
@@ -85,7 +85,7 @@ class CfrMiddlewareTest {
             browserStore.dispatch(trackerBlockedAction).joinBlocking()
             appStore.waitUntilIdle()
 
-            assertTrue(appStore.state.showTrackingProtectionCfr)
+            assertTrue(appStore.state.showTrackingProtectionCfrForTab.getOrDefault("1", false))
         }
     }
 
@@ -106,14 +106,14 @@ class CfrMiddlewareTest {
             browserStore.dispatch(updateSecurityInfoAction).joinBlocking()
             appStore.waitUntilIdle()
 
-            assertFalse(appStore.state.showTrackingProtectionCfr)
+            assertFalse(appStore.state.showTrackingProtectionCfrForTab.getOrDefault("1", false))
         }
     }
 
     @Test
     fun `GIVEN mozilla tab WHEN UpdateSecurityInfoAction is intercepted THEN showTrackingProtectionCfr is not changed to true`() {
         if (onboardingExperiment.isCfrEnabled) {
-            val mozillaTab = createTab(url = "https://www.mozilla.org")
+            val mozillaTab = createTab(id = "1", url = "https://www.mozilla.org")
             val updateSecurityInfoAction = ContentAction.UpdateSecurityInfoAction(
                 "1",
                 SecurityInfoState(
@@ -126,7 +126,7 @@ class CfrMiddlewareTest {
             browserStore.dispatch(updateSecurityInfoAction).joinBlocking()
             appStore.waitUntilIdle()
 
-            assertFalse(appStore.state.showTrackingProtectionCfr)
+            assertFalse(appStore.state.showTrackingProtectionCfrForTab.getOrDefault("1", false))
         }
     }
 


### PR DESCRIPTION
The Shield Icon CFR should not be displayed for pages with 0 trackers if a page with trackers is opened in a new tab 

https://user-images.githubusercontent.com/8118371/174077770-5a6dc742-822a-4bd5-abad-33b993804536.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
