### PR TITLE
For #6486, #6678: re-enable browsing notification tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/SwitchContextTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SwitchContextTest.kt
@@ -13,7 +13,6 @@ import org.junit.After
 import org.junit.Assert
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -67,12 +66,13 @@ class SwitchContextTest {
 
     @SmokeTest
     @Test
-    @Ignore("Failing. See https://github.com/mozilla-mobile/focus-android/issues/6486")
     fun notificationOpenButtonTest() {
         val testPage = TestAssetHelper.getGenericAsset(webServer)
 
         searchScreen {
-        }.loadPage(testPage.url) { }
+        }.loadPage(testPage.url) {
+            verifyPageContent(testPage.content)
+        }
         // Send app to background
         pressHomeKey()
         // Pull down system bar and select Open
@@ -87,7 +87,6 @@ class SwitchContextTest {
 
     @SmokeTest
     @Test
-    @Ignore("See https://github.com/mozilla-mobile/focus-android/issues/6958")
     fun switchFromSettingsToFocusTest() {
         // Initialize UiDevice instance
         val LAUNCH_TIMEOUT = 5000

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/NotificationRobot.kt
@@ -39,16 +39,14 @@ class NotificationRobot {
     }
 
     fun verifySystemNotificationExists(notificationMessage: String) {
-        val notificationInTray = mDevice.wait(
-            Until.hasObject(
-                By.res(NOTIFICATION_SHADE).hasDescendant(
-                    By.text(notificationMessage)
-                )
-            ),
-            waitingTime
-        )
+        val notification = mDevice.findObject(UiSelector().text(notificationMessage))
+        while (!notification.waitForExists(waitingTime)) {
+            UiScrollable(
+                UiSelector().resourceId(NOTIFICATION_SHADE)
+            ).flingToEnd(1)
+        }
 
-        assertTrue(notificationInTray)
+        assertTrue(notification.exists())
     }
 
     fun verifyMediaNotificationExists(notificationMessage: String) {
@@ -145,7 +143,8 @@ private val notificationOpenButton = mDevice.findObject(
 
 private val notificationTray = UiScrollable(
     UiSelector().resourceId("com.android.systemui:id/notification_stack_scroller")
-).setAsVerticalList()
+)
+    .setAsVerticalList()
 
 private val notificationHeader = mDevice.findObject(
     UiSelector()


### PR DESCRIPTION
For #6486, #6678 - ran both tests 100x on Firebase, all good.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
