### PR TITLE
For #7257 Mixed match for has_content_blocked metric

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/GleanMetricsService.kt
@@ -124,7 +124,7 @@ class GleanMetricsService(context: Context) : MetricsService {
         // tracking protection metrics
         TrackingProtection.hasAdvertisingBlocked.set(settings.hasAdvertisingBlocked())
         TrackingProtection.hasAnalyticsBlocked.set(settings.hasAnalyticsBlocked())
-        TrackingProtection.hasContentBlocked.set(settings.hasContentBlocked())
+        TrackingProtection.hasContentBlocked.set(settings.shouldBlockOtherTrackers())
         TrackingProtection.hasSocialBlocked.set(settings.hasSocialBlocked())
 
         // theme telemetry

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -336,11 +336,6 @@ class Settings(
         true
     )
 
-    fun hasContentBlocked() = preferences.getBoolean(
-        getPreferenceKey(R.string.pref_key_privacy_block_other3),
-        true
-    )
-
     var lightThemeSelected = preferences.getBoolean(
         getPreferenceKey(R.string.pref_key_light_theme),
         false


### PR DESCRIPTION
I removed hasContentBlocked() because it was referring to the same sharePref key like shouldBlockOtherTrackers()

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
