### PR TITLE
Update experiments timespan lifetime

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1828,6 +1828,7 @@ nimbus_experiments:
     description: >
       Measures the time spent to download the nimbus experiments
     time_unit: millisecond
+    lifetime: application
     bugs:
       - https://github.com/mozilla-mobile/focus-android/issues/6847
     data_reviews:


### PR DESCRIPTION
For #7256 
Experiments timespan lifetime was set by default to ping and records invalid state errors. To fix this I set the lifetime to application

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
