### PR TITLE
For #7269 Focus Nightly should not crash when a search is performed on Android 5

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegration.kt
@@ -260,7 +260,7 @@ class BrowserToolbarIntegration(
             flow.mapNotNull { state -> state.showTrackingProtectionCfrForTab }
                 .ifChanged()
                 .collect { showTrackingProtectionCfrForTab ->
-                    if (showTrackingProtectionCfrForTab.getOrDefault(store.state.selectedTabId, false)) {
+                    if (showTrackingProtectionCfrForTab[store.state.selectedTabId] == true) {
                         FocusNimbus.features.onboarding.recordExposure()
                         CFRPopup(
                             container = fragment.requireView(),

--- a/app/src/main/java/org/mozilla/focus/cfr/CfrMiddleware.kt
+++ b/app/src/main/java/org/mozilla/focus/cfr/CfrMiddleware.kt
@@ -44,9 +44,7 @@ class CfrMiddleware(private val appContext: Context) : Middleware<BrowserState, 
 
         if (action is TabListAction.AddTabAction &&
             onboardingConfig.isCfrEnabled &&
-            !components.appStore.state.showTrackingProtectionCfrForTab.getOrDefault(
-                    context.state.selectedTabId, false
-                )
+            components.appStore.state.showTrackingProtectionCfrForTab[context.state.selectedTabId] != true
         ) {
             components.settings.numberOfTabsOpened++
             if (components.settings.numberOfTabsOpened == ERASE_CFR_LIMIT) {


### PR DESCRIPTION
This crash is happening because map.getOrDefault () call requires API level 24 and on android 5 is crashing 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
