### PR TITLE
For #7309: Show storage access prompts when requested

### DIFF
--- a/app/src/main/java/org/mozilla/focus/settings/permissions/permissionoptions/SitePermissionOptionsStorage.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/permissions/permissionoptions/SitePermissionOptionsStorage.kt
@@ -183,7 +183,7 @@ class SitePermissionOptionsStorage(private val context: Context) {
         autoplayInaudible = getAutoplayRules().second,
         persistentStorage = SitePermissionsRules.Action.BLOCKED,
         mediaKeySystemAccess = getSitePermissionRules(SitePermission.MEDIA_KEY_SYSTEM_ACCESS),
-        crossOriginStorageAccess = SitePermissionsRules.Action.BLOCKED
+        crossOriginStorageAccess = SitePermissionsRules.Action.ASK_TO_ALLOW
     )
 
     private fun getSitePermissionRules(sitePermission: SitePermission): SitePermissionsRules.Action {


### PR DESCRIPTION

As we already [added TCP](https://github.com/mozilla-mobile/focus-android/pull/5943) to Focus, we need to enable the cross access permission prompt to be shown, It looks like we regressed from https://github.com/mozilla-mobile/focus-android/pull/6115/ on https://github.com/mozilla-mobile/focus-android/pull/6754. 

<img width="437" alt="image" src="https://user-images.githubusercontent.com/773158/176757777-322a9613-001a-42f3-ba0a-13889666a0bd.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
