### PR TITLE
Apply cfr nimbus feature from the first run

### DIFF
--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -61,7 +61,6 @@ import org.mozilla.focus.experiments.createNimbus
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.settings
 import org.mozilla.focus.media.MediaSessionService
-import org.mozilla.focus.nimbus.FocusNimbus
 import org.mozilla.focus.notification.PrivateNotificationMiddleware
 import org.mozilla.focus.search.SearchFilterMiddleware
 import org.mozilla.focus.search.SearchMigration
@@ -143,12 +142,6 @@ class Components(
     }
 
     val store by lazy {
-        val onboardingFeature = FocusNimbus.features.onboarding
-        val cfrMiddleware = if (onboardingFeature.value(context = context).isCfrEnabled) {
-            listOf(CfrMiddleware(context))
-        } else {
-            listOf()
-        }
         BrowserStore(
             middleware = listOf(
                 PrivateNotificationMiddleware(context),
@@ -166,7 +159,7 @@ class Components(
                 BlockedTrackersMiddleware(context),
                 MergeTabsMiddleware(context),
                 RecordingDevicesMiddleware(context),
-            ) + EngineMiddleware.create(engine) + cfrMiddleware
+            ) + EngineMiddleware.create(engine) + CfrMiddleware(context)
         ).apply {
             MediaSessionFeature(context, MediaSessionService::class.java, this).start()
         }
@@ -200,9 +193,7 @@ class Components(
     val metrics: GleanMetricsService by lazy { GleanMetricsService(context) }
 
     val experiments: NimbusApi by lazy {
-        createNimbus(context, BuildConfig.NIMBUS_ENDPOINT).also { api ->
-            FocusNimbus.api = api
-        }
+        createNimbus(context, BuildConfig.NIMBUS_ENDPOINT)
     }
 
     val adsTelemetry: AdsTelemetry by lazy { AdsTelemetry() }

--- a/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -28,6 +28,7 @@ import mozilla.components.support.webextensions.WebExtensionSupport
 import org.mozilla.focus.biometrics.LockObserver
 import org.mozilla.focus.ext.settings
 import org.mozilla.focus.navigation.StoreLink
+import org.mozilla.focus.nimbus.FocusNimbus
 import org.mozilla.focus.session.VisibilityLifeCycleCallback
 import org.mozilla.focus.telemetry.FactsProcessor
 import org.mozilla.focus.telemetry.ProfilerMarkerFactProcessor
@@ -114,6 +115,9 @@ open class FocusApplication : LocaleAwareApplication(), CoroutineScope {
             // experiment on features close to startup.
             // But we need viaduct (the RustHttp client) to be ready before we do.
             components.experiments.initialize()
+            // This is the recommended way(Nimbus.api will be deprecated) to establish
+            // the connection between the Nimbus SDK (and thus the Nimbus server) and the generated code
+            FocusNimbus.initialize { components.experiments }
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/cfr/CfrMiddleware.kt
+++ b/app/src/main/java/org/mozilla/focus/cfr/CfrMiddleware.kt
@@ -36,15 +36,26 @@ class CfrMiddleware(private val appContext: Context) : Middleware<BrowserState, 
         action: BrowserAction
     ) {
         onboardingConfig = onboardingFeature.value(context = appContext)
+        if (onboardingConfig.isCfrEnabled) {
+            if (action is ContentAction.UpdateSecurityInfoAction) {
+                isCurrentTabSecure = action.securityInfo.secure
+            }
 
-        if (action is ContentAction.UpdateSecurityInfoAction) {
-            isCurrentTabSecure = action.securityInfo.secure
+            next(action)
+
+            showEraseTabsCfr(action, context)
+
+            showTrackingProtectionCfr(action, context)
+        } else {
+            next(action)
         }
+    }
 
-        next(action)
-
+    private fun showEraseTabsCfr(
+        action: BrowserAction,
+        context: MiddlewareContext<BrowserState, BrowserAction>
+    ) {
         if (action is TabListAction.AddTabAction &&
-            onboardingConfig.isCfrEnabled &&
             components.appStore.state.showTrackingProtectionCfrForTab[context.state.selectedTabId] != true
         ) {
             components.settings.numberOfTabsOpened++
@@ -53,7 +64,12 @@ class CfrMiddleware(private val appContext: Context) : Middleware<BrowserState, 
                 components.appStore.dispatch(AppAction.ShowEraseTabsCfrChange(true))
             }
         }
+    }
 
+    private fun showTrackingProtectionCfr(
+        action: BrowserAction,
+        context: MiddlewareContext<BrowserState, BrowserAction>
+    ) {
         if (shouldShowCfrForTrackingProtection(action = action, browserState = context.state)) {
             if (!tpExposureAlreadyRecorded) {
                 FocusNimbus.features.onboarding.recordExposure()
@@ -62,11 +78,7 @@ class CfrMiddleware(private val appContext: Context) : Middleware<BrowserState, 
 
             components.appStore.dispatch(
                 AppAction.ShowTrackingProtectionCfrChange(
-                    mapOf(
-                        (
-                            action as TrackingProtectionAction.TrackerBlockedAction
-                            ).tabId to true
-                    )
+                    mapOf((action as TrackingProtectionAction.TrackerBlockedAction).tabId to true)
                 )
             )
         }
@@ -87,7 +99,6 @@ class CfrMiddleware(private val appContext: Context) : Middleware<BrowserState, 
     ) = (
         isActionSecure(action = action) &&
             !isMozillaUrl(browserState = browserState) &&
-            onboardingConfig.isCfrEnabled &&
             components.settings.shouldShowCfrForTrackingProtection &&
             !components.appStore.state.showEraseTabsCfr
         )


### PR DESCRIPTION
For #7324 
We should check in middleware if the feature is available because at store initialization is too early
Replace nimbus api with initialize because api will be deprecated
Clear nimbus cache only at fresh install
Record experiments fetching time only at fresh install


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
