### PR TITLE
Fix About screen header text alignment

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/about/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/about/AboutFragment.kt
@@ -111,9 +111,11 @@ class AboutFragment : BaseSettingsLikeFragment() {
         val packageInfo = requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)
         val versionCode = PackageInfoCompat.getLongVersionCode(packageInfo).toString()
 
+        // \u200F is just a unicode character which helps the system to know the text alignment, say LTR.
+        // The paragraph usually uses the direction of its first character.
         @Suppress("ImplicitDefaultLocale")
         return String.format(
-            "%s (Build #%s)\n%s: %s\n%s: %s",
+            "\u200F" + "%s (Build #%s)\n%s: %s\n%s: %s",
             packageInfo.versionName,
             versionCode + engineIndicator,
             componentsAbbreviation,


### PR DESCRIPTION
For #6641
In Unicode many characters have a specific directionality, which lets the system know
it has to be written, say LTR.
The paragraph usually uses the direction of its first character.
#### RTL
<img src="https://user-images.githubusercontent.com/11731652/178755810-34126b26-55a5-4491-9f6c-473fd4cab0d5.png" width="30%"/>

#### LTR
<img src="https://user-images.githubusercontent.com/11731652/178755824-06b6e3d5-ee06-4d4f-8c87-19ae23cb18c9.png" width="30%"/>

No unit tests required
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
