### PR TITLE
Bug 1779797 - Let mergify automatically approve all l10n bumps

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,6 +17,28 @@ queue_rules:
       - status-success=ui-test-x86-debug
       - status-success=ui-test-x86-nightly
 pull_request_rules:
+  - name: L10N - Auto Merge
+    conditions:
+      - and:
+        - files~=(strings.xml|l10n.toml)
+        - or:
+          - and:
+            - author=mozilla-l10n-automation-bot
+            - base=main
+            - status-success=pr-complete
+          - and:
+            - author=github-actions[bot]
+            - base~=releases[_/].*
+            # Taskcluster doesn't run when PRs are created by github-actions[bot]
+            # because it's not considered a collaborator.
+    actions:
+      review:
+        type: APPROVE
+        message: LGTM 😎
+      queue:
+        method: rebase
+        name: default
+        rebase_fallback: none
   - name: Needs landing - Rebase
     conditions:
       - base=main


### PR DESCRIPTION
Ports https://github.com/mozilla-mobile/fenix/pull/26046 to focus. This will make mergify approve l10n bumps on both the main branch and the release ones.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
