### PR TITLE
Issue #7376 - use mock location in UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/helpers/MockLocationUpdatesRule.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/MockLocationUpdatesRule.kt
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.helpers
+
+import android.content.Context
+import android.location.Location
+import android.location.LocationManager
+import android.os.Build
+import android.os.SystemClock
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import org.junit.rules.ExternalResource
+import org.mozilla.focus.helpers.TestHelper.executeShellCommandBlocking
+import java.util.Date
+import kotlin.random.Random
+
+private const val mockProviderName = LocationManager.GPS_PROVIDER
+
+/**
+ * Rule that sets up a mock location provider that can inject location samples
+ * straight to the device that the test is running on.
+ *
+ * Credit to the mapbox team
+ * https://github.com/mapbox/mapbox-navigation-android/blob/87fab7ea1152b29533ee121eaf6c05bc202adf02/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/MockLocationUpdatesRule.kt
+ *
+ */
+class MockLocationUpdatesRule : ExternalResource() {
+    private val instrumentation = getInstrumentation()
+    private val appContext = (ApplicationProvider.getApplicationContext() as Context)
+    val latitude = Random.nextDouble(-90.0, 90.0)
+    val longitude = Random.nextDouble(-180.0, 180.0)
+
+    private val locationManager: LocationManager by lazy {
+        (appContext.getSystemService(Context.LOCATION_SERVICE) as LocationManager)
+    }
+
+    override fun before() {
+        /* ADB command to enable the mock location setting on the device.
+         * Will not be turned back off due to limitations on knowing its initial state.
+         */
+        instrumentation.uiAutomation.executeShellCommandBlocking(
+            "appops set " +
+                appContext.packageName +
+                " android:mock_location allow"
+        )
+
+        // To mock locations we need a location provider, so we generate and set it here.
+        try {
+            locationManager.addTestProvider(
+                mockProviderName,
+                false,
+                false,
+                false,
+                false,
+                true,
+                true,
+                true,
+                3,
+                2
+            )
+        } catch (ex: Exception) {
+            // unstable
+            Log.w("MockLocationUpdatesRule", "addTestProvider failed")
+        }
+        locationManager.setTestProviderEnabled(mockProviderName, true)
+    }
+
+    // Cleaning up the location provider after the test.
+    override fun after() {
+        locationManager.setTestProviderEnabled(mockProviderName, false)
+        locationManager.removeTestProvider(mockProviderName)
+    }
+
+    /**
+     * Generate a valid mock location data and set with the help of a test provider.
+     *
+     * @param modifyLocation optional callback for modifying the constructed location before setting it.
+     */
+    fun setMockLocation(modifyLocation: (Location.() -> Unit)? = null) {
+        check(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            "MockLocationUpdatesRule is supported only on Android devices " +
+                "running version >= Build.VERSION_CODES.M"
+        }
+
+        val location = Location(mockProviderName)
+        location.time = Date().time
+        location.elapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos()
+        location.accuracy = 5f
+        location.altitude = 0.0
+        location.bearing = 0f
+        location.speed = 5f
+        location.latitude = latitude
+        location.longitude = longitude
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            location.verticalAccuracyMeters = 5f
+            location.bearingAccuracyDegrees = 5f
+            location.speedAccuracyMetersPerSecond = 5f
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            location.elapsedRealtimeUncertaintyNanos = 0.0
+        }
+
+        modifyLocation?.let {
+            location.apply(it)
+        }
+
+        locationManager.setTestProviderLocation(mockProviderName, location)
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/focus/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/TestHelper.kt
@@ -5,6 +5,7 @@ package org.mozilla.focus.helpers
 
 import android.annotation.TargetApi
 import android.app.PendingIntent
+import android.app.UiAutomation
 import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.ContentResolver
@@ -34,7 +35,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.espresso.web.sugar.Web
-import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import junit.framework.AssertionFailedError
@@ -46,13 +47,14 @@ import org.junit.Assert.assertTrue
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.IntentReceiverActivity
 import org.mozilla.focus.utils.IntentUtils
+import java.io.FileInputStream
 import java.io.IOException
 import java.io.InputStream
 
 @Suppress("TooManyFunctions")
 object TestHelper {
     @JvmField
-    var mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    var mDevice = UiDevice.getInstance(getInstrumentation())
     const val waitingTime = DateUtils.SECOND_IN_MILLIS * 15
     const val pageLoadingTime = DateUtils.SECOND_IN_MILLIS * 25
     const val waitingTimeShort = DateUtils.SECOND_IN_MILLIS * 5
@@ -65,7 +67,7 @@ object TestHelper {
             .joinToString("")
 
     @JvmStatic
-    val getTargetContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
+    val getTargetContext: Context = getInstrumentation().targetContext
 
     @JvmStatic
     val packageName: String = getTargetContext.packageName
@@ -98,7 +100,7 @@ object TestHelper {
 
     fun isPackageInstalled(packageName: String): Boolean {
         return try {
-            val packageManager = InstrumentationRegistry.getInstrumentation().context.packageManager
+            val packageManager = getInstrumentation().context.packageManager
             packageManager.getApplicationInfo(packageName, 0).enabled
         } catch (exception: PackageManager.NameNotFoundException) {
             Log.d("TestLog", exception.message.toString())
@@ -171,7 +173,7 @@ object TestHelper {
     }
 
     fun verifyDownloadedFileOnStorage(fileName: String) {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val context = getInstrumentation().targetContext
         val resolver = context.contentResolver
         val fileUri = queryDownloadMediaStore(fileName)
 
@@ -190,7 +192,7 @@ object TestHelper {
      */
     @TargetApi(Build.VERSION_CODES.Q)
     private fun queryDownloadMediaStore(fileName: String): Uri? {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val context = getInstrumentation().targetContext
         val resolver = context.contentResolver
         val queryProjection = arrayOf(MediaStore.Downloads._ID)
         val querySelection = "${MediaStore.Downloads.DISPLAY_NAME} = ?"
@@ -248,6 +250,11 @@ object TestHelper {
         }
     }
 
+    fun UiAutomation.executeShellCommandBlocking(command: String) {
+        val output = executeShellCommand(command)
+        FileInputStream(output.fileDescriptor).use { it.readBytes() }
+    }
+
     @JvmStatic
     fun pressEnterKey() {
         mDevice.pressKeyCode(KeyEvent.KEYCODE_ENTER)
@@ -269,7 +276,7 @@ object TestHelper {
         customMenuItemLabel: String = "",
         customActionButtonDescription: String = ""
     ): Intent {
-        val appContext = InstrumentationRegistry.getInstrumentation()
+        val appContext = getInstrumentation()
             .targetContext
             .applicationContext
         val pendingIntent = PendingIntent.getActivity(appContext, 0, Intent(), IntentUtils.defaultIntentPendingFlags)
@@ -380,7 +387,7 @@ object TestHelper {
     @JvmStatic
     @Throws(IOException::class)
     fun readTestAsset(filename: String?): Buffer {
-        InstrumentationRegistry.getInstrumentation().getContext().assets.open(filename!!)
+        getInstrumentation().getContext().assets.open(filename!!)
             .use { stream -> return readStreamFile(stream) }
     }
 


### PR DESCRIPTION
For #7376, the share location tests didn't work on Firebase. solution found here https://stackoverflow.com/a/70532450/19230622 on the linked [Github project](https://github.com/mapbox/mapbox-navigation-android/blob/87fab7ea1152b29533ee121eaf6c05bc202adf02/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/MockLocationUpdatesRule.kt)
Ran the test on Firebase with this and it works perfectly https://github.com/mozilla-mobile/focus-android/runs/7388480509

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
