### PR TITLE
Bug 1777255 - part 3: Bump focus-android-beta-version Github Action t…

### DIFF
--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: "Discover Focus Beta Version"
         id: focus-android-beta-version
-        uses: mozilla-mobile/fenix-beta-version@4.0.0
+        uses: mozilla-mobile/fenix-beta-version@4.1.0
       - name: "Skip non-beta versions"
         uses: andymckay/cancel-action@0.2
         if: ${{ steps.focus-android-beta-version.outputs.beta_version == '' }}


### PR DESCRIPTION
…o support new version numbers

Depends on https://github.com/mozilla-mobile/fenix-beta-version/pull/6. Ports https://github.com/mozilla-mobile/fenix/pull/26118 to focus. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
