### PR TITLE
(v103) Bug 1779797 - Android: release branch string uplifts should auto-merge if CI is green

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,6 +17,28 @@ queue_rules:
       - status-success=ui-test-x86-debug
       - status-success=ui-test-x86-nightly
 pull_request_rules:
+  - name: L10N - Auto Merge
+    conditions:
+      - and:
+        - files~=(strings.xml|l10n.toml)
+        - or:
+          - and:
+            - author=mozilla-l10n-automation-bot
+            - base=main
+            - status-success=pr-complete
+          - and:
+            - author=github-actions[bot]
+            - base~=releases[_/].*
+            # Taskcluster doesn't run when PRs are created by github-actions[bot]
+            # because it's not considered a collaborator.
+    actions:
+      review:
+        type: APPROVE
+        message: LGTM 😎
+      queue:
+        method: rebase
+        name: default
+        rebase_fallback: none
   - name: Needs landing - Rebase
     conditions:
       - base=main

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,21 +1,7 @@
 queue_rules:
   - name: default
     conditions:
-      - status-success=build-android-test-beta
-      - status-success=build-android-test-debug
-      - status-success=build-android-test-nightly
-      - status-success=build-beta-firebase
-      - status-success=build-focus-debug
-      - status-success=build-klar-debug
-      - status-success=build-nightly-firebase
-      - status-success=lint-compare-locales
-      - status-success=lint-detekt
-      - status-success=lint-ktlint
-      - status-success=lint-lint
-      - status-success=test-debug
-      - status-success=ui-test-x86-beta
-      - status-success=ui-test-x86-debug
-      - status-success=ui-test-x86-nightly
+      - status-success=complete-pr
 pull_request_rules:
   - name: L10N - Auto Merge
     conditions:
@@ -25,7 +11,7 @@ pull_request_rules:
           - and:
             - author=mozilla-l10n-automation-bot
             - base=main
-            - status-success=pr-complete
+            - status-success=complete-pr
           - and:
             - author=github-actions[bot]
             - base~=releases[_/].*

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,13 @@
 queue_rules:
   - name: default
     conditions:
-      - status-success=complete-pr
+      - or:
+        - status-success=complete-pr
+        - and:
+          # For more context, see "L10N - Auto Merge" rule down below
+          - base~=^releases[_/].*
+          - head~=^automation/sync-strings-\d+
+          - status-success=complete-push
 pull_request_rules:
   - name: L10N - Auto Merge
     conditions:
@@ -11,12 +17,17 @@ pull_request_rules:
           - and:
             - author=mozilla-l10n-automation-bot
             - base=main
+            - head=import-l10n
             - status-success=complete-pr
           - and:
             - author=github-actions[bot]
             - base~=releases[_/].*
-            # Taskcluster doesn't run when PRs are created by github-actions[bot]
-            # because it's not considered a collaborator.
+            - head~=^automation/sync-strings-\d+
+            - status-success=complete-push
+            # Taskcluster only runs on git-push events because github-actions[bot] is not considered
+            # a collaborator, so pull request events are triggered. That said, github-actions[bot]
+            # doesn't create the PR on a separate fork (unlike mozilla-l10n-automation-bot). That's
+            # why git-push events are taken into account
     actions:
       review:
         type: APPROVE

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,7 +12,11 @@ pull_request_rules:
   - name: L10N - Auto Merge
     conditions:
       - and:
-        - files~=(strings.xml|l10n.toml)
+        - files~=^(l10n.toml|app/src/main/res/values[A-Za-z-]*/strings\.xml)$
+        # /!\ The line above doesn't prevent random files to be changed alongside
+        # l10n ones. That's why the additional condition exists below. For more
+        # information: https://docs.mergify.com/conditions/#how-to-match-lists
+        - -files~=^(?!(l10n.toml|app/src/main/res/values[A-Za-z-]*/strings\.xml)).+$
         - or:
           - and:
             - author=mozilla-l10n-automation-bot

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -5,19 +5,20 @@ policy:
 tasks:
     - $let:
           trustDomain: mobile
+
           # Github events have this stuff in different places...
           ownerEmail:
               $if: 'tasks_for in ["cron", "action"]'
               then: '${tasks_for}@noreply.mozilla.org'
               else:
-                $if: 'tasks_for == "github-push"'
-                then: '${event.pusher.email}'
-                else:
-                    $if: 'tasks_for == "github-pull-request"'
-                    then: '${event.pull_request.user.login}@users.noreply.github.com'
-                    else:
-                        $if: 'tasks_for == "github-release"'
-                        then: '${event.sender.login}@users.noreply.github.com'
+                  $if: 'event.sender.login == "github-actions[bot]"'
+                  then: 'github-actions[bot]@users.noreply.github.com'
+                  else:
+                      $if: 'tasks_for == "github-push"'
+                      then: '${event.pusher.email}'
+                      else:
+                          $if: 'tasks_for == "github-pull-request"'
+                          then: '${event.pull_request.user.login}@users.noreply.github.com'
           baseRepoUrl:
               $if: 'tasks_for in ["github-push", "github-release"]'
               then: '${event.repository.html_url}'

--- a/taskcluster/ci/complete/kind.yml
+++ b/taskcluster/ci/complete/kind.yml
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+kind-dependencies:
+    - build
+    - lint
+    - test
+    - ui-test
+
+transforms:
+    - taskgraph.transforms.code_review:transforms
+    - taskgraph.transforms.task:transforms
+
+job-defaults:
+    worker-type: succeed
+
+
+jobs:
+    pr:
+        description: PR Summary Task
+        run-on-tasks-for: [github-pull-request]
+
+    push:
+        description: Push Summary Task
+        run-on-tasks-for: [github-push]

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -11,7 +11,15 @@ treeherder:
         'release': 'Production-related tasks with same APK configuration as Focus'
         'TL': 'Toolchain builds for Linux 64-bits'
 
-task-priority: highest
+task-priority:
+    by-project:
+        "focus-android": highest
+        "staging-focus-android": low
+        # This handles cases where a fork may end up not being named
+        # as one of the explicit names above. Ideally anything forked
+        # from "focus-android" would inherit its setting, but "low" is the
+        # safer default
+        default: low
 
 taskgraph:
     register: focus_android_taskgraph:register


### PR DESCRIPTION
Ports https://github.com/mozilla-mobile/focus-android/pull/7397 and https://github.com/mozilla-mobile/focus-android/pull/7369 to the current release branch. No conflicts to solve.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
