### PR TITLE
For #7363 fix flaky verifySelectTextTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/WebControlsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/WebControlsTest.kt
@@ -7,7 +7,6 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -124,7 +123,6 @@ class WebControlsTest {
 
     @SmokeTest
     @Test
-    @Ignore("Failing, see https://github.com/mozilla-mobile/focus-android/issues/7363")
     fun verifyDismissTextSelectionToolbarTest() {
         val tab1Url = TestAssetHelper.getGenericTabAsset(webServer, 1).url
         val htmlControlsPage = TestAssetHelper.getHTMLControlsPageAsset(webServer).url

--- a/app/src/androidTest/java/org/mozilla/focus/activity/WebControlsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/WebControlsTest.kt
@@ -143,7 +143,6 @@ class WebControlsTest {
 
     @SmokeTest
     @Test
-    @Ignore("Failing, see https://github.com/mozilla-mobile/focus-android/issues/7363")
     fun verifySelectTextTest() {
         val htmlControlsPage = TestAssetHelper.getHTMLControlsPageAsset(webServer).url
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.focus.activity.robots
 
+import android.util.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
@@ -19,6 +20,7 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.Matchers.not
+import org.junit.Assert
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.focus.R
@@ -318,19 +320,27 @@ class BrowserRobot {
     }
 
     fun longClickAndCopyText(expectedText: String) {
-        var currentTries = 0
-        while (currentTries++ < 3) {
+        for (i in 1..RETRY_COUNT) {
             try {
-                mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
-                mDevice.findObject(By.textContains(expectedText)).also { it.longClick() }
+                mDevice.wait(Until.findObject(By.textContains(expectedText)), waitingTime)
+                Assert.assertNotNull(mDevice.findObject(By.textContains(expectedText)))
+                mDevice.findObject(By.textContains(expectedText)).longClick()
 
-                mDevice.findObject(UiSelector().textContains("Copy")).waitForExists(waitingTime)
-                mDevice.findObject(By.textContains("Copy")).also { it.click() }
+                mDevice.wait(Until.findObject(By.textContains("Copy")), waitingTime)
+                Assert.assertNotNull(mDevice.findObject(By.textContains("Copy")))
+                mDevice.findObject(By.textContains("Copy")).click()
+
                 break
             } catch (e: NullPointerException) {
-                browserScreen {
-                }.openMainMenu {
-                }.clickReloadButton {}
+                if (i == RETRY_COUNT) {
+                    throw e
+                } else {
+                    Log.e("TestLog", "Failed to click Copy button ${e.localizedMessage}")
+
+                    browserScreen {
+                    }.openMainMenu {
+                    }.clickReloadButton {}
+                }
             }
         }
     }
@@ -339,14 +349,25 @@ class BrowserRobot {
         assertFalse(mDevice.findObject(UiSelector().textContains("Copy")).waitForExists(waitingTime))
 
     fun clickAndPasteTextInInputBox() {
-        var currentTries = 0
-        while (currentTries++ < 3) {
+        for (i in 1..RETRY_COUNT) {
             try {
-                mDevice.findObject(UiSelector().textContains("Paste")).waitForExists(waitingTime)
-                mDevice.findObject(By.textContains("Paste")).also { it.click() }
+                longPressTextInputBox()
+
+                mDevice.wait(Until.findObject(By.textContains("Paste")), waitingTime)
+                Assert.assertNotNull(mDevice.findObject(By.textContains("Paste")))
+                mDevice.findObject(By.textContains("Paste")).click()
+
                 break
             } catch (e: NullPointerException) {
-                longPressTextInputBox()
+                if (i == RETRY_COUNT) {
+                    throw e
+                } else {
+                    Log.e("TestLog", "Failed to click Paste button ${e.localizedMessage}")
+
+                    browserScreen {
+                    }.openMainMenu {
+                    }.clickReloadButton {}
+                }
             }
         }
     }

--- a/app/src/androidTest/java/org/mozilla/focus/helpers/RetryTestRule.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/RetryTestRule.kt
@@ -9,7 +9,6 @@ import androidx.test.uiautomator.UiObjectNotFoundException
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import java.lang.AssertionError
 
 class RetryTestRule(private val retryCount: Int = 5) : TestRule {
 
@@ -28,6 +27,10 @@ class RetryTestRule(private val retryCount: Int = 5) : TestRule {
                         throw t
                     }
                 } catch (t: NoMatchingViewException) {
+                    if (i == retryCount) {
+                        throw t
+                    }
+                } catch (t: NullPointerException) {
                     if (i == retryCount) {
                         throw t
                     }

--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -38,8 +38,7 @@ gcloud:
   performance-metrics: true
 
   test-targets:
-    - package org.mozilla.focus.activity
-    - package org.mozilla.focus.privacy
+    - class org.mozilla.focus.activity.WebControlsTest#verifyDismissTextSelectionToolbarTest
 
   device:
    - model: Pixel3
@@ -52,7 +51,7 @@ flank:
   max-test-shards: -1
   # num-test-runs: the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
-  num-test-runs: 1
+  num-test-runs: 10
   ### Output Style flag
   ## Output style of execution status. May be one of [verbose, multi, single, compact].
   ## For runs with only one test execution the default value is 'verbose', in other cases


### PR DESCRIPTION
For #7363 fix flaky `verifySelectTextTest` UI test ✅ successfully ran 100x on Firebase

Summary: 
The problem was that the "Paste" context option sometimes wasn't displayed, as well as the fact that it wasn't properly identified, failing to click it.

Refactored in the same fashion the long click and copy of text.

Also added `NullPointerException` to the retry rule in case the click fails on a UiObject2

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.

Fixes #7363
Fixes #7363
Fixes #7363
Fixes #7363
Fixes #7363
Fixes #7363