### PR TITLE
Bug 1780740 - A-C bumps should auto-merge if CI is green on release branches

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,10 +4,16 @@ queue_rules:
       - or:
         - status-success=complete-pr
         - and:
-          # For more context, see "L10N - Auto Merge" rule down below
-          - base~=^releases[_/].*
-          - head~=^automation/sync-strings-\d+
+          # For more context, see "Auto Merge" rules down below
           - status-success=complete-push
+          - or:
+            - and:
+              - base~=^releases[_/].*
+              - head~=^(relbot/focus|automation/sync-strings)-\d+
+            - and:
+              - base=main
+              - head~=relbot/AC-Nightly-.+
+
 pull_request_rules:
   - name: L10N - Auto Merge
     conditions:
@@ -40,16 +46,24 @@ pull_request_rules:
         method: rebase
         name: default
         rebase_fallback: none
-  - name: Relbot - Auto Merge
+  - name: Android-Components bump - Auto Merge
     conditions:
-      - base=main
-      - files=buildSrc/src/main/java/AndroidComponents.kt
-      - -files~=^(?!buildSrc/src/main/java/AndroidComponents.kt).+$
-      - author=github-actions[bot]
+      - and:
+        - files=buildSrc/src/main/java/AndroidComponents.kt
+        - -files~=^(?!buildSrc/src/main/java/AndroidComponents.kt).+$
+        - author=github-actions[bot]
+        - status-success=complete-push
+        - or:
+          - and:
+            - base=main
+            - head~=relbot/AC-Nightly-.+
+          - and:
+            - base~=^releases[_/].*
+            - head~=^relbot/focus-\d+
     actions:
       review:
         type: APPROVE
-        message: ✅ Cleared to land.
+        message: 🚢
       queue:
         method: rebase
         name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -35,7 +35,7 @@ pull_request_rules:
             - head~=^automation/sync-strings-\d+
             - status-success=complete-push
             # Taskcluster only runs on git-push events because github-actions[bot] is not considered
-            # a collaborator, so pull request events are triggered. That said, github-actions[bot]
+            # a collaborator, so pull request events not are triggered. That said, github-actions[bot]
             # doesn't create the PR on a separate fork (unlike mozilla-l10n-automation-bot). That's
             # why git-push events are taken into account
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -43,7 +43,8 @@ pull_request_rules:
   - name: Relbot - Auto Merge
     conditions:
       - base=main
-      - files~=AndroidComponents.kt
+      - files=buildSrc/src/main/java/AndroidComponents.kt
+      - -files~=^(?!buildSrc/src/main/java/AndroidComponents.kt).+$
       - author=github-actions[bot]
     actions:
       review:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -40,6 +40,19 @@ pull_request_rules:
         method: rebase
         name: default
         rebase_fallback: none
+  - name: Relbot - Auto Merge
+    conditions:
+      - base=main
+      - files~=AndroidComponents.kt
+      - author=github-actions[bot]
+    actions:
+      review:
+        type: APPROVE
+        message: ✅ Cleared to land.
+      queue:
+        method: rebase
+        name: default
+        rebase_fallback: none
   - name: Needs landing - Rebase
     conditions:
       - base=main
@@ -60,19 +73,6 @@ pull_request_rules:
     actions:
       queue:
         method: squash
-        name: default
-        rebase_fallback: none
-  - name: Relbot - Auto Merge
-    conditions:
-      - base=main
-      - files~=AndroidComponents.kt
-      - author=github-actions[bot]
-    actions:
-      review:
-        type: APPROVE
-        message: ✅ Cleared to land.
-      queue:
-        method: rebase
         name: default
         rebase_fallback: none
   - name: Relbot - delete head branch after merge


### PR DESCRIPTION

Ports https://github.com/mozilla-mobile/fenix/pull/26148 to focus. This does the same as https://github.com/mozilla-mobile/focus-android/pull/7369 and https://github.com/mozilla-mobile/focus-android/pull/7396 but for A-C bumps. See https://github.com/mozilla-mobile/fenix/pull/26148#issue-1315141377 regarding testing.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.
