### PR TITLE
For #7423: Replace icon for navigate up/back button.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/compose/Modifier.kt
+++ b/app/src/main/java/org/mozilla/focus/compose/Modifier.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.compose
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
+
+/**
+ * Modifier used for performing auto mirroring in RTL for composable.
+ */
+@Stable
+fun Modifier.autoMirror(): Modifier = composed {
+    if (LocalLayoutDirection.current == LayoutDirection.Rtl)
+        this.scale(scaleX = -1f, scaleY = 1f)
+    else
+        this
+}

--- a/app/src/main/java/org/mozilla/focus/settings/BaseComposeFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/BaseComposeFragment.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
@@ -26,6 +27,7 @@ import com.google.accompanist.insets.rememberInsetsPaddingValues
 import com.google.accompanist.insets.ui.TopAppBar
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.MainActivity
+import org.mozilla.focus.compose.autoMirror
 import org.mozilla.focus.ext.hideToolbar
 import org.mozilla.focus.ui.theme.FocusTheme
 import org.mozilla.focus.ui.theme.focusColors
@@ -99,6 +101,7 @@ abstract class BaseComposeFragment : Fragment() {
                                                 Icon(
                                                     painterResource(id = R.drawable.mozac_ic_back),
                                                     stringResource(R.string.go_back),
+                                                    modifier = Modifier.autoMirror(),
                                                     tint = focusColors.toolbarColor
                                                 )
                                             }

--- a/app/src/main/java/org/mozilla/focus/settings/BaseComposeFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/BaseComposeFragment.kt
@@ -13,13 +13,12 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.fragment.app.Fragment
 import com.google.accompanist.insets.LocalWindowInsets
@@ -98,7 +97,7 @@ abstract class BaseComposeFragment : Fragment() {
                                                 onClick = onNavigateUp()
                                             ) {
                                                 Icon(
-                                                    Icons.Filled.ArrowBack,
+                                                    painterResource(id = R.drawable.mozac_ic_back),
                                                     stringResource(R.string.go_back),
                                                     tint = focusColors.toolbarColor
                                                 )


### PR DESCRIPTION
The new icon is already used in all other app fragments.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.





### GitHub Automation
Fixes #7423