### PR TITLE
(v104) Bug 1781248 - Notify release-signoff@m.o when mobile builds are ready to be tested

### DIFF
--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -12,7 +12,7 @@ transforms:
 kind-dependencies:
     - toolchain
 
-job-defaults:
+task-defaults:
     apk-artifact-template:
         type: file
         name: 'public/build/{gradle_build}/{abi}/target.apk'
@@ -38,7 +38,7 @@ job-defaults:
         max-run-time: 7200
         chain-of-trust: true
 
-jobs:
+tasks:
     focus-debug:
         description: 'Focus debug build from source code'
         run-on-tasks-for: [github-pull-request, github-push]

--- a/taskcluster/ci/complete/kind.yml
+++ b/taskcluster/ci/complete/kind.yml
@@ -14,11 +14,11 @@ transforms:
     - taskgraph.transforms.code_review:transforms
     - taskgraph.transforms.task:transforms
 
-job-defaults:
+task-defaults:
     worker-type: succeed
 
 
-jobs:
+tasks:
     pr:
         description: PR Summary Task
         run-on-tasks-for: [github-pull-request]

--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -10,7 +10,7 @@ transforms:
     - taskgraph.transforms.cached_tasks:transforms
     - taskgraph.transforms.task:transforms
 
-jobs:
+tasks:
     android-build:
         symbol: I(agb)
         parent: base

--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -9,10 +9,10 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
-job-defaults:
+task-defaults:
     docker-image: {in-tree: base}
 
-jobs:
+tasks:
     android-sdk-3859397:
         description: Android SDK
         fetch:

--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -13,7 +13,7 @@ kind-dependencies:
     - toolchain
 
 
-job-defaults:
+task-defaults:
     attributes:
         code-review: true
         retrigger: true
@@ -40,7 +40,7 @@ job-defaults:
                   path: /builds/worker/github
                   type: directory
 
-jobs:
+tasks:
     compare-locales:
         description: 'Validate strings.xml with compare-locales'
         run:
@@ -65,7 +65,7 @@ jobs:
             gradlew: ['ktlint']
         treeherder:
             symbol: ktlint
-    
+
     lint:
         description: 'Running lint over all modules'
         run:

--- a/taskcluster/ci/release-notify-promote/kind.yml
+++ b/taskcluster/ci/release-notify-promote/kind.yml
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - focus_android_taskgraph.transforms.release_deps:transforms
+    - taskgraph.transforms.release_notifications:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - push-apk
+
+primary-dependency: push-apk
+
+group-by: build-type
+
+only-for-build-types:
+    - beta
+    - release
+
+task-defaults:
+    attributes:
+        shipping_phase: promote
+    name: notify-release-drivers-promote
+    description: Sends email to release-drivers telling release was promoted.
+    worker-type: succeed
+    worker:
+        implementation: succeed
+    notifications:
+        subject: "{config[params][project]} {config[params][version]} build{config[params][build_number]} has been pushed to the closed testing track on Google Play"
+        emails:
+            by-level:
+                '3': ["release-signoff@mozilla.org"]
+                default: ["{config[params][owner]}"]
+
+tasks:
+    beta:
+        attributes:
+            release-type: beta
+    release:
+        attributes:
+            release-type: release

--- a/taskcluster/ci/release-notify-ship/kind.yml
+++ b/taskcluster/ci/release-notify-ship/kind.yml
@@ -1,0 +1,47 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - focus_android_taskgraph.transforms.release_deps:transforms
+    - taskgraph.transforms.release_notifications:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - push-apk
+    - github-release
+    - version-bump
+    - mark-as-shipped
+
+primary-dependency: push-apk
+
+group-by: build-type
+
+only-for-build-types:
+    - beta
+    - release
+
+task-defaults:
+    attributes:
+        shipping_phase: ship
+    name: notify-release-drivers-ship
+    description: Sends email to release-drivers telling release was shipped.
+    worker-type: succeed
+    worker:
+        implementation: succeed
+    notifications:
+        subject: "{config[params][project]} {config[params][version]} build{config[params][build_number]} has been tagged in GitHub"
+        emails:
+            by-level:
+                '3': ["release-signoff@mozilla.org"]
+                default: ["{config[params][owner]}"]
+
+tasks:
+    beta:
+        attributes:
+            release-type: beta
+    release:
+        attributes:
+            release-type: release

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -11,10 +11,10 @@ transforms:
 kind-dependencies:
     - toolchain
 
-job-defaults:
+task-defaults:
     attributes:
         retrigger: true
-    description: Unit tests 
+    description: Unit tests
     fetches:
         toolchain:
             - android-sdk-linux
@@ -30,7 +30,7 @@ job-defaults:
         docker-image: {in-tree: base}
         max-run-time: 7200
 
-jobs:
+tasks:
     debug:
         attributes:
             code-review: true

--- a/taskcluster/ci/toolchain/android.yml
+++ b/taskcluster/ci/toolchain/android.yml
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
-job-defaults:
+task-defaults:
     run:
         using: toolchain-script
     treeherder:

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -13,5 +13,5 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 
-jobs-from:
+tasks-from:
     - android.yml

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -12,13 +12,13 @@ kind-dependencies:
     - toolchain
     - build
 
-job-defaults:
+task-defaults:
     attributes:
         build-type: debug
         code-review: true
         retrigger: true
     dependencies:
-        # key is arbitrary, the value corresponds to <kind name>-<build-name> 
+        # key is arbitrary, the value corresponds to <kind name>-<build-name>
         signed-debug-apk: signing-focus-debug
         signed-android-test: signing-android-test-debug
     worker-type: b-android
@@ -52,7 +52,7 @@ job-defaults:
             - [wget, {artifact-reference: '<signed-debug-apk/public/build/focus/x86/target.apk>'}, '-O', app.apk]
             - [wget, {artifact-reference: '<signed-android-test/public/build/app-focus-androidTest.apk>'}, '-O', android-test.apk]
 
-jobs:
+tasks:
     x86-debug:
         description: 'UI tests with firebase'
         run:

--- a/taskcluster/focus_android_taskgraph/parameters.py
+++ b/taskcluster/focus_android_taskgraph/parameters.py
@@ -15,8 +15,6 @@ def get_defaults(repo_root):
         "pull_request_number": None,
         "release_type": "",
         "shipping_phase": None,
-        "next_version": "",
-        "version": "",
     }
 
 
@@ -24,16 +22,11 @@ extend_parameters_schema({
     Required("pull_request_number"): Any(All(int, Range(min=1)), None),
     Required("release_type"): str,
     Optional("shipping_phase"): Any('build', 'promote', 'ship', None),
-    Required("version"): str,
-    Required("next_version"): Any(None, str),
 }, defaults_fn=get_defaults)
 
 
 def get_decision_parameters(graph_config, parameters):
     parameters.setdefault("release_type", "")
-    head_tag = parameters["head_tag"]
-    parameters["version"] = head_tag[1:] if head_tag else ""
 
     pr_number = os.environ.get("MOBILE_PULL_REQUEST_NUMBER", None)
     parameters["pull_request_number"] = None if pr_number is None else int(pr_number)
-    parameters.setdefault("next_version", None)

--- a/taskcluster/focus_android_taskgraph/release_promotion.py
+++ b/taskcluster/focus_android_taskgraph/release_promotion.py
@@ -26,9 +26,9 @@ def is_release_promotion_available(parameters):
 
 @register_callback_action(
     name='release-promotion',
-    title='Ship Focus/Klar',
+    title='Release Promotion',
     symbol='${input.release_promotion_flavor}',
-    description="Ship Focus/Klar",
+    description="Release Promotion",
     generic=False,
     order=500,
     context=[],
@@ -143,7 +143,7 @@ def release_promotion_action(parameters, graph_config, input, task_group_id, tas
     version_string = input.get('version', None)
 
     # shipit uses the version in version.txt to determine next version number; check that its passed in
-    # in the payload     
+    # in the payload
     if not version_string:
         version_string = version_in_file
     elif version_string != version_in_file:

--- a/taskcluster/focus_android_taskgraph/transforms/mark_as_shipped.py
+++ b/taskcluster/focus_android_taskgraph/transforms/mark_as_shipped.py
@@ -30,14 +30,14 @@ def resolve_keys(config, tasks):
 
 
 @transforms.add
-def make_task_description(config, jobs):
-    for job in jobs:
+def make_task_description(config, tasks):
+    for task in tasks:
         # used to query shipit so the case needs to match
         product = "Focus-android"
         version = config.params['version'] or "{ver}"
-        job['worker']['release-name'] = '{product}-{version}-build{build_number}'.format(
+        task['worker']['release-name'] = '{product}-{version}-build{build_number}'.format(
             product=product,
             version=version,
             build_number=config.params.get('build_number', 1)
         )
-        yield job
+        yield task

--- a/taskcluster/focus_android_taskgraph/transforms/release_deps.py
+++ b/taskcluster/focus_android_taskgraph/transforms/release_deps.py
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Add dependencies to release tasks.
+"""
+
+from taskgraph.transforms.base import TransformSequence
+
+PHASES = ["build", "promote", "push", "ship"]
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def add_dependencies(config, tasks):
+    for task in tasks:
+        dependencies = {}
+        # Add any kind_dependencies_tasks with matching release_type as dependencies
+        release_type = task["attributes"].get("release-type")
+        phase = task["attributes"].get("shipping_phase")
+        if release_type is None:
+            continue
+
+        for dep_task in config.kind_dependencies_tasks:
+            # Weed out unwanted tasks.
+            # XXX we have run-on-projects which specifies the on-push behavior;
+            # we need another attribute that specifies release promotion,
+            # possibly which action(s) each task belongs in.
+
+            # We can only depend on tasks in the current or previous phases
+            dep_phase = dep_task.attributes.get("shipping_phase")
+            if dep_phase and PHASES.index(dep_phase) > PHASES.index(phase):
+                continue
+
+            # Add matching release_type tasks to deps
+            if (
+                dep_task.task.get("release-type") == release_type
+                or dep_task.attributes.get("release-type") == release_type
+            ):
+                dependencies[dep_task.label] = dep_task.label
+
+        task.setdefault("dependencies", {}).update(dependencies)
+
+        yield task

--- a/taskcluster/requirements.txt
+++ b/taskcluster/requirements.txt
@@ -8,9 +8,9 @@ appdirs==1.4.4 \
     --hash=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41 \
     --hash=sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
     # via taskcluster-taskgraph
-attrs==21.4.0 \
-    --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
-    --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
+attrs==22.1.0 \
+    --hash=sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6 \
+    --hash=sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c
     # via
     #   mozilla-version
     #   taskcluster-taskgraph
@@ -91,18 +91,18 @@ slugid==2.0.0 \
     --hash=sha256:a950d98b72691178bdd4d6c52743c4a2aa039207cf7a97d71060a111ff9ba297 \
     --hash=sha256:aec8b0e01c4ad32e38e12d609eab3ec912fd129aaf6b2ded0199b56a5f8fd67c
     # via taskcluster-taskgraph
-taskcluster-taskgraph==1.7.1 \
-    --hash=sha256:736054efee8c56987417d4ad2960cfc99c91338253580eadece072a43e042718 \
-    --hash=sha256:9cb13e19ddf74331c51a9f1dd68afde179f148e7856269e8e5f6182e0a2e5732
+taskcluster-taskgraph==2.0.0 \
+    --hash=sha256:3d22ab488071ddc82997b33fc6c1c524a44bdc7e14b30a274d99dbbdd7389502 \
+    --hash=sha256:93eff40ba39a29cd290fc25a2124ed9bf5806d87891edd7e8de35df568708141
     # via -r requirements.in
 taskcluster-urls==13.0.1 \
     --hash=sha256:5e25e7e6818e8877178b175ff43d2e6548afad72694aa125f404a7329ece0973 \
     --hash=sha256:b25e122ecec249c4299ac7b20b08db76e3e2025bdaeb699a9d444556de5fd367 \
     --hash=sha256:f66dcbd6572a6216ab65949f0fa0b91f2df647918028436c384e6af5cd12ae2b
     # via taskcluster-taskgraph
-urllib3==1.26.10 \
-    --hash=sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec \
-    --hash=sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6
+urllib3==1.26.11 \
+    --hash=sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc \
+    --hash=sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a
     # via requests
 voluptuous==0.13.1 \
     --hash=sha256:4b838b185f5951f2d6e8752b68fcf18bd7a9c26ded8f143f92d6d28f3921a3e6 \


### PR DESCRIPTION
This patch just uplifts https://github.com/mozilla-mobile/focus-android/pull/7440 to the v104 branch so that we get email notifications in the next beta. This patch has no impact on the build themselves. No conflicts to resolve when cherry-picking the commits

See https://github.com/mozilla-mobile/fenix/pull/26279 for the fenix equivalent. 
