### PR TITLE
Show all supported languages

### DIFF
--- a/app/src/main/java/org/mozilla/focus/locale/screen/LanguageStorage.kt
+++ b/app/src/main/java/org/mozilla/focus/locale/screen/LanguageStorage.kt
@@ -68,21 +68,14 @@ class LanguageStorage(private val context: Context) {
     }
 
     /**
-     * Not every locale we ship can be used on every device, due to
-     * font or rendering constraints.
-     * This method filters down the list before generating the descriptor array.
+     * This method generates the descriptor array.
      */
     private fun getUsableLocales(): Array<LocaleDescriptor?> {
         val shippingLocales = LocaleManager.getPackagedLocaleTags()
         val initialCount: Int = shippingLocales.size
         val locales: MutableSet<LocaleDescriptor> = HashSet(initialCount)
         for (tag in shippingLocales) {
-            val descriptor = LocaleDescriptor(tag)
-            if (!descriptor.isUsable()) {
-                Logger.warn("Skipping locale $tag on this device.")
-                continue
-            }
-            locales.add(descriptor)
+            locales.add(LocaleDescriptor(tag))
         }
         val usableCount = locales.size
         val descriptors: Array<LocaleDescriptor?> = locales.toTypedArray()

--- a/app/src/main/java/org/mozilla/focus/locale/screen/LocaleDescriptor.kt
+++ b/app/src/main/java/org/mozilla/focus/locale/screen/LocaleDescriptor.kt
@@ -96,35 +96,6 @@ class LocaleDescriptor(private val localeTag: String) : Comparable<LocaleDescrip
         }
     }
 
-    /**
-     * See Bug 1023451 Comment 10 for the research that led to
-     * this method.
-     *
-     * @return true if this locale can be used for displaying UI
-     * on this device without known issues.
-     */
-    fun isUsable(): Boolean {
-        // Oh, for Java 7 switch statements.
-        // Bengali sometimes has an English label if the Bengali script
-        // is missing. This prevents us from simply checking character
-        // rendering for bn-IN; we'll get a false positive for "B", not "ব".
-        //
-        // This doesn't seem to affect other Bengali-script locales
-        // (below), which always have a label in native script.
-        if (localeTag == "bn-IN" && !nativeName!!.startsWith("বাংলা")) {
-            // We're on an Android version that doesn't even have
-            // characters to say বাংলা. Definite failure.
-            return false
-        }
-
-        // These locales use a script that is often unavailable
-        // on common Android devices. Make sure we can show them.
-        // See documentation for CharacterValidator.
-        // Note that bn-IN is checked here even if it passed above.
-        return localeTag != "or" && localeTag != "my" && localeTag != "pa-IN" &&
-            localeTag != "gu-IN" && localeTag != "bn-IN"
-    }
-
     fun getTag(): String {
         return localeTag
     }


### PR DESCRIPTION
For #7447 
Some locale names not displayable in locale picker with default fonts due to Java 7, but since we are using Java 8+ now we can show all suported locals

<img src="https://user-images.githubusercontent.com/11731652/183307842-24e3670c-3053-4862-bc3b-1f60a725a176.png" width="30%"/>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.



### GitHub Automation
Fixes #7447