### PR TITLE
For #7318 fix flaky openLinksInAppsTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/SettingsAdvancedTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SettingsAdvancedTest.kt
@@ -14,7 +14,6 @@ import org.mozilla.focus.activity.robots.homeScreen
 import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
 import org.mozilla.focus.helpers.MockWebServerHelper
-import org.mozilla.focus.helpers.RetryTestRule
 import org.mozilla.focus.helpers.TestAssetHelper.getGenericTabAsset
 import org.mozilla.focus.helpers.TestHelper.waitingTimeShort
 import org.mozilla.focus.testAnnotations.SmokeTest
@@ -28,10 +27,6 @@ class SettingsAdvancedTest {
 
     @get: Rule
     var mActivityTestRule = MainActivityFirstrunTestRule(showFirstRun = false)
-
-    @Rule
-    @JvmField
-    val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setup() {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
@@ -231,7 +231,20 @@ class BrowserRobot {
 
     fun verifyOpenLinksInAppsPrompt(openLinksInAppsEnabled: Boolean, link: String) = assertOpenLinksInAppsPrompt(openLinksInAppsEnabled, link)
 
-    fun clickOpenLinksInAppsCancelButton() = openLinksInAppsCancelButton.click()
+    fun clickOpenLinksInAppsCancelButton() {
+        for (i in 1..RETRY_COUNT) {
+            try {
+                openLinksInAppsCancelButton.click()
+                assertTrue(openLinksInAppsMessage.waitUntilGone(waitingTime))
+
+                break
+            } catch (e: AssertionError) {
+                if (i == RETRY_COUNT) {
+                    throw e
+                }
+            }
+        }
+    }
 
     fun clickOpenLinksInAppsOpenButton() = openLinksInAppsOpenButton.click()
 


### PR DESCRIPTION
For #7318 fix flaky openLinksInAppsTest UI test ✅ successfully passed 100x on Firebase.

Summary:
• Removed the retry rule because the "Open links in apps" toggle was already enabled after re-run.
• Sometimes the click on the "Cancel" button wasn't properly performed so I've refactored `clickOpenLinksInAppsCancelButton`


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.



### GitHub Automation
Fixes #7318