### PR TITLE
For #7427: Upgrade compose to 1.2.1 version.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,7 +93,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = Versions.compose_version
+        kotlinCompilerExtensionVersion = Versions.compose_compiler
     }
 
     flavorDimensions "product"
@@ -156,6 +156,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
             allWarningsAsErrors = true
             freeCompilerArgs += "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
             freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+            freeCompilerArgs += "-Xjvm-default=enable"
             jvmTarget = '1.8'
         }
 }

--- a/app/src/main/java/org/mozilla/focus/compose/CFRPopup.kt
+++ b/app/src/main/java/org/mozilla/focus/compose/CFRPopup.kt
@@ -50,7 +50,8 @@ import androidx.compose.ui.window.PopupProperties
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.ViewTreeLifecycleOwner
-import androidx.savedstate.ViewTreeSavedStateRegistryOwner
+import androidx.savedstate.findViewTreeSavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import mozilla.components.support.ktx.android.util.dpToPx
 import org.mozilla.focus.R
 import org.mozilla.focus.R.color
@@ -188,7 +189,7 @@ internal class CFRPopupFullScreenLayout(
 
     init {
         ViewTreeLifecycleOwner.set(this, ViewTreeLifecycleOwner.get(container))
-        ViewTreeSavedStateRegistryOwner.set(this, ViewTreeSavedStateRegistryOwner.get(container))
+        this.setViewTreeSavedStateRegistryOwner(container.findViewTreeSavedStateRegistryOwner())
         GeckoScreenOrientation.getInstance().addListener(orientationChangeListener)
         anchor.addOnAttachStateChangeListener(anchorDetachedListener)
     }
@@ -370,7 +371,7 @@ internal class CFRPopupFullScreenLayout(
         GeckoScreenOrientation.getInstance().removeListener(orientationChangeListener)
         disposeComposition()
         ViewTreeLifecycleOwner.set(this, null)
-        ViewTreeSavedStateRegistryOwner.set(this, null)
+        this.setViewTreeSavedStateRegistryOwner(null)
         windowManager.removeViewImmediate(this)
     }
 

--- a/app/src/main/java/org/mozilla/focus/settings/BaseComposeFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/BaseComposeFragment.kt
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("UnusedMaterialScaffoldPaddingParameter")
+
 package org.mozilla.focus.settings
 
 import android.os.Bundle

--- a/app/src/main/java/org/mozilla/focus/settings/BaseComposeFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/BaseComposeFragment.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
@@ -29,7 +28,6 @@ import com.google.accompanist.insets.rememberInsetsPaddingValues
 import com.google.accompanist.insets.ui.TopAppBar
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.MainActivity
-import org.mozilla.focus.compose.autoMirror
 import org.mozilla.focus.ext.hideToolbar
 import org.mozilla.focus.ui.theme.FocusTheme
 import org.mozilla.focus.ui.theme.focusColors
@@ -103,7 +101,6 @@ abstract class BaseComposeFragment : Fragment() {
                                                 Icon(
                                                     painterResource(id = R.drawable.mozac_ic_back),
                                                     stringResource(R.string.go_back),
-                                                    modifier = Modifier.autoMirror(),
                                                     tint = focusColors.toolbarColor
                                                 )
                                             }

--- a/app/src/test/java/org/mozilla/focus/compose/CFRPopupTest.kt
+++ b/app/src/test/java/org/mozilla/focus/compose/CFRPopupTest.kt
@@ -10,7 +10,7 @@ import android.view.View
 import android.view.ViewManager
 import android.view.WindowManager
 import androidx.lifecycle.ViewTreeLifecycleOwner
-import androidx.savedstate.ViewTreeSavedStateRegistryOwner
+import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
@@ -32,7 +32,7 @@ class CFRPopupTest {
         val popupView = spy(CFRPopupFullScreenLayout(container, mock(), "", mock(), mock()))
 
         assertEquals(ViewTreeLifecycleOwner.get(container), ViewTreeLifecycleOwner.get(popupView))
-        assertEquals(ViewTreeSavedStateRegistryOwner.get(container), ViewTreeSavedStateRegistryOwner.get(popupView))
+        assertEquals(container.findViewTreeSavedStateRegistryOwner(), popupView.findViewTreeSavedStateRegistryOwner())
     }
 
     @Test
@@ -47,7 +47,7 @@ class CFRPopupTest {
         popupView.dismiss()
 
         assertEquals(null, ViewTreeLifecycleOwner.get(popupView))
-        assertEquals(null, ViewTreeSavedStateRegistryOwner.get(popupView))
+        assertEquals(null, popupView.findViewTreeSavedStateRegistryOwner())
         verify(popupView).disposeComposition()
         verify(windowManager).removeViewImmediate(popupView)
     }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object Versions {
-    const val compose_version = "1.1.1"
+    const val compose_version = "1.2.1"
+    const val compose_compiler = "1.1.1"
     const val leakcanary = "2.8.1"
     const val sentry = "5.7.3"
 


### PR DESCRIPTION
Split versioning of compose compiler.
Enable Xjvm-default to allow inheriting from interfaces with '@JvmDefault' members
like AbstractComposeView, NestedScrollConnection.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.









### GitHub Automation
Fixes #7427