### PR TITLE
Bug 1781051 - simplify setting ownerEmail in .taskcluster.yml

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -11,14 +11,11 @@ tasks:
               $if: 'tasks_for in ["cron", "action"]'
               then: '${tasks_for}@noreply.mozilla.org'
               else:
-                  $if: 'event.sender.login == "github-actions[bot]"'
-                  then: 'github-actions[bot]@users.noreply.github.com'
+                  $if: 'tasks_for == "github-push"'
+                  then: '${event.pusher.email}'
                   else:
-                      $if: 'tasks_for == "github-push"'
-                      then: '${event.pusher.email}'
-                      else:
-                          $if: 'tasks_for == "github-pull-request"'
-                          then: '${event.pull_request.user.login}@users.noreply.github.com'
+                      $if: 'tasks_for == "github-pull-request"'
+                      then: '${event.pull_request.user.login}@users.noreply.github.com'
           baseRepoUrl:
               $if: 'tasks_for in ["github-push", "github-release"]'
               then: '${event.repository.html_url}'


### PR DESCRIPTION
Remove special case for github-actions: the github-actions special case breaks chain-of-trust's ability to rebuild the decision task definition: because we don't leave a breadcrumb to record event.sender.login, it has to guess, and if it gets it wrong, chain of trust verification fails.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
