### PR TITLE
For #7659: Disable SettingsAdvancedTest#openLinksInAppsTest.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/SettingsAdvancedTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/SettingsAdvancedTest.kt
@@ -7,6 +7,7 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -43,6 +44,7 @@ class SettingsAdvancedTest {
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
+    @Ignore("Failing: https://github.com/mozilla-mobile/focus-android/issues/7659")
     @SmokeTest
     @Test
     fun openLinksInAppsTest() {


### PR DESCRIPTION
Temporarily disable the test to un-block PRs from landing.
Fixes #7659
Fixes #7659