### PR TITLE
For #7645 Both screens from OnBoarding must support only portrait mode

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingFirstFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingFirstFragment.kt
@@ -21,6 +21,19 @@ import org.mozilla.focus.ui.theme.FocusTheme
 class OnboardingFirstFragment : Fragment() {
     private lateinit var onboardingInteractor: OnboardingInteractor
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        onboardingInteractor = DefaultOnboardingInteractor(
+            DefaultOnboardingController(
+                onboardingStorage = OnboardingStorage(requireContext()),
+                appStore = requireComponents.appStore,
+                activity = requireActivity(),
+                selectedTabId = requireComponents.store.state.selectedTabId,
+            ),
+        )
+        onboardingInteractor.onOnboardingStarted()
+    }
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         val transition =
@@ -33,14 +46,6 @@ class OnboardingFirstFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        onboardingInteractor = DefaultOnboardingInteractor(
-            DefaultOnboardingController(
-                onboardingStorage = OnboardingStorage(requireContext()),
-                appStore = requireComponents.appStore,
-                context = requireActivity(),
-                selectedTabId = requireComponents.store.state.selectedTabId,
-            ),
-        )
         return ComposeView(requireContext()).apply {
             setContent {
                 FocusTheme {

--- a/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingInteractor.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingInteractor.kt
@@ -13,6 +13,7 @@ interface OnboardingInteractor {
     fun onGetStartedButtonClicked()
     fun onMakeFocusDefaultBrowserButtonClicked(activityResultLauncher: ActivityResultLauncher<Intent>)
     fun onActivityResultImplementation(activityResult: ActivityResult)
+    fun onOnboardingStarted()
 }
 
 class DefaultOnboardingInteractor(private val controller: OnboardingController) : OnboardingInteractor {
@@ -30,5 +31,9 @@ class DefaultOnboardingInteractor(private val controller: OnboardingController) 
 
     override fun onActivityResultImplementation(activityResult: ActivityResult) {
         controller.handleActivityResultImplementation(activityResult)
+    }
+
+    override fun onOnboardingStarted() {
+        controller.handleOnboardingStarted()
     }
 }

--- a/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingSecondFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingSecondFragment.kt
@@ -30,6 +30,19 @@ class OnboardingSecondFragment : Fragment() {
         onboardingInteractor.onActivityResultImplementation(it)
     }
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        onboardingInteractor = DefaultOnboardingInteractor(
+            DefaultOnboardingController(
+                onboardingStorage = OnboardingStorage(requireContext()),
+                appStore = requireComponents.appStore,
+                activity = requireActivity(),
+                selectedTabId = requireComponents.store.state.selectedTabId,
+            ),
+        )
+        onboardingInteractor.onOnboardingStarted()
+    }
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         val transition =
@@ -42,14 +55,6 @@ class OnboardingSecondFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        onboardingInteractor = DefaultOnboardingInteractor(
-            DefaultOnboardingController(
-                onboardingStorage = OnboardingStorage(requireContext()),
-                appStore = requireComponents.appStore,
-                context = requireActivity(),
-                selectedTabId = requireComponents.store.state.selectedTabId,
-            ),
-        )
         return ComposeView(requireContext()).apply {
             setContent {
                 FocusTheme {

--- a/app/src/test/java/org/mozilla/focus/onboarding/OnboardingControllerTest.kt
+++ b/app/src/test/java/org/mozilla/focus/onboarding/OnboardingControllerTest.kt
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.focus.onboarding
 
+import android.app.Activity
 import android.os.Build
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
@@ -34,6 +35,9 @@ class OnboardingControllerTest {
     private lateinit var onboardingStorage: OnboardingStorage
     private lateinit var onboardingController: OnboardingController
 
+    @Mock
+    private lateinit var activity: Activity
+
     @Before
     fun init() {
         MockitoAnnotations.openMocks(this)
@@ -41,7 +45,7 @@ class OnboardingControllerTest {
             DefaultOnboardingController(
                 onboardingStorage,
                 appStore,
-                ApplicationProvider.getApplicationContext(),
+                activity,
                 "1",
             ),
         )


### PR DESCRIPTION
Tests and screenshots not needed 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.



### GitHub Automation
Fixes #7645