### PR TITLE
For #7712: Treat ComposeViews as single unit in transitions.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationFragment.kt
@@ -46,6 +46,7 @@ class BiometricAuthenticationFragment : BaseFragment(), AuthenticationDelegate {
                     }
                 }
             }
+            isTransitionGroup = true
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/compose/CFRPopup.kt
+++ b/app/src/main/java/org/mozilla/focus/compose/CFRPopup.kt
@@ -140,6 +140,7 @@ class CFRPopup(
         anchor.post {
             CFRPopupFullScreenLayout(container, anchor, text, properties, onDismiss).apply {
                 this.show()
+                isTransitionGroup = true
             }
         }
     }

--- a/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingFirstFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingFirstFragment.kt
@@ -56,6 +56,7 @@ class OnboardingFirstFragment : Fragment() {
                     )
                 }
             }
+            isTransitionGroup = true
         }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingSecondFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingSecondFragment.kt
@@ -69,6 +69,7 @@ class OnboardingSecondFragment : Fragment() {
                     )
                 }
             }
+            isTransitionGroup = true
         }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/searchwidget/SearchWidgetUtils.kt
+++ b/app/src/main/java/org/mozilla/focus/searchwidget/SearchWidgetUtils.kt
@@ -64,6 +64,7 @@ object SearchWidgetUtils {
                             )
                         }
                     }
+                    isTransitionGroup = true
                 },
             )
         }.show()

--- a/app/src/main/java/org/mozilla/focus/settings/BaseComposeFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/BaseComposeFragment.kt
@@ -114,6 +114,7 @@ abstract class BaseComposeFragment : Fragment() {
                     }
                 }
             }
+            isTransitionGroup = true
         }
     }
 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.


### GitHub Automation
Fixes #7712