### PR TITLE
For #7511 - Custom set to default onboarding page for Huawei users

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingController.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingController.kt
@@ -21,6 +21,8 @@ import mozilla.components.support.utils.Browsers
 import org.mozilla.focus.ext.settings
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.AppStore
+import org.mozilla.focus.utils.ManufacturerCodes
+import org.mozilla.focus.utils.SupportUtils
 import org.mozilla.focus.widget.DefaultBrowserPreference
 
 interface OnboardingController {
@@ -51,6 +53,11 @@ class DefaultOnboardingController(
     }
 
     override fun handleMakeFocusDefaultBrowserButtonClicked(activityResultLauncher: ActivityResultLauncher<Intent>) {
+        if (ManufacturerCodes.isHuawei) {
+            SupportUtils.openDefaultBrowserSumoPage(context)
+            handleFinishOnBoarding()
+            return
+        }
         val isDefault = Browsers.all(context).isDefaultBrowser
         if (isDefault) {
             handleFinishOnBoarding()

--- a/app/src/main/java/org/mozilla/focus/utils/ManufacturerCodes.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/ManufacturerCodes.kt
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.utils
+
+import android.os.Build
+
+object ManufacturerCodes {
+    private const val HUAWEI: String = "HUAWEI"
+    val isHuawei get() = Build.MANUFACTURER.equals(HUAWEI, ignoreCase = true)
+}


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.


### GitHub Automation
Fixes #7511