### PR TITLE
Fix long pressing links in UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ContextMenusTest.kt
@@ -101,7 +101,6 @@ class ContextMenusTest {
 
         searchScreen {
         }.loadPage(tab1Page.url) {
-            verifyPageContent("Tab 1")
             longPressLink("Tab 2")
             verifyLinkContextMenu(tab2Page.url)
             clickContextMenuCopyLink()
@@ -122,7 +121,6 @@ class ContextMenusTest {
 
         searchScreen {
         }.loadPage(tab1Page.url) {
-            verifyPageContent("Tab 1")
             longPressLink("Tab 2")
             verifyLinkContextMenu(tab2Page.url)
             clickShareLink()

--- a/app/src/androidTest/java/org/mozilla/focus/activity/MultitaskingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/MultitaskingTest.kt
@@ -78,7 +78,6 @@ class MultitaskingTest {
         // Load website: Erase button visible, Tabs button not
         searchScreen {
         }.loadPage(tab1.url) {
-            verifyPageContent("Tab 1")
             longPressLink("Tab 2")
             verifyLinkContextMenu(tab2.url)
             openLinkInNewTab()
@@ -136,7 +135,6 @@ class MultitaskingTest {
 
         searchScreen {
         }.loadPage(tab1.url) {
-            verifyPageContent("Tab 1")
             longPressLink("Tab 2")
             openLinkInNewTab()
         }.openTabsTray {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
@@ -16,6 +16,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.Matchers.not
@@ -112,9 +113,27 @@ class BrowserRobot {
         eraseBrowsingButton.check(matches(isDisplayed()))
 
     fun longPressLink(linkText: String) {
-        val link = mDevice.findObject(UiSelector().text(linkText))
-        link.waitForExists(waitingTime)
-        link.longClick()
+        for (i in 1..RETRY_COUNT) {
+            try {
+                mDevice.findObject(UiSelector().text(linkText))
+                    .also {
+                        it.waitForExists(waitingTime)
+                        it.longClick()
+                    }
+
+                break
+            } catch (e: UiObjectNotFoundException) {
+                if (i == RETRY_COUNT) {
+                    throw e
+                } else {
+                    browserScreen {
+                    }.openMainMenu {
+                    }.clickReloadButton {
+                    }
+                    progressBar.waitUntilGone(waitingTime)
+                }
+            }
+        }
     }
 
     fun openLinkInNewTab() {


### PR DESCRIPTION
For #7756 #7754 #7748 #7739 #7680 #7746 #7745 fix for long pressing links in UI tests. 
All tests successfully passed 100x on Firebase. ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.


### GitHub Automation
Fixes #7756
Fixes #7754
Fixes #7748
Fixes #7739
Fixes #7680
Fixes #7746
Fixes #7745