### PR TITLE
No issue: Clean up SessionLoadedIdlingResource inits

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
@@ -34,6 +34,8 @@ import java.time.LocalDate
 
 class BrowserRobot {
 
+    private lateinit var sessionLoadedIdlingResource: SessionLoadedIdlingResource
+
     val progressBar =
         mDevice.findObject(
             UiSelector().resourceId("$packageName:id/progress"),
@@ -60,9 +62,8 @@ class BrowserRobot {
     }
 
     fun verifyPageURL(expectedText: String) {
-        val sessionLoadedIdlingResource = SessionLoadedIdlingResource()
-
         browserURLbar.waitForExists(waitingTime)
+        sessionLoadedIdlingResource = SessionLoadedIdlingResource()
 
         runWithIdleRes(sessionLoadedIdlingResource) {
             assertTrue(

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/CustomTabRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/CustomTabRobot.kt
@@ -24,6 +24,9 @@ import org.mozilla.focus.helpers.TestHelper.waitingTime
 import org.mozilla.focus.idlingResources.SessionLoadedIdlingResource
 
 class CustomTabRobot {
+
+    private lateinit var sessionLoadedIdlingResource: SessionLoadedIdlingResource
+
     val progressBar: UiObject =
         mDevice.findObject(
             UiSelector().resourceId("$packageName:id/progress"),
@@ -59,7 +62,7 @@ class CustomTabRobot {
     }
 
     fun verifyPageURL(expectedText: String) {
-        val sessionLoadedIdlingResource = SessionLoadedIdlingResource()
+        sessionLoadedIdlingResource = SessionLoadedIdlingResource()
 
         runWithIdleRes(sessionLoadedIdlingResource) {
             mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SearchRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SearchRobot.kt
@@ -76,10 +76,14 @@ class SearchRobot {
     }
 
     class Transition {
+
+        private lateinit var sessionLoadedIdlingResource: SessionLoadedIdlingResource
+
         fun loadPage(url: String, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            val sessionLoadedIdlingResource = SessionLoadedIdlingResource()
             val geckoEngineView = mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView"))
             val trackingProtectionDialog = mDevice.findObject(UiSelector().resourceId("$packageName:id/message"))
+
+            sessionLoadedIdlingResource = SessionLoadedIdlingResource()
 
             searchScreen { typeInSearchBar(url) }
             pressEnterKey()

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsMozillaMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsMozillaMenuRobot.kt
@@ -26,6 +26,9 @@ import org.mozilla.focus.helpers.TestHelper.waitingTime
 import org.mozilla.focus.idlingResources.SessionLoadedIdlingResource
 
 class SettingsMozillaMenuRobot {
+
+    private lateinit var sessionLoadedIdlingResource: SessionLoadedIdlingResource
+
     fun verifyMozillaMenuItems() {
         mozillaSettingsList.waitForExists(waitingTime)
         aboutFocusPageLink.check(matches(isDisplayed()))
@@ -40,7 +43,8 @@ class SettingsMozillaMenuRobot {
         val versionName = packageInfo.versionName
         val gvBuildId = org.mozilla.geckoview.BuildConfig.MOZ_APP_BUILDID
         val gvVersion = org.mozilla.geckoview.BuildConfig.MOZ_APP_VERSION
-        val sessionLoadedIdlingResource = SessionLoadedIdlingResource()
+
+        sessionLoadedIdlingResource = SessionLoadedIdlingResource()
 
         runWithIdleRes(sessionLoadedIdlingResource) {
             assertTrue(


### PR DESCRIPTION
In testing https://github.com/mozilla-mobile/focus-android/issues/7738 locally, I wasn't able to reproduce after changing the `SessionLoadedIdlingResource` inits. This matches the same init approach we use in Fenix (e.g, [here](https://github.com/mozilla-mobile/fenix/blob/main/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt#L70)). Might be related to the recent `UiObjectNotFound` problems where there's a race condition on the page being loaded. I'm guessing the IdlingResource wasn't init properly or is used improperly (should `isIdleNow()` be called somewhere?).