### PR TITLE
For #6531 new shortcutsDoNotOpenInNewTabTest UI smoke test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/ShortcutsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ShortcutsTest.kt
@@ -12,10 +12,12 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.focus.activity.robots.browserScreen
+import org.mozilla.focus.activity.robots.homeScreen
 import org.mozilla.focus.activity.robots.searchScreen
 import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityFirstrunTestRule
 import org.mozilla.focus.helpers.MockWebServerHelper
+import org.mozilla.focus.helpers.TestAssetHelper
 import org.mozilla.focus.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.focus.testAnnotations.SmokeTest
 import java.io.IOException
@@ -70,6 +72,33 @@ class ShortcutsTest {
             clickRenameShortcut()
             renameShortcutAndSave(webPage.newTitle)
             verifyPageShortcutExists(webPage.newTitle)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun shortcutsDoNotOpenInNewTabTest() {
+        val tab1 = TestAssetHelper.getGenericTabAsset(webServer, 1)
+        val tab2 = TestAssetHelper.getGenericTabAsset(webServer, 2)
+
+        searchScreen {
+        }.loadPage(tab1.url) {
+        }.openMainMenu {
+            clickAddToShortcuts()
+        }
+        browserScreen {
+        }.clearBrowsingData {
+            verifyPageShortcutExists(tab1.title)
+        }
+
+        searchScreen {
+        }.loadPage(tab2.url) {
+        }.openSearchBar {
+        }
+
+        homeScreen {
+        }.clickPageShortcut(tab1.title) {
+            verifyTabsCounterNotShown()
         }
     }
 


### PR DESCRIPTION
For #6531 new `shortcutsDoNotOpenInNewTabTest` UI smoke test ✅ successfully passed 100x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.


### GitHub Automation
Fixes #6531