### PR TITLE
For #7741 #7740 and #7668 fix flaky UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
@@ -163,17 +163,51 @@ class BrowserRobot {
         assertTrue(shareAppsList.waitForExists(waitingTime))
 
     fun clickPlayButton() {
-        val playButton =
-            mDevice.findObject(UiSelector().text("Play"))
-        playButton.waitForExists(pageLoadingTime)
-        playButton.click()
+        for (i in 1..RETRY_COUNT) {
+            try {
+                mDevice.findObject(UiSelector().text("Play"))
+                    .also {
+                        it.waitForExists(waitingTime)
+                        it.click()
+                    }
+
+                break
+            } catch (e: UiObjectNotFoundException) {
+                if (i == RETRY_COUNT) {
+                    throw e
+                } else {
+                    browserScreen {
+                    }.openMainMenu {
+                    }.clickReloadButton {
+                    }
+                    progressBar.waitUntilGone(waitingTime)
+                }
+            }
+        }
     }
 
     fun clickPauseButton() {
-        val pauseButton =
-            mDevice.findObject(UiSelector().text("Pause"))
-        pauseButton.waitForExists(pageLoadingTime)
-        pauseButton.click()
+        for (i in 1..RETRY_COUNT) {
+            try {
+                mDevice.findObject(UiSelector().text("Pause"))
+                    .also {
+                        it.waitForExists(waitingTime)
+                        it.click()
+                    }
+
+                break
+            } catch (e: UiObjectNotFoundException) {
+                if (i == RETRY_COUNT) {
+                    throw e
+                } else {
+                    browserScreen {
+                    }.openMainMenu {
+                    }.clickReloadButton {
+                    }
+                    progressBar.waitUntilGone(waitingTime)
+                }
+            }
+        }
     }
 
     fun waitForPlaybackToStart() {


### PR DESCRIPTION
For #7741 #7740 and #7668 fix flaky UI tests.

`testMediaContentNotification` ✅ successfully passed 100x on Firebase
`blockAudioVideoAutoplayPermissionTest` ✅ successfully passed 100x on Firebase
`blockAudioAutoplayPermissionOnMutedVideoTest` ✅ successfully passed 100x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.


### GitHub Automation
Fixes #7741
Fixes #7740
Fixes #7668