### PR TITLE
For #7678 - Redone all the navigation from lockscreen,search widget and custom tab

### DIFF
--- a/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationFragment.kt
@@ -19,6 +19,7 @@ import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.fragment.BaseFragment
+import org.mozilla.focus.searchwidget.ExternalIntentNavigation
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.ui.theme.FocusTheme
 
@@ -88,6 +89,11 @@ class BiometricAuthenticationFragment : BaseFragment(), AuthenticationDelegate {
 
     @VisibleForTesting
     internal fun onAuthenticated() {
+        ExternalIntentNavigation.handleAppNavigation(
+            bundle = arguments,
+            context = requireContext(),
+        )
+
         val tabId = requireComponents.store.state.selectedTabId
         requireComponents.appStore.dispatch(AppAction.Unlock(tabId))
         dismiss()
@@ -100,5 +106,10 @@ class BiometricAuthenticationFragment : BaseFragment(), AuthenticationDelegate {
 
     companion object {
         const val FRAGMENT_TAG = "biometric-authentication-fragment"
+        fun createWithDestinationData(bundle: Bundle? = null): BiometricAuthenticationFragment {
+            val fragment = BiometricAuthenticationFragment()
+            fragment.arguments = bundle
+            return fragment
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/biometrics/LockObserver.kt
+++ b/app/src/main/java/org/mozilla/focus/biometrics/LockObserver.kt
@@ -47,14 +47,14 @@ class LockObserver(
                 totalSites = DefaultTopSitesStorage.TOP_SITES_MAX_LIMIT,
                 frecencyConfig = null,
             )
-            if (tabCount == 0L && topSitesList.isNullOrEmpty()) {
+            if (tabCount == 0L && topSitesList.isEmpty()) {
                 return@launch
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                 context.settings.shouldUseBiometrics() &&
                 context.canUseBiometricFeature()
             ) {
-                appStore.dispatch(AppAction.Lock)
+                appStore.dispatch(AppAction.Lock())
             }
         }
     }

--- a/app/src/main/java/org/mozilla/focus/navigation/MainActivityNavigation.kt
+++ b/app/src/main/java/org/mozilla/focus/navigation/MainActivityNavigation.kt
@@ -5,6 +5,7 @@
 package org.mozilla.focus.navigation
 
 import android.os.Build
+import android.os.Bundle
 import org.mozilla.experiments.nimbus.internal.FeatureHolder
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.MainActivity
@@ -206,8 +207,11 @@ class MainActivityNavigation(
 
     /**
      * Lock app.
+     *
+     * @param bundle it is used for app navigation. If the user can unlock with success he should
+     * be redirected to a certain screen. It comes from the external intent.
      */
-    fun lock() {
+    fun lock(bundle: Bundle? = null) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             throw IllegalStateException("Trying to lock unsupported device")
         }
@@ -230,7 +234,11 @@ class MainActivityNavigation(
 
         fragmentManager
             .beginTransaction()
-            .replace(R.id.container, BiometricAuthenticationFragment(), BiometricAuthenticationFragment.FRAGMENT_TAG)
+            .replace(
+                R.id.container,
+                BiometricAuthenticationFragment.createWithDestinationData(bundle),
+                BiometricAuthenticationFragment.FRAGMENT_TAG,
+            )
             .commit()
     }
 

--- a/app/src/main/java/org/mozilla/focus/navigation/Navigator.kt
+++ b/app/src/main/java/org/mozilla/focus/navigation/Navigator.kt
@@ -47,7 +47,7 @@ class Navigator(
                 screen.tabId,
             )
             is Screen.FirstRun -> navigation.firstRun()
-            is Screen.Locked -> navigation.lock()
+            is Screen.Locked -> navigation.lock(screen.bundle)
             is Screen.Settings -> navigation.settings(screen.page)
             is Screen.SitePermissionOptionsScreen -> navigation.sitePermissionOptionsFragment(screen.sitePermission)
             is Screen.OnboardingSecondScreen -> navigation.showOnBoardingSecondScreen()

--- a/app/src/main/java/org/mozilla/focus/perf/Performance.kt
+++ b/app/src/main/java/org/mozilla/focus/perf/Performance.kt
@@ -8,7 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.BatteryManager
-import mozilla.components.support.utils.SafeIntent
+import android.os.Bundle
 import android.provider.Settings as AndroidSettings
 
 /**
@@ -18,7 +18,7 @@ object Performance {
 
     private const val EXTRA_IS_PERFORMANCE_TEST = "performancetest"
 
-    fun processIntentIfPerformanceTest(intent: SafeIntent, context: Context) = isPerformanceTest(intent, context)
+    fun processIntentIfPerformanceTest(bundle: Bundle?, context: Context) = isPerformanceTest(bundle, context)
 
     /**
      * This checks for the charging state and ADB debugging in case another application tries to
@@ -26,8 +26,8 @@ object Performance {
      * it is for testing visual metrics. These checks aren't foolproof but most of our users won't
      * have ADB on and charging at the same time when running Firefox.
      */
-    private fun isPerformanceTest(intent: SafeIntent, context: Context): Boolean {
-        if (!intent.getBooleanExtra(EXTRA_IS_PERFORMANCE_TEST, false)) {
+    private fun isPerformanceTest(bundle: Bundle?, context: Context): Boolean {
+        if (bundle == null || !bundle.getBoolean(EXTRA_IS_PERFORMANCE_TEST, false)) {
             return false
         }
 

--- a/app/src/main/java/org/mozilla/focus/searchwidget/ExternalIntentNavigation.kt
+++ b/app/src/main/java/org/mozilla/focus/searchwidget/ExternalIntentNavigation.kt
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.searchwidget
+
+import android.content.Context
+import android.os.Bundle
+import androidx.annotation.VisibleForTesting
+import mozilla.components.browser.state.state.SessionState
+import mozilla.components.feature.search.widget.BaseVoiceSearchActivity
+import mozilla.telemetry.glean.private.NoExtras
+import org.mozilla.focus.GleanMetrics.SearchWidget
+import org.mozilla.focus.activity.IntentReceiverActivity
+import org.mozilla.focus.ext.components
+import org.mozilla.focus.ext.settings
+import org.mozilla.focus.perf.Performance
+import org.mozilla.focus.state.AppAction
+import org.mozilla.focus.utils.SearchUtils
+
+/**
+ * Handles all actions from outside the app that starts it.
+ */
+object ExternalIntentNavigation {
+
+    /**
+     * Handle all the navigation from search widget, app icon, lockscreen and custom tab.
+     *
+     * @param bundle External Intent [Bundle] with data based on which destination will be computed.
+     * @param context Android [Context] used for system interactions or accessing dependencies.
+     */
+    fun handleAppNavigation(
+        bundle: Bundle?,
+        context: Context,
+    ) {
+        if (handleWidgetVoiceSearch(bundle, context)) return
+
+        if (handleWidgetTextSearch(bundle, context)) return
+
+        if (handleBrowserTabAlreadyOpen(context)) return
+
+        handleAppOpened(bundle, context)
+    }
+
+    /**
+     * Handle the app being opened with no specified destination.
+     * This can show the onboarding or the app's home screen.
+     */
+    @VisibleForTesting
+    internal fun handleAppOpened(
+        bundle: Bundle?,
+        context: Context,
+    ) {
+        if (context.settings.isFirstRun &&
+            !Performance.processIntentIfPerformanceTest(bundle, context)
+        ) {
+            context.components.appStore.dispatch(AppAction.ShowFirstRun)
+        }
+    }
+
+    /**
+     * Try navigating to the currently selected tab.
+     *
+     * @return Whether or not the app navigated to the currently selected tab.
+     */
+    @VisibleForTesting
+    internal fun handleBrowserTabAlreadyOpen(context: Context): Boolean {
+        val tabId = context.components.store.state.selectedTabId
+
+        return when (tabId != null) {
+            true -> {
+                context.components.appStore.dispatch(AppAction.OpenTab(tabId))
+                true
+            }
+            else -> false
+        }
+    }
+
+    /**
+     * Try navigating to search by text.
+     *
+     * @return Whether or not a widget interaction was detected and the app opened the search screen for it.
+     */
+    @VisibleForTesting
+    internal fun handleWidgetTextSearch(bundle: Bundle?, context: Context): Boolean {
+        val searchWidgetIntent = bundle?.getBoolean(IntentReceiverActivity.SEARCH_WIDGET_EXTRA, false)
+
+        return when (searchWidgetIntent == true) {
+            true -> {
+                SearchWidget.newTabButton.record(NoExtras())
+                context.components.appStore.dispatch(AppAction.ShowHomeScreen)
+                true
+            }
+            else -> false
+        }
+    }
+
+    /**
+     * Try opening a new tab for the user voice search.
+     *
+     * @return Whether or not a voice search was identified and the app opened a new tab for it.
+     */
+    @VisibleForTesting
+    internal fun handleWidgetVoiceSearch(bundle: Bundle?, context: Context): Boolean {
+        val voiceSearchText = bundle?.getString(BaseVoiceSearchActivity.SPEECH_PROCESSING)
+
+        return when (!voiceSearchText.isNullOrEmpty()) {
+            true -> {
+                val tabId = context.components.tabsUseCases.addTab(
+                    url = SearchUtils.createSearchUrl(
+                        context,
+                        voiceSearchText,
+                    ),
+                    source = SessionState.Source.External.ActionSend(null),
+                    searchTerms = voiceSearchText,
+                    selectTab = true,
+                    private = true,
+                )
+                context.components.appStore.dispatch(AppAction.OpenTab(tabId))
+                true
+            }
+            else -> false
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/state/AppAction.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppAction.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.focus.state
 
+import android.os.Bundle
 import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.lib.state.Action
 import org.mozilla.focus.settings.permissions.permissionoptions.SitePermission
@@ -51,7 +52,7 @@ sealed class AppAction : Action {
     /**
      * The app should get locked.
      */
-    object Lock : AppAction()
+    data class Lock(val bundle: Bundle? = null) : AppAction()
 
     /**
      * The app should get unlocked.

--- a/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppReducer.kt
@@ -23,7 +23,7 @@ object AppReducer : Reducer<AppState, AppAction> {
             is AppAction.HideTabs -> hideTabs(state)
             is AppAction.ShowFirstRun -> showFirstRun(state)
             is AppAction.FinishFirstRun -> finishFirstRun(state, action)
-            is AppAction.Lock -> lock(state)
+            is AppAction.Lock -> lock(state, action)
             is AppAction.Unlock -> unlock(state, action)
             is AppAction.OpenSettings -> openSettings(state, action)
             is AppAction.NavigateUp -> navigateUp(state, action)
@@ -128,8 +128,8 @@ private fun showHomeScreen(state: AppState): AppState {
 /**
  * Lock the application.
  */
-private fun lock(state: AppState): AppState {
-    return state.copy(screen = Screen.Locked)
+private fun lock(state: AppState, action: AppAction.Lock): AppState {
+    return state.copy(screen = Screen.Locked(action.bundle))
 }
 
 /**

--- a/app/src/main/java/org/mozilla/focus/state/AppState.kt
+++ b/app/src/main/java/org/mozilla/focus/state/AppState.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.focus.state
 
+import android.os.Bundle
 import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.lib.state.State
 import org.mozilla.focus.settings.permissions.permissionoptions.SitePermission
@@ -79,8 +80,11 @@ sealed class Screen {
 
     /**
      * The application is locked (and requires unlocking).
+     *
+     * @param bundle it is used for app navigation. If the user can unlock with success he should
+     * be redirected to a certain screen.It comes from the external intent.
      */
-    object Locked : Screen()
+    data class Locked(val bundle: Bundle? = null) : Screen()
     data class SitePermissionOptionsScreen(val sitePermission: SitePermission) : Screen()
     data class Settings(
         val page: Page = Page.Start,

--- a/app/src/test/java/org/mozilla/focus/biometrics/BiometricAuthenticationFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/focus/biometrics/BiometricAuthenticationFragmentTest.kt
@@ -16,14 +16,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mozilla.focus.R
-import org.mozilla.focus.ext.components
-import org.mozilla.focus.state.Screen
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -69,26 +66,6 @@ class BiometricAuthenticationFragmentTest {
         fragment.showBiometricPrompt(biometricPromptAuth)
 
         verify(biometricPromptAuth, never()).requestAuthentication(titleBiometric, subTitleBiometric)
-    }
-
-    @Test
-    fun `GIVEN biometric authentication fragment WHEN on Auth Success is  called THEN AppAction Unlock should be dispatched`() {
-        doAnswer {}.`when`(fragment).dismiss()
-
-        fragment.onAuthSuccess()
-
-        verify(fragment).onAuthenticated()
-        assertEquals(testContext.components.appStore.state.screen, Screen.Home)
-        verify(fragment).dismiss()
-    }
-
-    @Test
-    fun `GIVEN biometric authentication fragment WHEN on Auth Success is  called THEN fragment should be dismissed`() {
-        doReturn(fragmentTransaction).`when`(fragmentTransaction).remove(fragment)
-
-        fragment.onAuthSuccess()
-
-        verify(fragmentTransaction).remove(fragment)
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/focus/searchwidget/ExternalIntentNavigationTest.kt
+++ b/app/src/test/java/org/mozilla/focus/searchwidget/ExternalIntentNavigationTest.kt
@@ -1,0 +1,183 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.searchwidget
+
+import android.app.Activity
+import android.content.Context
+import android.os.Bundle
+import mozilla.components.browser.state.selector.allTabs
+import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
+import mozilla.components.browser.state.selector.privateTabs
+import mozilla.components.browser.state.state.SessionState
+import mozilla.components.feature.search.widget.BaseVoiceSearchActivity
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.telemetry.glean.testing.GleanTestRule
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.runner.RunWith
+import org.mozilla.focus.GleanMetrics.SearchWidget
+import org.mozilla.focus.activity.IntentReceiverActivity
+import org.mozilla.focus.ext.components
+import org.mozilla.focus.ext.settings
+import org.mozilla.focus.perf.Performance
+import org.mozilla.focus.state.Screen
+import org.mozilla.focus.utils.SearchUtils
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+
+@RunWith(RobolectricTestRunner::class)
+internal class ExternalIntentNavigationTest {
+    @get:Rule
+    val gleanTestRule = GleanTestRule(testContext)
+
+    private val activity: Activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+    private val appStore = activity.components.appStore
+
+    @Test
+    fun `GIVEN the onboarding should be shown and the app is not used in performance tests WHEN the app is opened THEN show the onboarding`() {
+        activity.settings.isFirstRun = true
+
+        ExternalIntentNavigation.handleAppOpened(null, activity)
+        appStore.waitUntilIdle()
+
+        assertEquals(Screen.FirstRun, appStore.state.screen)
+    }
+
+    @Test
+    @Config(shadows = [ShadowPerformance::class])
+    fun `GIVEN the onboarding should be shown and the app is used in a performance test WHEN the app is opened THEN show the homescreen`() {
+        activity.settings.isFirstRun = true
+
+        ExternalIntentNavigation.handleAppOpened(null, activity)
+        appStore.waitUntilIdle()
+
+        assertEquals(Screen.Home, appStore.state.screen)
+    }
+
+    @Test
+    @Config(shadows = [ShadowPerformance::class])
+    fun `GIVEN the onboarding should not be shown and in a performance test WHEN the app is opened THEN show the home screen`() {
+        activity.settings.isFirstRun = false
+
+        ExternalIntentNavigation.handleAppOpened(null, activity)
+        appStore.waitUntilIdle()
+
+        assertEquals(Screen.Home, appStore.state.screen)
+    }
+
+    @Test
+    fun `GIVEN the onboarding should not be shown and not in a performance test WHEN the app is opened THEN show the home screen`() {
+        activity.settings.isFirstRun = false
+
+        ExternalIntentNavigation.handleAppOpened(null, activity)
+        appStore.waitUntilIdle()
+
+        assertEquals(Screen.Home, appStore.state.screen)
+    }
+
+    @Test
+    fun `GIVEN a tab is already open WHEN trying to navigate to the current tab THEN navigate to it and return true`() {
+        activity.components.tabsUseCases.addTab(url = "https://mozilla.com")
+        activity.components.store.waitUntilIdle()
+
+        val result = ExternalIntentNavigation.handleBrowserTabAlreadyOpen(activity)
+        activity.components.appStore.waitUntilIdle()
+
+        assertTrue(result)
+        val selectedTabId = activity.components.store.state.selectedTabId!!
+        assertEquals(Screen.Browser(selectedTabId, false), activity.components.appStore.state.screen)
+    }
+
+    @Test
+    fun `GIVEN no tabs are currently open WHEN trying to navigate to the current tab THEN navigate home and return false`() {
+        val result = ExternalIntentNavigation.handleBrowserTabAlreadyOpen(activity)
+        activity.components.appStore.waitUntilIdle()
+
+        assertFalse(result)
+        assertEquals(Screen.Home, activity.components.appStore.state.screen)
+    }
+
+    @Test
+    fun `GIVEN a text search from the search widget WHEN handling widget interactions THEN record telemetry, show the home screen and return true`() {
+        val bundle = Bundle().apply {
+            putBoolean(IntentReceiverActivity.SEARCH_WIDGET_EXTRA, true)
+        }
+
+        val result = ExternalIntentNavigation.handleWidgetTextSearch(bundle, activity)
+        appStore.waitUntilIdle()
+
+        assertTrue(result)
+        assertNotNull(SearchWidget.newTabButton.testGetValue())
+        assertEquals(Screen.Home, appStore.state.screen)
+    }
+
+    @Test
+    fun `GIVEN no text search from the search widget WHEN handling widget interactions THEN don't record telemetry, show the home screen and false true`() {
+        val bundle = Bundle()
+
+        val result = ExternalIntentNavigation.handleWidgetTextSearch(bundle, activity)
+        appStore.waitUntilIdle()
+
+        assertFalse(result)
+        assertNull(SearchWidget.newTabButton.testGetValue())
+        assertEquals(Screen.Home, appStore.state.screen)
+    }
+
+    @Test
+    fun `GIVEN a voice search WHEN handling widget interactions THEN create and open a new tab and return true`() {
+        val browserStore = activity.components.store
+        val searchArgument = "test"
+        val bundle = Bundle().apply {
+            putString(BaseVoiceSearchActivity.SPEECH_PROCESSING, searchArgument)
+        }
+
+        val result = ExternalIntentNavigation.handleWidgetVoiceSearch(bundle, activity)
+
+        assertTrue(result)
+        browserStore.waitUntilIdle()
+        assertEquals(1, browserStore.state.allTabs.size)
+        assertEquals(1, browserStore.state.privateTabs.size)
+        val voiceSearchTab = browserStore.state.privateTabs[0]
+        assertEquals(voiceSearchTab, browserStore.state.findCustomTabOrSelectedTab())
+        assertEquals(SearchUtils.createSearchUrl(activity, searchArgument), voiceSearchTab.content.url)
+        assertEquals(SessionState.Source.External.ActionSend(null), voiceSearchTab.source)
+        assertEquals(searchArgument, voiceSearchTab.content.searchTerms)
+        appStore.waitUntilIdle()
+        assertEquals(Screen.Browser(voiceSearchTab.id, false), appStore.state.screen)
+    }
+
+    @Test
+    fun `GIVEN no voice search WHEN handling widget interactions THEN don't open a new tab and return false`() {
+        val browserStore = activity.components.store
+        val bundle = Bundle()
+
+        val result = ExternalIntentNavigation.handleWidgetVoiceSearch(bundle, activity)
+
+        assertFalse(result)
+        browserStore.waitUntilIdle()
+        assertEquals(0, browserStore.state.allTabs.size)
+        appStore.waitUntilIdle()
+        assertEquals(Screen.Home, appStore.state.screen)
+    }
+}
+
+/**
+ * Shadow of [Performance] that will have [processIntentIfPerformanceTest] always return `true`.
+ */
+@Implements(Performance::class)
+class ShadowPerformance {
+    @Implementation
+    @Suppress("Unused_Parameter")
+    fun processIntentIfPerformanceTest(bundle: Bundle?, context: Context) = true
+}


### PR DESCRIPTION
If the lockScreen is active doesn't matter from where the user enters in the app the lockScreen should appear. 

If a browsing page is open and the users closes the app but doesn't removed it from background , when he opens again the app he should be redirected to that page (if the lockScreen is active it should appear first and after that the browsing page ).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.










### GitHub Automation
Fixes #7678