### PR TITLE
For #7580 re-enable Open custom tab in focus UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
@@ -96,7 +96,6 @@ class CustomTabTest {
 
     @SmokeTest
     @Test
-    @Ignore("See https://github.com/mozilla-mobile/focus-android/issues/7580")
     fun openCustomTabInFocusTest() {
         val browserPage = getGenericAsset(webServer)
         val customTabPage = getGenericTabAsset(webServer, 1)
@@ -105,7 +104,7 @@ class CustomTabTest {
         homeScreen {
             // The new onboarding moved to experiments, remove comment when implemented again in Focus
             // clickStartBrowsing()
-            skipFirstRun()
+            closeOnboarding()
         }
 
         searchScreen {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/robots/HomeScreenRobot.kt
@@ -30,6 +30,8 @@ class HomeScreenRobot {
 
     fun skipFirstRun() = onView(withId(R.id.skip)).perform(click())
 
+    fun closeOnboarding() = onboardingCloseButton.clickAndWaitForNewWindow(waitingTime)
+
     fun verifyOnboardingFirstSlide() {
         firstSlide.check(matches(isDisplayed()))
     }


### PR DESCRIPTION
For #7580 re-enable `openCustomTabInFocusTest` UI test ✅ successfully passed 100x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
