### PR TITLE
Remove extraneous coroutines_version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ import org.mozilla.focus.gradle.tasks.GithubDetailsTask
 
 buildscript {
     ext.espresso_version = '3.4.0'
-    ext.coroutines_version = '1.4.2'
     ext.jna_version = "5.8.0"
     // Pinning the last working version of the service-telemetry component until we decide
     // what we want to do with telemetry in the app.


### PR DESCRIPTION
We use the one set by Dependencies.kt, so remove this one to avoid confusion.