### PR TITLE
No issue: remove old onboarding UI tests from FirstRunTest class

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/FirstRunTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/FirstRunTest.kt
@@ -7,7 +7,6 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,34 +39,6 @@ class FirstRunTest {
     fun stopWebServer() {
         webServer.shutdown()
         featureSettingsHelper.resetAllFeatureFlags()
-    }
-
-    @Test
-    @Ignore("See https://github.com/mozilla-mobile/focus-android/issues/7580")
-    fun firstRunOnboardingTest() {
-        homeScreen {
-            verifyOnboardingFirstSlide()
-            clickOnboardingNextBtn()
-            verifyOnboardingSecondSlide()
-            clickOnboardingNextBtn()
-            verifyOnboardingThirdSlide()
-            clickOnboardingNextBtn()
-            verifyOnboardingLastSlide()
-            clickOnboardingFinishBtn()
-            verifyEmptySearchBar()
-        }
-    }
-
-    @Test
-    @Ignore("See https://github.com/mozilla-mobile/focus-android/issues/7580")
-    fun skipFirstRunOnboardingTest() {
-        homeScreen {
-            verifyOnboardingFirstSlide()
-            clickOnboardingNextBtn()
-            verifyOnboardingSecondSlide()
-            skipFirstRun()
-            verifyEmptySearchBar()
-        }
     }
 
     @SmokeTest


### PR DESCRIPTION
Moved the test to OldFirstRunTest class in #7791
Forgot to delete them from FirstRunTest class.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
