### PR TITLE
For #7838 re-enable UI tests with frequent ANR

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
@@ -14,7 +14,6 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -65,7 +64,6 @@ class CustomTabTest {
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
-    @Ignore("Crashing, see: https://github.com/mozilla-mobile/focus-android/issues/6437")
     @SmokeTest
     @Test
     fun testCustomTabUI() {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/EnhancedTrackingProtectionSettingsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/EnhancedTrackingProtectionSettingsTest.kt
@@ -253,7 +253,6 @@ class EnhancedTrackingProtectionSettingsTest {
         }
     }
 
-    @Ignore("Failing, see https://github.com/mozilla-mobile/focus-android/issues/6661")
     @SmokeTest
     @Test
     fun addURLToTPExceptionsListTest() {
@@ -277,7 +276,6 @@ class EnhancedTrackingProtectionSettingsTest {
         }
     }
 
-    @Ignore("Failing, see https://github.com/mozilla-mobile/focus-android/issues/6425")
     @SmokeTest
     @Test
     fun removeOneExceptionURLTest() {
@@ -307,7 +305,6 @@ class EnhancedTrackingProtectionSettingsTest {
         }
     }
 
-    @Ignore("Failing, see https://github.com/mozilla-mobile/focus-android/issues/6679")
     @SmokeTest
     @Test
     fun removeAllExceptionURLTest() {

--- a/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/ErrorPagesTest.kt
@@ -6,7 +6,6 @@ package org.mozilla.focus.activity
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -47,7 +46,6 @@ class ErrorPagesTest {
     }
 
     @Test
-    @Ignore("See https://github.com/mozilla-mobile/focus-android/issues/6971")
     fun noNetworkConnectionErrorPageTest() {
         val pageUrl = "mozilla.org"
 

--- a/app/src/androidTest/java/org/mozilla/focus/activity/WebControlsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/WebControlsTest.kt
@@ -96,7 +96,6 @@ class WebControlsTest {
         }
     }
 
-    @Ignore("See https://github.com/mozilla-mobile/focus-android/issues/7667")
     @SmokeTest
     @Test
     fun emailLinkTest() {


### PR DESCRIPTION
For #7838 re-enable UI tests with frequent ANR.

`noNetworkConnectionErrorPageTest` ✅ successfully passed 100x on Firebase
`removeAllExceptionURLTest` ✅ successfully passed 100x on Firebase
`addURLToTPExceptionsListTest` ✅ successfully passed 100x on Firebase
`removeOneExceptionURLTest` ✅ successfully passed 100x on Firebase
`testCustomTabUI` ✅ successfully passed 100x on Firebase
`emailLinkTest` ✅ successfully passed 100x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.


### GitHub Automation
Fixes #7838