### PR TITLE
Close #7848: Disable automatic memory trimming middlware.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -155,7 +155,18 @@ class Components(
                 AdsTelemetryMiddleware(adsTelemetry),
                 BlockedTrackersMiddleware(context),
                 RecordingDevicesMiddleware(context),
-            ) + EngineMiddleware.create(engine) + CfrMiddleware(context),
+                CfrMiddleware(context),
+            ) + EngineMiddleware.create(
+                engine,
+                // We are disabling automatic suspending of engine sessions under memory pressure.
+                // Instead we solely rely on GeckoView and the Android system to reclaim memory
+                // when needed. For details, see:
+                // https://bugzilla.mozilla.org/show_bug.cgi?id=1752594
+                // https://github.com/mozilla-mobile/fenix/issues/12731
+                // https://github.com/mozilla-mobile/android-components/issues/11300
+                // https://github.com/mozilla-mobile/android-components/issues/11653
+                trimMemoryAutomatically = false,
+            ),
         ).apply {
             MediaSessionFeature(context, MediaSessionService::class.java, this).start()
         }


### PR DESCRIPTION
We want to keep this feature off because GeckoView suspends engine sessions automatically in order to reclaim memory.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
