### PR TITLE
For #7838 re-enable notificationEraseAndOpenButtonTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/EraseBrowsingDataTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/EraseBrowsingDataTest.kt
@@ -79,7 +79,6 @@ class EraseBrowsingDataTest {
 
     @SmokeTest
     @Test
-    @Ignore("See https://github.com/mozilla-mobile/focus-android/issues/7037")
     fun notificationEraseAndOpenButtonTest() {
         val testPage = getGenericTabAsset(webServer, 1)
 


### PR DESCRIPTION
For #7838 re-enable `notificationEraseAndOpenButtonTest` UI test ✅ successfully passed 100x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.


### GitHub Automation
Fixes #7838