### PR TITLE
For #6792 - The colors of the icons from the toolbar should be in contrast with the toolbar background color

### DIFF
--- a/app/src/main/java/org/mozilla/focus/utils/SupportUtils.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/SupportUtils.kt
@@ -9,10 +9,13 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.feature.customtabs.createCustomTabConfigFromIntent
 import org.mozilla.focus.BuildConfig
+import org.mozilla.focus.R
 import org.mozilla.focus.activity.CustomTabActivity
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.getPackageInfoCompat
@@ -104,6 +107,11 @@ object SupportUtils {
     }
 
     fun openUrlInCustomTab(activity: FragmentActivity, destinationUrl: String) {
+        activity.intent.putExtra(
+            CustomTabsIntent.EXTRA_TOOLBAR_COLOR,
+            ContextCompat.getColor(activity, R.color.settings_background),
+        )
+
         val tabId = activity.components.customTabsUseCases.add(
             url = destinationUrl,
             customTabConfig = createCustomTabConfigFromIntent(activity.intent, activity.resources),


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/8118371/195368417-14b005a0-8041-40d1-8428-f5a4b319ee03.png" width="300" height="600" /> 
<img src="https://user-images.githubusercontent.com/8118371/195368422-9263e161-dd5d-40a3-9f8c-ce39dff7be7a.png" width="300" height="600" /> 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.



### GitHub Automation
Fixes #6792