### PR TITLE
Use a consistent mockwebserver version

### DIFF
--- a/service-telemetry/build.gradle
+++ b/service-telemetry/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
 
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.10.0'
 
     testImplementation "org.mozilla.components:lib-fetch-httpurlconnection:${AndroidComponents.VERSION}"
     testImplementation "org.mozilla.components:lib-fetch-okhttp:${AndroidComponents.VERSION}"


### PR DESCRIPTION
I'm cleaning up some dependencies and noticed that we're currently specifying two different versions of mockwebserver. Hopefully this is green because it'll make my life easier later if it is.