### PR TITLE
Revert espresso-contrib back to 3.1.0-alpha4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -331,7 +331,7 @@ dependencies {
     androidTestImplementation Dependencies.fastlane
     implementation Dependencies.falcon // Required by fastlane
 
-    androidTestImplementation Dependencies.espresso_contrib, {
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0-alpha4', {
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.android.support', module: 'support-v4'
         exclude group: 'com.android.support', module: 'design'


### PR DESCRIPTION
#7876 moved a lot of things around but wasn't supposed to change any actual dependency versions, with one exception: it changed `espresso-contrib` from 3.1.0-alpha4 to 3.4.0 like the other espresso libs already were. While CI on the pull request was green, it turns out that the non-debug UI tests (which don't run on PRs) are now permafailing:
```
RunTests
java.nio.BufferUnderflowException
	at java.base/java.nio.Buffer.nextGetIndex(Buffer.java:651)
	at java.base/java.nio.HeapByteBuffer.getInt(HeapByteBuffer.java:402)
	at com.linkedin.dex.spec.AnnotationOffItem.<init>(AnnotationOffItem.kt:13)
	at com.linkedin.dex.spec.AnnotationSetItem$Companion.create(AnnotationSetItem.kt:18)
	at com.linkedin.dex.parser.AnnotationUtilsKt.checkIfAnnotationIsInherited(AnnotationUtils.kt:89)
	at com.linkedin.dex.parser.AnnotationUtilsKt.getTestAnnotation(AnnotationUtils.kt:77)
	at com.linkedin.dex.parser.AnnotationUtilsKt.getClassAnnotationValues(AnnotationUtils.kt:46)
	at ftl.run.platform.android.CreateAndroidTestContextKt.isParametrizedClass(CreateAndroidTestContext.kt:210)
	at ftl.run.platform.android.CreateAndroidTestContextKt.getParametrizedClasses(CreateAndroidTestContext.kt:200)
	at ftl.run.platform.android.CreateAndroidTestContextKt.getFlankTestMethods(CreateAndroidTestContext.kt:153)
	at ftl.run.platform.android.CreateAndroidTestContextKt.calculateShardsNormally(CreateAndroidTestContext.kt:86)
	at ftl.run.platform.android.CreateAndroidTestContextKt.calculateShards(CreateAndroidTestContext.kt:112)
	at ftl.run.platform.android.CreateAndroidTestContextKt.access$calculateShards(CreateAndroidTestContext.kt:1)
	at ftl.run.platform.android.CreateAndroidTestContextKt$setupShards$2$1$1.invokeSuspend(CreateAndroidTestContext.kt:49)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at ftl.presentation.RunStateKt.runBlockingWithObservingRunState(RunState.kt:17)
	at ftl.domain.RunTestAndroidKt.invoke(RunTestAndroid.kt:63)
	at ftl.presentation.cli.firebase.test.android.AndroidRunCommand.run(AndroidRunCommand.kt:58)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1939)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at ftl.Main$main$1.invoke(Main.kt:12)
	at ftl.Main$main$1.invoke(Main.kt:10)
	at ftl.run.exception.ExceptionHandlerKt.withGlobalExceptionHandling(ExceptionHandler.kt:28)
	at ftl.run.exception.ExceptionHandlerKt.withGlobalExceptionHandling(ExceptionHandler.kt:17)
	at ftl.Main.main(Main.kt:10)

FAILURE: UI test run failed, please check above URL
```
https://firefoxci.taskcluster-artifacts.net/bE1ZptW6Qtu4GM8IzjsDTw/0/public/logs/live_backing.log

It's not immediately clear how to address this (and this job not running on PRs further complicates things), so let's revert that change for now.