### PR TITLE
Update AndroidX testing libraries to the latest releases

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -333,11 +333,13 @@ dependencies {
     androidTestImplementation Dependencies.fastlane
     implementation Dependencies.falcon // Required by fastlane
 
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0-alpha4', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-        exclude group: 'com.android.support', module: 'support-v4'
-        exclude group: 'com.android.support', module: 'design'
-        exclude group: 'com.android.support', module: 'recyclerview-v7'
+    androidTestImplementation Dependencies.espresso_contrib, {
+        exclude module: 'appcompat-v7'
+        exclude module: 'support-v4'
+        exclude module: 'support-annotations'
+        exclude module: 'recyclerview-v7'
+        exclude module: 'design'
+        exclude module: 'espresso-core'
     }
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_runner

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -47,10 +47,10 @@ object Versions {
     }
 
     object Testing {
-        const val androidx_core = "1.4.0"
-        const val androidx_espresso = "3.4.0"
-        const val androidx_ext_junit = "1.1.3"
-        const val androidx_orchestrator = "1.4.1"
+        const val androidx_core = "1.5.0"
+        const val androidx_espresso = "3.5.0"
+        const val androidx_ext_junit = "1.1.4"
+        const val androidx_orchestrator = "1.4.2"
         const val androidx_uiautomator = "2.2.0"
         const val falcon = "2.2.0"
         const val fastlane = "2.1.1"


### PR DESCRIPTION
Was reverted back to 3.1.0-alpha4 in #7883. This is aiming to get it back to 3.4.0 again.