### PR TITLE
Update to Android-Components 108.0.20221023143208.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -619,6 +619,11 @@ if (gradle.hasProperty('localProperties.autoPublish.application-services.dir')) 
     apply from: "../${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
 }
 
+if (gradle.hasProperty('localProperties.autoPublish.glean.dir')) {
+    ext.gleanSrcDir = gradle."localProperties.autoPublish.glean.dir"
+    apply from: "../${gleanSrcDir}/build-scripts/substitute-local-glean.gradle"
+}
+
 // -------------------------------------------------------------------------------------------------
 // Task for printing APK information for the requested variant
 // Taskgraph Usage: "./gradlew printVariants

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -230,6 +230,7 @@ dependencies {
     implementation Dependencies.androidx_savedstate
     implementation Dependencies.androidx_splashscreen
     implementation Dependencies.androidx_transition
+    implementation Dependencies.androidx_work_ktx
 
     implementation Dependencies.google_accompanist_insets_ui
     implementation Dependencies.google_play

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -179,6 +179,18 @@
                 android:resource="@xml/search_widget_info" />
         </receiver>
 
+        <!-- Removes the default Workmanager initialization so that we can use on-demand initializer. -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge" >
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -8,9 +8,12 @@ package org.mozilla.focus
 import android.content.Context
 import android.os.Build
 import android.os.StrictMode
+import android.util.Log.INFO
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.preference.PreferenceManager
+import androidx.work.Configuration.Builder
+import androidx.work.Configuration.Provider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -37,7 +40,7 @@ import org.mozilla.focus.utils.AdjustHelper
 import org.mozilla.focus.utils.AppConstants
 import kotlin.coroutines.CoroutineContext
 
-open class FocusApplication : LocaleAwareApplication(), CoroutineScope {
+open class FocusApplication : LocaleAwareApplication(), Provider, CoroutineScope {
     private var job = Job()
     override val coroutineContext: CoroutineContext
         get() = job + Dispatchers.Main
@@ -192,4 +195,6 @@ open class FocusApplication : LocaleAwareApplication(), CoroutineScope {
             },
         )
     }
+
+    override fun getWorkManagerConfiguration() = Builder().setMinimumLoggingLevel(INFO).build()
 }

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "108.0.20221018160640"
+    const val VERSION = "108.0.20221023143208"
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -101,6 +101,7 @@ object Dependencies {
     const val androidx_splashscreen = "androidx.core:core-splashscreen:${Versions.AndroidX.splashscreen}"
     const val androidx_savedstate = "androidx.savedstate:savedstate-ktx:${Versions.AndroidX.savedstate}"
     const val androidx_transition = "androidx.transition:transition:${Versions.AndroidX.transition}"
+    const val androidx_work_ktx = "androidx.work:work-runtime-ktx:${Versions.AndroidX.work}"
     const val androidx_work_testing = "androidx.work:work-testing:${Versions.AndroidX.work}"
 
     const val google_material = "com.google.android.material:material:${Versions.Google.material}"

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,6 +35,7 @@ def runCmd(cmd, workingDir, successMessage, captureStdout=true) {
 Properties localProperties = null
 String settingAppServicesPath = "autoPublish.application-services.dir"
 String settingAndroidComponentsPath = "autoPublish.android-components.dir"
+String settingGleanPath = "autoPublish.glean.dir"
 
 if (file('local.properties').canRead()) {
     localProperties = new Properties()
@@ -78,6 +79,21 @@ if (localProperties != null) {
         runCmd(publishAcCmd, androidComponentsLocalPath, "Published android-components for local development.", false)
     } else {
         log("Disabled auto-publication of android-components. Enable it by settings '$settingAndroidComponentsPath' in local.properties")
+    }
+
+    String gleanLocalPath = localProperties.getProperty(settingGleanPath)
+
+    if (gleanLocalPath != null) {
+        log("Enabling automatic publication of Glean from: $gleanLocalPath")
+        // As above, hacks to execute .py files on Windows.
+        def publishGleanCmd = [];
+        if (System.properties['os.name'].toLowerCase().contains('windows')) {
+            publishGleanCmd << "py";
+        }
+        publishGleanCmd << "./build-scripts/publish_to_maven_local_if_modified.py";
+        runCmd(publishGleanCmd, gleanLocalPath, "Published Glean for local development.", false)
+    } else {
+        log("Disabled auto-publication of Glean. Enable it by settings '$settingGleanPath' in local.properties")
     }
 }
 


### PR DESCRIPTION
Supersedes #7899 

---

The underlying exception is:

```
java.lang.IllegalStateException: WorkManager is not initialized properly.  You have explicitly disabled WorkManagerInitializer in your manifest, have not manually called WorkManager#initialize at this point, and your Application does not implement Configuration.Provider.
```

This didn't show in previous versions because it happens in some side-thread I guess (or we caught and dropped it, I'm not 100% sure).
Recent UniFFI changes surface that as a Rust panic (I'll work on a followup to make this easier to debug).

I am not sure at all why it worked before in practice.
For tests it probably didn't matter, because it failed in tests that don't test Glean.

This adds a new dependency, I'm not sure if that needs additional approval from Focus folks?
It fixes the test run for me locally.