### PR TITLE
Don't use password inputType on AddToHomeScreenSiteTitle

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -75,8 +75,7 @@
 
     <style name="AddToHomeScreenSiteTitle" parent="Widget.AppCompat.EditText">
         <item name="android:textSize">20sp</item>
-        <!-- Setting textVisiblePassword as inputType removes the line below the text-->
-        <item name="android:inputType">text|textVisiblePassword</item>
+        <item name="android:inputType">text|textNoSuggestions</item>
         <item name="android:textColor">@color/primaryText</item>
         <item name="android:textCursorDrawable">@null</item>
     </style>


### PR DESCRIPTION
Setting `inputType` of an EditText to `Password` or its variants (`VisiblePassword`) would completely disable the ablility to switch input method (language) other than English in many IMEs, including Gboard. So it's not possible to type CJK characters or emoji into the EditText, even though you can type them somewhere else then copy/paste them.

|current state|expected state|
|:-|:-|
|![Screenshot_20221025-212719](https://user-images.githubusercontent.com/13914967/197788809-ed0137d7-ed4a-4ceb-8323-24c0bfe7273d.png)|![Screenshot_20221025-213823](https://user-images.githubusercontent.com/13914967/197788822-fc997d1d-3816-4898-bd02-0e5bc10f6f0f.png)|
|can't switch to other language, it is locked to "English"|able to switch to other language|

"the line below the text" mentioned in comments is actually [composing text](https://developer.android.com/reference/android/view/inputmethod/InputConnection#setComposingText(java.lang.CharSequence,%20int)), which means "unfinished" inputing state and IME may provide auto correction to replace the composing text span. If you really want to get rid of the auto correction behavior of IME, [InputType#TYPE_TEXT_FLAG_NO_SUGGESTIONS](https://developer.android.com/reference/android/text/InputType#TYPE_TEXT_FLAG_NO_SUGGESTIONS) should be used instead. Even though some IMEs won't follow that flag, it's their choice, and I consider which would be better than not allowing user to switch to other language at all.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
