### PR TITLE
No issue: Simplify openCustomTabInFocusTest.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/CustomTabTest.kt
@@ -19,8 +19,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.activity.robots.browserScreen
 import org.mozilla.focus.activity.robots.customTab
-import org.mozilla.focus.activity.robots.homeScreen
-import org.mozilla.focus.activity.robots.searchScreen
 import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MockWebServerHelper
 import org.mozilla.focus.helpers.TestAssetHelper.getGenericAsset
@@ -96,20 +94,7 @@ class CustomTabTest {
     @SmokeTest
     @Test
     fun openCustomTabInFocusTest() {
-        val browserPage = getGenericAsset(webServer)
         val customTabPage = getGenericTabAsset(webServer, 1)
-
-        launchActivity<IntentReceiverActivity>()
-        homeScreen {
-            // The new onboarding moved to experiments, remove comment when implemented again in Focus
-            // clickStartBrowsing()
-            closeOnboarding()
-        }
-
-        searchScreen {
-        }.loadPage(browserPage.url) {
-            verifyPageURL(browserPage.url)
-        }
 
         launchActivity<IntentReceiverActivity>(createCustomTabIntent(customTabPage.url))
         customTab {
@@ -118,8 +103,6 @@ class CustomTabTest {
             openCustomTabMenu()
         }.clickOpenInFocusButton {
             verifyPageURL(customTabPage.url)
-            mDevice.pressBack()
-            verifyPageURL(browserPage.url)
         }
     }
 


### PR DESCRIPTION
Remove extraneous check of an initial browser page.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
