### PR TITLE
Ensure Nimbus starts up predictably

### DIFF
--- a/app/src/main/java/org/mozilla/focus/experiments/NimbusSetup.kt
+++ b/app/src/main/java/org/mozilla/focus/experiments/NimbusSetup.kt
@@ -6,6 +6,7 @@ package org.mozilla.focus.experiments
 
 import android.content.Context
 import androidx.core.net.toUri
+import kotlinx.coroutines.runBlocking
 import mozilla.components.service.nimbus.Nimbus
 import mozilla.components.service.nimbus.NimbusApi
 import mozilla.components.service.nimbus.NimbusAppInfo
@@ -15,12 +16,15 @@ import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.experiments.nimbus.NimbusInterface
 import org.mozilla.experiments.nimbus.internal.EnrolledExperiment
 import org.mozilla.experiments.nimbus.internal.NimbusException
+import org.mozilla.experiments.nimbus.joinOrTimeout
 import org.mozilla.focus.BuildConfig
 import org.mozilla.focus.GleanMetrics.NimbusExperiments
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.settings
 import org.mozilla.focus.nimbus.FocusNimbus
+
+private const val TIME_OUT_LOADING_EXPERIMENT_FROM_DISK_MS = 200L
 
 @Suppress("TooGenericExceptionCaught")
 fun createNimbus(context: Context, url: String?): NimbusApi {
@@ -34,79 +38,47 @@ fun createNimbus(context: Context, url: String?): NimbusApi {
         context.components.crashReporter.submitCaughtException(e)
     }
 
-    return try {
-        // Eventually we'll want to use `NimbusDisabled` when we have no NIMBUS_ENDPOINT.
-        // but we keep this here to not mix feature flags and how we configure Nimbus.
-        val serverSettings = if (!url.isNullOrBlank()) {
-            if (context.settings.shouldUseNimbusPreview) {
-                NimbusServerSettings(url = url.toUri(), collection = "nimbus-preview")
-            } else {
-                NimbusServerSettings(url = url.toUri())
-            }
+    // Eventually we'll want to use `NimbusDisabled` when we have no NIMBUS_ENDPOINT.
+    // but we keep this here to not mix feature flags and how we configure Nimbus.
+    val serverSettings = if (!url.isNullOrBlank()) {
+        if (context.settings.shouldUseNimbusPreview) {
+            NimbusServerSettings(url = url.toUri(), collection = "nimbus-preview")
         } else {
-            null
+            NimbusServerSettings(url = url.toUri())
         }
+    } else {
+        null
+    }
 
-        // Global opt out state is stored in Nimbus, and shouldn't be toggled to `true`
-        // from the app unless the user does so from a UI control.
-        // However, the user may have opt-ed out of making experiments already, so
-        // we should respect that setting here.
-        val enabled = context.settings.isExperimentationEnabled
+    val isTheFirstLaunch = context.settings.getAppLaunchCount() == 0
 
-        // The name "focus-android" or "klar-android" here corresponds to the app_name defined
-        // for the family of apps that encompasses all of the channels for the Focus app.
-        // This is defined upstream in the telemetry system. For more context on where the
-        // app_name come from see:
-        // https://probeinfo.telemetry.mozilla.org/v2/glean/app-listings
-        // and
-        // https://github.com/mozilla/probe-scraper/blob/master/repositories.yaml
-        val appInfo = NimbusAppInfo(
-            appName = getNimbusAppName(),
-            // Note: Using BuildConfig.BUILD_TYPE is important here so that it matches the value
-            // passed into Glean. `Config.channel.toString()` turned out to be non-deterministic
-            // and would mostly produce the value `Beta` and rarely would produce `beta`.
-            channel = BuildConfig.BUILD_TYPE,
-        )
+    // The name "focus-android" or "klar-android" here corresponds to the app_name defined
+    // for the family of apps that encompasses all of the channels for the Focus app.
+    // This is defined upstream in the telemetry system. For more context on where the
+    // app_name come from see:
+    // https://probeinfo.telemetry.mozilla.org/v2/glean/app-listings
+    // and
+    // https://github.com/mozilla/probe-scraper/blob/master/repositories.yaml
+    val appInfo = NimbusAppInfo(
+        appName = getNimbusAppName(),
+        // Note: Using BuildConfig.BUILD_TYPE is important here so that it matches the value
+        // passed into Glean. `Config.channel.toString()` turned out to be non-deterministic
+        // and would mostly produce the value `Beta` and rarely would produce `beta`.
+        channel = BuildConfig.BUILD_TYPE,
+    )
+    return try {
         Nimbus(context, appInfo, serverSettings, errorReporter).apply {
-            val isTheFirstLaunch = context.settings.getAppLaunchCount() == 0
-            if (isTheFirstLaunch) {
-                register(EventsObserver)
+            register(EventsObserver)
+
+            val job = if (isTheFirstLaunch || url.isNullOrBlank()) {
+                applyLocalExperiments(R.raw.initial_experiments)
+            } else {
+                applyPendingExperiments()
             }
 
-            // This performs the minimal amount of work required to load branch and enrolment data
-            // into memory. If `getExperimentBranch` is called from another thread between here
-            // and the next nimbus disk write (setting `globalUserParticipation` or
-            // `applyPendingExperiments()`) then this has you covered.
-            // This call does its work on the db thread.
-            initialize()
-
-            if (!enabled) {
-                // This opts out of nimbus experiments. It involves writing to disk, so does its
-                // work on the db thread.
-                globalUserParticipation = enabled
+            runBlocking {
+                job.joinOrTimeout(TIME_OUT_LOADING_EXPERIMENT_FROM_DISK_MS)
             }
-
-            if (url.isNullOrBlank()) {
-                setExperimentsLocally(R.raw.initial_experiments)
-            }
-
-            if (isTheFirstLaunch) {
-                NimbusExperiments.nimbusInitialFetch.start()
-            }
-            fetchExperiments()
-
-            register(
-                object : NimbusInterface.Observer {
-                    override fun onExperimentsFetched() {
-                        applyPendingExperiments()
-                        if (isTheFirstLaunch) {
-                            NimbusExperiments.nimbusInitialFetch.stop()
-                        }
-                        // Remove lingering observer when we're done fetching experiments on startup.
-                        unregister(this)
-                    }
-                },
-            )
         }
     } catch (e: Throwable) {
         // Something went wrong. We'd like not to, but stability of the app is more important than
@@ -115,6 +87,27 @@ fun createNimbus(context: Context, url: String?): NimbusApi {
         NimbusDisabled(context = context)
     }
 }
+
+internal fun finishNimbusInitialization(experiments: NimbusApi) =
+    experiments.run {
+        // We fetch experiments in all cases,
+        if (context.settings.getAppLaunchCount() == 0) {
+            // … however on first run, we immediately apply pending experiments.
+            // We also want to measure how long this will take, with Glean.
+            register(
+                object : NimbusInterface.Observer {
+                    override fun onExperimentsFetched() {
+                        NimbusExperiments.nimbusInitialFetch.stop()
+                        applyPendingExperiments()
+                        // Remove lingering observer when we're done fetching experiments on startup.
+                        unregister(this)
+                    }
+                },
+            )
+            NimbusExperiments.nimbusInitialFetch.start()
+        }
+        fetchExperiments()
+    }
 
 fun getNimbusAppName(): String {
     return if (BuildConfig.FLAVOR.contains("focus")) {

--- a/app/src/test/java/org/mozilla/focus/TestFocusApplication.kt
+++ b/app/src/test/java/org/mozilla/focus/TestFocusApplication.kt
@@ -30,6 +30,8 @@ class TestFocusApplication : FocusApplication() {
     override val components: Components by lazy {
         Components(this, engineOverride = FakeEngine(), clientOverride = FakeClient())
     }
+
+    override fun initializeNimbus() = Unit
 }
 
 // Borrowed this from AC unit tests. This is something we should consider moving to support-test, so

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "109.0.20221121143245"
+    const val VERSION = "109.0.20221121201219"
 }


### PR DESCRIPTION
This is the Focus equivalent of https://github.com/mozilla-mobile/fenix/pull/27650

This shifts the Nimbus to be started right after the crashreporter, at the beginning of the `FocusApplication.onCreate`, and importantly before the engine has been warmed up.

This is to ensure Nimbus is available right from the beginning of the application session, including for first page load.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
