### PR TITLE
For #7927 - The homeScreen should not be displayed before the onBoarding

### DIFF
--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -87,7 +87,7 @@ class Components(
     val appStore: AppStore by lazy {
         AppStore(
             AppState(
-                screen = Screen.Home,
+                screen = if (context.settings.isFirstRun) Screen.FirstRun else Screen.Home,
                 topSites = emptyList(),
             ),
         )

--- a/app/src/test/java/org/mozilla/focus/searchwidget/ExternalIntentNavigationTest.kt
+++ b/app/src/test/java/org/mozilla/focus/searchwidget/ExternalIntentNavigationTest.kt
@@ -28,6 +28,7 @@ import org.mozilla.focus.activity.IntentReceiverActivity
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.settings
 import org.mozilla.focus.perf.Performance
+import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.Screen
 import org.mozilla.focus.utils.SearchUtils
 import org.robolectric.Robolectric
@@ -57,6 +58,9 @@ internal class ExternalIntentNavigationTest {
     @Test
     @Config(shadows = [ShadowPerformance::class])
     fun `GIVEN the onboarding should be shown and the app is used in a performance test WHEN the app is opened THEN show the homescreen`() {
+        // The AppStore is initialized before the test runs. By default isFirstRun is true. Simulate it being false.
+        appStore.dispatch(AppAction.ShowHomeScreen)
+        appStore.waitUntilIdle()
         activity.settings.isFirstRun = true
 
         ExternalIntentNavigation.handleAppOpened(null, activity)
@@ -68,6 +72,9 @@ internal class ExternalIntentNavigationTest {
     @Test
     @Config(shadows = [ShadowPerformance::class])
     fun `GIVEN the onboarding should not be shown and in a performance test WHEN the app is opened THEN show the home screen`() {
+        // The AppStore is initialized before the test runs. By default isFirstRun is true. Simulate it being false.
+        appStore.dispatch(AppAction.ShowHomeScreen)
+        appStore.waitUntilIdle()
         activity.settings.isFirstRun = false
 
         ExternalIntentNavigation.handleAppOpened(null, activity)
@@ -78,6 +85,9 @@ internal class ExternalIntentNavigationTest {
 
     @Test
     fun `GIVEN the onboarding should not be shown and not in a performance test WHEN the app is opened THEN show the home screen`() {
+        // The AppStore is initialized before the test runs. By default isFirstRun is true. Simulate it being false.
+        appStore.dispatch(AppAction.ShowHomeScreen)
+        appStore.waitUntilIdle()
         activity.settings.isFirstRun = false
 
         ExternalIntentNavigation.handleAppOpened(null, activity)
@@ -90,7 +100,6 @@ internal class ExternalIntentNavigationTest {
     fun `GIVEN a tab is already open WHEN trying to navigate to the current tab THEN navigate to it and return true`() {
         activity.components.tabsUseCases.addTab(url = "https://mozilla.com")
         activity.components.store.waitUntilIdle()
-
         val result = ExternalIntentNavigation.handleBrowserTabAlreadyOpen(activity)
         activity.components.appStore.waitUntilIdle()
 
@@ -101,6 +110,9 @@ internal class ExternalIntentNavigationTest {
 
     @Test
     fun `GIVEN no tabs are currently open WHEN trying to navigate to the current tab THEN navigate home and return false`() {
+        // The AppStore is initialized before the test runs. By default isFirstRun is true. Simulate it being false.
+        appStore.dispatch(AppAction.ShowHomeScreen)
+        appStore.waitUntilIdle()
         val result = ExternalIntentNavigation.handleBrowserTabAlreadyOpen(activity)
         activity.components.appStore.waitUntilIdle()
 
@@ -124,6 +136,9 @@ internal class ExternalIntentNavigationTest {
 
     @Test
     fun `GIVEN no text search from the search widget WHEN handling widget interactions THEN don't record telemetry, show the home screen and false true`() {
+        // The AppStore is initialized before the test runs. By default isFirstRun is true. Simulate it being false.
+        appStore.dispatch(AppAction.ShowHomeScreen)
+        appStore.waitUntilIdle()
         val bundle = Bundle()
 
         val result = ExternalIntentNavigation.handleWidgetTextSearch(bundle, activity)
@@ -159,6 +174,9 @@ internal class ExternalIntentNavigationTest {
 
     @Test
     fun `GIVEN no voice search WHEN handling widget interactions THEN don't open a new tab and return false`() {
+        // The AppStore is initialized before the test runs. By default isFirstRun is true. Simulate it being false.
+        appStore.dispatch(AppAction.ShowHomeScreen)
+        appStore.waitUntilIdle()
         val browserStore = activity.components.store
         val bundle = Bundle()
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.



### GitHub Automation
Fixes #7927