### PR TITLE
Update leakcanary to version 2.10

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -63,7 +63,7 @@ object Versions {
 
     object ThirdParty {
         const val jna = "5.12.1"
-        const val leakcanary = "2.9.1"
+        const val leakcanary = "2.10"
         const val sentry = "6.6.0"
     }
 


### PR DESCRIPTION
Changelog:
https://square.github.io/leakcanary/changelog/#version-210-2022-11-10