### PR TITLE
Update AndroidX AppCompat to version 1.5.1

### DIFF
--- a/buildSrc/src/main/java/FocusDependencies.kt
+++ b/buildSrc/src/main/java/FocusDependencies.kt
@@ -10,7 +10,7 @@ object FocusVersions {
 
     object AndroidX {
         const val annotation = "1.5.0"
-        const val appcompat = "1.3.0"
+        const val appcompat = "1.5.1"
         const val arch = "2.1.0"
         const val browser = "1.4.0"
         const val cardview = "1.0.0"


### PR DESCRIPTION
Changelogs since our last update:
* https://developer.android.com/jetpack/androidx/releases/appcompat#version_131_3
* https://developer.android.com/jetpack/androidx/releases/appcompat#version_140_3
* https://developer.android.com/jetpack/androidx/releases/appcompat#1.4.1
* https://developer.android.com/jetpack/androidx/releases/appcompat#version_142_3
* https://developer.android.com/jetpack/androidx/releases/appcompat#version_150_3
* https://developer.android.com/jetpack/androidx/releases/appcompat#version_151_3