### PR TITLE
Update Material Components to version 1.7.0

### DIFF
--- a/buildSrc/src/main/java/FocusDependencies.kt
+++ b/buildSrc/src/main/java/FocusDependencies.kt
@@ -32,7 +32,7 @@ object FocusVersions {
     object Google {
         const val accompanist = "0.16.1"
         const val compose_compiler = "1.3.2"
-        const val material = "1.2.1"
+        const val material = "1.7.0"
         const val play = "1.10.3"
     }
 


### PR DESCRIPTION
Been a long time since we last updated, but CI is green with it anyway.

Changelogs since our current release:
* https://github.com/material-components/material-components-android/releases/tag/1.3.0
* https://github.com/material-components/material-components-android/releases/tag/1.4.0
* https://github.com/material-components/material-components-android/releases/tag/1.5.0
* https://github.com/material-components/material-components-android/releases/tag/1.6.0
* https://github.com/material-components/material-components-android/releases/tag/1.6.1
* https://github.com/material-components/material-components-android/releases/tag/1.7.0