### PR TITLE
Add initial_experiments.json Github Action

### DIFF
--- a/.github/workflows/focus-update-nimbus-experiments.yml
+++ b/.github/workflows/focus-update-nimbus-experiments.yml
@@ -1,0 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+name: "Focus - Update Nimbus Experiments"
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch: {}
+
+jobs:
+  update-nimbus-experiments:
+    name: "Update Nimbus Experiments"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Main Branch"
+        uses: actions/checkout@v2
+        with:
+          path: focus-android
+          ref: main
+          fetch-depth: 0
+      - name: "Update Experiments JSON"
+        id: update-experiments-json
+        uses: mozilla-mobile/update-experiments@v2
+        with:
+          repo-path: focus-android
+          output-path: app/src/main/res/raw/initial_experiments.json
+          experimenter-url: https://experimenter.services.mozilla.com/api/v6/experiments-first-run/
+          app-name: focus_android
+          branch: automation/update-nimbus-experiments
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        if: steps.update-experiments-json.outputs.changed == 1 && steps.update-experiments-json.outputs.changed-branch == 1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: focus-android
+          branch: automation/update-nimbus-experiments
+          commit-message: "Automated: update initial_experiments.json based on the current first-run experiments in experimenter"
+          title: "Update initial experiments JSON for Nimbus"
+          body: "This (automated) PR updates the initial_experiments.json on the `main` branch"
+          delete-branch: true


### PR DESCRIPTION
#8012 loads a bundled initial_experiments.json file at first start up.

This PR adds a github action to periodically download the first run experiments for Focus, in line with how the other mobile apps do this.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
