### PR TITLE
For #8054 - Focus should not crash when search engines are restored.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/search/RadioSearchEngineListPreference.kt
+++ b/app/src/main/java/org/mozilla/focus/search/RadioSearchEngineListPreference.kt
@@ -39,14 +39,14 @@ class RadioSearchEngineListPreference : SearchEngineListPreference, RadioGroup.O
     }
 
     override fun onCheckedChanged(group: RadioGroup, checkedId: Int) {
-        val selectedEngine = group.getChildAt(checkedId)
+        val selectedEngine = group.getChildAt(checkedId) ?: return
 
         // check if the corresponding button was pressed or a11y focused.
         val hasProperState = selectedEngine.isPressed || selectedEngine.isAccessibilityFocused
 
         /* onCheckedChanged is called intermittently before the search engine table is full, so we
            must check these conditions to prevent crashes and inconsistent states. */
-        if (group.childCount != searchEngines.count() || selectedEngine == null || !hasProperState) {
+        if (group.childCount != searchEngines.count() || !hasProperState) {
             return
         }
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.



### GitHub Automation
Fixes #8054