### PR TITLE
Bug 1802664 - Hide fragment content when app is locked.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationFragment.kt
@@ -12,18 +12,19 @@ import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
 import mozilla.components.lib.auth.AuthenticationDelegate
 import mozilla.components.lib.auth.BiometricPromptAuth
 import mozilla.components.lib.auth.canUseBiometricFeature
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.focus.R
+import org.mozilla.focus.ext.hideToolbar
 import org.mozilla.focus.ext.requireComponents
-import org.mozilla.focus.fragment.BaseFragment
 import org.mozilla.focus.searchwidget.ExternalIntentNavigation
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.ui.theme.FocusTheme
 
-class BiometricAuthenticationFragment : BaseFragment(), AuthenticationDelegate {
+class BiometricAuthenticationFragment : Fragment(), AuthenticationDelegate {
     @VisibleForTesting
     internal val biometricPromptAuth = ViewBoundFeatureWrapper<BiometricPromptAuth>()
 
@@ -51,6 +52,10 @@ class BiometricAuthenticationFragment : BaseFragment(), AuthenticationDelegate {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        hideToolbar()
+    }
     override fun onAuthError(errorText: String) {
         biometricErrorText.value = errorText
     }

--- a/app/src/main/java/org/mozilla/focus/biometrics/LockObserver.kt
+++ b/app/src/main/java/org/mozilla/focus/biometrics/LockObserver.kt
@@ -5,7 +5,6 @@
 package org.mozilla.focus.biometrics
 
 import android.content.Context
-import android.os.Build
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -50,8 +49,7 @@ class LockObserver(
             if (tabCount == 0L && topSitesList.isEmpty()) {
                 return@launch
             }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                context.settings.shouldUseBiometrics() &&
+            if (context.settings.shouldUseBiometrics() &&
                 context.canUseBiometricFeature()
             ) {
                 appStore.dispatch(AppAction.Lock())

--- a/app/src/main/java/org/mozilla/focus/fragment/BaseFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BaseFragment.kt
@@ -9,8 +9,11 @@ import android.view.animation.Animation
 import android.view.animation.AnimationSet
 import android.view.animation.AnimationUtils
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.view.isInvisible
 import androidx.fragment.app.Fragment
 import org.mozilla.focus.ext.hideToolbar
+import org.mozilla.focus.ext.requireComponents
+import org.mozilla.focus.state.Screen
 
 abstract class BaseFragment : Fragment() {
     private var animationSet: AnimationSet? = null
@@ -18,6 +21,7 @@ abstract class BaseFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         hideToolbar()
+        view?.isInvisible = requireComponents.appStore.state.screen == Screen.Locked()
     }
 
     fun cancelAnimation() {
@@ -25,6 +29,11 @@ abstract class BaseFragment : Fragment() {
             animationSet!!.duration = 0
             animationSet!!.cancel()
         }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        view?.isInvisible = requireComponents.appStore.state.screen == Screen.Locked()
     }
 
     @Suppress("SwallowedException")

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -593,6 +593,13 @@ class BrowserFragment :
         }
     }
 
+    override fun onPause() {
+        super.onPause()
+        // Custom tab content should always be visible, even if the app is locked.
+        if (tab.isCustomTab()) {
+            view?.isVisible = true
+        }
+    }
     private fun showDownloadCompletedSnackbar(
         state: DownloadState,
         extension: String?,
@@ -674,6 +681,11 @@ class BrowserFragment :
         (requireActivity() as? MainActivity)?.hideStatusBarBackground()
         StatusBarUtils.getStatusBarHeight(binding.statusBarBackground) { statusBarHeight ->
             binding.statusBarBackground.layoutParams.height = statusBarHeight
+        }
+
+        // Custom tab content should always be visible, even if the app is locked.
+        if (tab.isCustomTab()) {
+            view?.isVisible = true
         }
     }
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
