### PR TITLE
Bug 1805256 - Adds the legacy-id to Glean internal and other pings

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -239,14 +239,23 @@ legacy_ids:
       Sets the legacy client ID as part of the deletion-reqest ping.
     send_in_pings:
       - deletion-request
+      - metrics
+      - events
+      - baseline
+      - activation
     bugs:
       - https://github.com/mozilla-mobile/focus-android/issues/4545
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1805256
     data_reviews:
       - https://github.com/mozilla-mobile/focus-android/pull/5512#issuecomment-1023668181
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1805256
     notification_emails:
       - jalmeida@mozilla.com
       - android-probes@mozilla.com
+      - tlong@mozilla.com
     expires: never
+    no_lint:
+      - BASELINE_PING
 
 browser.search:
   with_ads:


### PR DESCRIPTION
This adds the legacy telemetry id to the Glean baseline, events, metrics, and the activation ping for the purpose of making historical analyses easier by allowing connecting of data between the two side-by-side systems.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on `Show All Checks`,
2. click `Details` next to `build-focus-debug` or `build-klar-debug` for changes targeting Klar,
2. click `View task in Taskcluster`,
3. click the `Artifacts` row,
4. click to download any of the apks listed here which use an appropriate name for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
